### PR TITLE
[INIT] #1: 프로젝트 초기 설정

### DIFF
--- a/src/main/java/org/sopt/snappinserver/global/config/jpa/JpaConfig.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/jpa/JpaConfig.java
@@ -1,0 +1,10 @@
+package org.sopt.snappinserver.global.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+
+}

--- a/src/main/java/org/sopt/snappinserver/global/config/querydsl/QueryDslConfig.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/querydsl/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package org.sopt.snappinserver.global.config.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
@@ -1,0 +1,34 @@
+package org.sopt.snappinserver.global.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .cors(Customizer.withDefaults())
+            .sessionManagement(sess ->
+                sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                .anyRequest().permitAll() // TODO 나중에 authenticated()
+            );
+
+        return http.build();
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/swagger/SwaggerConfig.java
@@ -1,0 +1,99 @@
+package org.sopt.snappinserver.global.config.swagger;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.info.Info;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+    servers = {
+        @Server(url="http://localhost:8080", description = "로컬 서버 주소")
+    }
+)
+@Configuration
+public class SwaggerConfig {
+
+    private static final String LOCAL_ORIGIN = "http://localhost:8080";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(apiInfo());
+    }
+
+    @Bean
+    public GroupedOpenApi all() {
+        return GroupedOpenApi.builder()
+            .group("all")
+            .pathsToMatch("/**")
+            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi v1Api() {
+        return groupedApi("v1", "/api/v1");
+    }
+
+    @Bean
+    public GroupedOpenApi v2Api() {
+        return groupedApi("v2", "/api/v2");
+    }
+
+    private GroupedOpenApi groupedApi(String group, String fullPrefix) {
+        return GroupedOpenApi.builder()
+            .group(group)
+            .pathsToMatch(fullPrefix + "/**")
+            .addOpenApiCustomizer(stripPrefixAndSetServer(fullPrefix))
+            .build();
+    }
+
+    private OpenApiCustomizer stripPrefixAndSetServer(String fullPrefix) {
+        final Pattern exact = Pattern.compile("^" + Pattern.quote(fullPrefix) + "/?$");
+        final String prefixWithSlash = fullPrefix.endsWith("/") ? fullPrefix : fullPrefix + "/";
+
+        return openApi -> {
+            Paths source = openApi.getPaths();
+            if (source == null || source.isEmpty()) {
+                return;
+            }
+
+            Paths rewritten = new Paths();
+            source.forEach((path, item) -> {
+                String newPath = path;
+                if (exact.matcher(path).matches()) {
+                    newPath = "/";
+                } else if (path.startsWith(prefixWithSlash)) {
+                    newPath = path.substring(fullPrefix.length());
+                }
+                rewritten.addPathItem(newPath, item);
+            });
+
+            openApi.setPaths(rewritten);
+
+            List<io.swagger.v3.oas.models.servers.Server> servers = new ArrayList<>();
+
+            servers.add(
+                new io.swagger.v3.oas.models.servers.Server()
+                    .url(LOCAL_ORIGIN + fullPrefix)
+                    .description("Local")
+            );
+
+            openApi.setServers(servers);
+        };
+    }
+
+    private Info apiInfo() {
+        return new Info()
+            .title("Snappin Swagger")
+            .description("DIVE SOPT 37기 앱잼 | Snappin Swagger")
+            .version("1.0.0");
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/global/config/web/CorsConfig.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/web/CorsConfig.java
@@ -1,0 +1,39 @@
+package org.sopt.snappinserver.global.config.web;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+
+    private static final List<String> ALLOWED_METHODS = List.of(
+        "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"
+    );
+
+    private static final List<String> ALLOWED_HEADERS = List.of(
+        "Authorization", "Content-Type"
+    );
+
+    @Value("${cors.allowed-origins}")
+    private List<String> allowedOrigins;
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOrigins(allowedOrigins);
+        config.setAllowedMethods(ALLOWED_METHODS);
+        config.setAllowedHeaders(ALLOWED_HEADERS);
+        config.setAllowCredentials(false);
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/global/entity/BaseEntity.java
+++ b/src/main/java/org/sopt/snappinserver/global/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package org.sopt.snappinserver.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.Instant;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    protected Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    protected Instant updatedAt;
+}

--- a/src/main/java/org/sopt/snappinserver/global/exception/BusinessException.java
+++ b/src/main/java/org/sopt/snappinserver/global/exception/BusinessException.java
@@ -1,0 +1,21 @@
+package org.sopt.snappinserver.global.exception;
+
+import lombok.Getter;
+import org.sopt.snappinserver.global.response.code.ErrorCode;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String detail) {
+        super(errorCode.getMessage() + " - " + detail);
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/org/sopt/snappinserver/global/exception/CommonErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/exception/CommonErrorCode.java
@@ -1,0 +1,25 @@
+package org.sopt.snappinserver.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.global.response.code.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+    // 400 BAD REQUEST
+    INVALID_MAPPING_PARAMETER(400, "COMMON_400_001", "매핑할 수 없는 값입니다."),
+
+    // 404 NOT FOUND
+    RESOURCE_NOT_FOUND(404, "COMMON_404_001", "존재하지 않는 리소스입니다."),
+
+    // 500 INTERNAL SERVER ERROR
+    INTERNAL_SERVER_ERROR(500, "COMMON_500_001", "서버 내부 오류가 발생했습니다."),
+
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/sopt/snappinserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/snappinserver/global/exception/GlobalExceptionHandler.java
@@ -90,4 +90,3 @@ public class GlobalExceptionHandler {
             );
     }
 }
-

--- a/src/main/java/org/sopt/snappinserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/snappinserver/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,93 @@
+package org.sopt.snappinserver.global.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.sopt.snappinserver.global.response.dto.ErrorMeta;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponseBody<Void, ErrorMeta>> handleHttpMessageNotReadable(
+        HttpMessageNotReadableException exception,
+        HttpServletRequest request
+    ) {
+        log.error("HttpMessageNotReadableException: {}", exception.getMessage());
+
+        ErrorMeta meta = new ErrorMeta(
+            request.getRequestURI(),
+            Instant.now()
+        );
+
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponseBody.onFailure(CommonErrorCode.INVALID_MAPPING_PARAMETER, meta));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiResponseBody<Void, ErrorMeta>> handleNoResourceFoundException(
+        NoResourceFoundException exception,
+        HttpServletRequest request
+    ) {
+        log.error("NoResourceFoundException: {}", exception.getMessage());
+
+        ErrorMeta meta = new ErrorMeta(
+            request.getRequestURI(),
+            Instant.now()
+        );
+
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(ApiResponseBody.onFailure(CommonErrorCode.RESOURCE_NOT_FOUND, meta));
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponseBody<Void, ErrorMeta>> handle(
+        BusinessException exception,
+        HttpServletRequest request
+    ) {
+        log.error("[errorCode={}] {}", exception.getErrorCode().getCode(), exception.getMessage());
+
+        ErrorMeta meta = new ErrorMeta(
+            request.getRequestURI(),
+            Instant.now()
+        );
+
+        return ResponseEntity
+            .status(exception.getErrorCode().getStatus())
+            .body(ApiResponseBody.onFailure(exception.getErrorCode(), meta));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponseBody<Void, ErrorMeta>> handle(
+        Exception exception,
+        HttpServletRequest request
+    ) {
+        log.error("{}: {}", exception.getClass().getName(), exception.getMessage());
+
+        ErrorMeta meta = new ErrorMeta(
+            request.getRequestURI(),
+            Instant.now()
+        );
+
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(
+                ApiResponseBody.onFailure(
+                    CommonErrorCode.INTERNAL_SERVER_ERROR,
+                    exception.getMessage(),
+                    meta
+                )
+            );
+    }
+}
+

--- a/src/main/java/org/sopt/snappinserver/global/logging/RequestLoggingFilter.java
+++ b/src/main/java/org/sopt/snappinserver/global/logging/RequestLoggingFilter.java
@@ -1,0 +1,82 @@
+package org.sopt.snappinserver.global.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+        @NonNull HttpServletRequest request,
+        @NonNull HttpServletResponse response,
+        @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String requestId = generateRequestId();
+        MDC.put("requestId", requestId);
+
+        long start = System.currentTimeMillis();
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            long took = System.currentTimeMillis() - start;
+
+            String method = request.getMethod();
+            String uri = request.getRequestURI(); // TODO API 명세 설계 완료 후 특정 API에 한해 query Parameter 추가
+            int status = response.getStatus();
+            String ip = extractClientIp(request);
+            String principal = resolvePrincipal();
+
+            if (status >= 500) {
+                log.error("[{}] {} {} -> status={} user={} ip={} took={}ms",
+                    requestId, method, uri, status, principal, ip, took);
+            } else if (status >= 400) {
+                log.warn("[{}] {} {} -> status={} user={} ip={} took={}ms",
+                    requestId, method, uri, status, principal, ip, took);
+            } else {
+                log.info("[{}] {} {} -> status={} user={} ip={} took={}ms",
+                    requestId, method, uri, status, principal, ip, took);
+            }
+
+            MDC.clear();
+        }
+    }
+
+    private String generateRequestId() {
+        return UUID.randomUUID().toString();
+    }
+
+    private String extractClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    private String resolvePrincipal() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "anonymous";
+        }
+
+        return "authenticated";
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/global/logging/ServiceLoggingAspect.java
+++ b/src/main/java/org/sopt/snappinserver/global/logging/ServiceLoggingAspect.java
@@ -1,0 +1,35 @@
+package org.sopt.snappinserver.global.logging;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class ServiceLoggingAspect {
+
+    @Around("execution(* org.sopt.snappinserver..service..*(..))")
+    public Object logService(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        String signature = proceedingJoinPoint.getSignature().toShortString();
+        long start = System.currentTimeMillis();
+
+        try {
+            Object result = proceedingJoinPoint.proceed();
+            long took = System.currentTimeMillis() - start;
+
+            log.info("{} success took={}ms", signature, took);
+
+            return result;
+        } catch (Throwable exception) {
+            long took = System.currentTimeMillis() - start;
+
+            log.error("{} failed took={}ms errorType={} message={}",
+                signature, took, exception.getClass().getSimpleName(), exception.getMessage());
+
+            throw exception;
+        }
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/global/response/code/ErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/ErrorCode.java
@@ -1,0 +1,4 @@
+package org.sopt.snappinserver.global.response.code;
+
+public interface ErrorCode extends ResponseCode {
+}

--- a/src/main/java/org/sopt/snappinserver/global/response/code/ResponseCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/ResponseCode.java
@@ -1,0 +1,7 @@
+package org.sopt.snappinserver.global.response.code;
+
+public interface ResponseCode {
+    int getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/org/sopt/snappinserver/global/response/code/SuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/SuccessCode.java
@@ -1,0 +1,4 @@
+package org.sopt.snappinserver.global.response.code;
+
+public interface SuccessCode extends ResponseCode {
+}

--- a/src/main/java/org/sopt/snappinserver/global/response/dto/ApiResponseBody.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/dto/ApiResponseBody.java
@@ -1,0 +1,82 @@
+package org.sopt.snappinserver.global.response.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.global.response.code.ErrorCode;
+import org.sopt.snappinserver.global.response.code.SuccessCode;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "공통 응답 DTO")
+public record ApiResponseBody<T, M>(
+
+    @Schema(description = "해당 API의 성공 여부를 반환합니다. true면 성공, false면 실패입니다.")
+    boolean success,
+
+    @Schema(description = "해당 API의 HTTP 상태 코드입니다.")
+    int status,
+
+    @Schema(description = "해당 API의 결과에 대한 상태 메시지입니다.")
+    String message,
+
+    @Schema(description = "해당 API 관련 커스텀 코드입니다. 도메인(3글자)-상태코드-순번 으로 이루어져 있습니다.", example = "TIC_200_001")
+    String code,
+
+    @Schema(description = "해당 API에서 반환하는 결과 데이터입니다.")
+    T data,
+
+    @Schema(description = "해당 API의 data를 설명하는 meta data입니다. 페이지네이션 정보나, 에러 발생 시 에러 정보를 반환합니다.")
+    M meta
+) {
+
+    public static <T> ApiResponseBody<T, Void> ok(SuccessCode successCode, T data) {
+        return new ApiResponseBody<>(
+            true,
+            successCode.getStatus(),
+            successCode.getMessage(),
+            successCode.getCode(),
+            data,
+            null
+        );
+    }
+
+    public static <T, M> ApiResponseBody<T, M> ok(SuccessCode successCode, T data, M meta) {
+        return new ApiResponseBody<>(
+            true,
+            successCode.getStatus(),
+            successCode.getMessage(),
+            successCode.getCode(),
+            data,
+            meta
+        );
+    }
+
+    public static ApiResponseBody<Void, ErrorMeta> onFailure(
+        ErrorCode errorCode,
+        ErrorMeta errorMeta
+    ) {
+        return new ApiResponseBody<>(
+            false,
+            errorCode.getStatus(),
+            errorCode.getMessage(),
+            errorCode.getCode(),
+            null,
+            errorMeta
+        );
+    }
+
+    public static ApiResponseBody<Void, ErrorMeta> onFailure(
+        ErrorCode errorCode,
+        String message,
+        ErrorMeta errorMeta
+    ) {
+        return new ApiResponseBody<>(
+            false,
+            errorCode.getStatus(),
+            message,
+            errorCode.getCode(),
+            null,
+            errorMeta
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/global/response/dto/ErrorMeta.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/dto/ErrorMeta.java
@@ -1,0 +1,15 @@
+package org.sopt.snappinserver.global.response.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+
+@Schema(description = "에러 발생 시 meta DTO")
+public record ErrorMeta(
+    @Schema(description = "에러가 발생한 API 경로입니다.")
+    String path,
+
+    @Schema(description = "에러가 발생한 시간입니다.")
+    Instant timestamp
+) {
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,6 +8,6 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
     show-sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,6 @@ springdoc:
   swagger-ui:
     tags-sorter: alpha
     operations-sorter: alpha
+
+cors:
+  allowed-origins: "http://localhost:3000,http://localhost:8080"


### PR DESCRIPTION
## 👀 Summary

- close #1

프로젝트 초기 공통(global) 모듈 구성: 응답 포맷, 예외 처리, 로깅, 보안/웹/JPA/QueryDSL/Swagger 설정 추가


## 🖇️ Tasks

### 1️⃣ 프로젝트 구조 설명
````
snappinserver
    ├── domain => 추후 비즈니스 로직 및 엔티티
    └── global => 여러 군데서 사용되는 설정 / 기본 파일
        ├── config => 설정 파일
        │   ├── jpa => Jpa 설정 파일 (BaseEntity에서 자동으로 createdAt, updatedAt 관리 위함)
        │   ├── querydsl => QueryDSL 설정 파일
        │   ├── security => 보안 관련 설정
        │   ├── swagger => Swagger 설정
        │   └── web => CORS 설정
        ├── entity => 기본 엔티티
        ├── exception => 예외 관련 로직 (예외 클래스, 예외 코드, 예외 처리 핸들러)
        ├── logging => 로그 관련 설정 (필터 단, 서비스단)
        └── response => 응답 시 필요한 내용
            ├── code => 응답 코드 인터페이스
            └── dto => 공통 응답 DTO 형식
````

### 2️⃣ Config 파일 관련

`main()` 실행 시, 함께 돌아가야 하는 어노테이션 설정들이 있을 거예요. 예를 들면 `JpaConfig.java`의 `@EnableJpaAuditing`이라든지? 요런 것들은 반드시 한 번만 설정되어야 하고, `main()` 위에 이런 설정들이 다 붙어있으면 뭐가 어떤 건지 관리하기도 어렵습니다. 그래서 config 파일을 두고, 우리 프로젝트에 필요한 설정 파일을 목적 별로 관리합니다. `main()`이 있는 `SnappinServerApplication.java`는 건들지 않고, 깨끗하게 관리할게요. 각각의 Config 파일에는 `@Configuration`이 해당 파일이 설정 파일이고, 프로젝트 전체에서 한 번만 실행될 수 있게 해 줍니다. 

관련해서 Component, Bean, Configuration 어노테이션도 함께 공부해 보시면 좋을 것 같아요!


### 3️⃣ SecurityConfig의 역할
인증, 인가 관련 구현을 위해 Spring Secuirty를 사용합니다. 현재 SecurityConfig에서 하는 보안 관련 설정은 크게 4가지 입니다.

1. Session 관련 설정 비활성화 (CSRF, sessionManagement) 
2. CORS  관련 설정 위임
3. 기본 인증 기능 비활성화
4. 인증 요청 관련 설정 (authorizeHttpRequest -> 어떤 부분이 인증이 필요하고, 어떤 부분은 필요없는지)

먼저, 저희는 인증 인가 관련 설정을 Session 대신 토큰으로 구현할 계획이에요. 그래서 Session 관련 보안 설정 내용은 필요하지 않기 때문에 비활성화 했습니다.

두 번째로, CORS 관련 설정을 위임합니다. CORS는 보안(인증, 인가)과 관련 있다기보다는 web(브라우저) 관련 내용이라 /web/CorsConfig.java에서 어떤 Origin에 대해 어떤 Method와, 어떤 Header를 허용할지 작성해줍니다.

세 번째로, Spring Security에는 자동으로 기본 인증 기능이 존재해서 브라우저에 localhost:8080으로 접속하면 자동으로 localhost:8080/login으로 이동하고, 다음과 같은 화면이 뜹니다.
<img width="1562" height="1011" alt="스크린샷 2025-12-29 오후 9 58 14" src="https://github.com/user-attachments/assets/20ba3cbd-b782-4f08-867a-e1ea8c3dcb61" />
그런데 저희는 해당 기본 인증 기능을 사용하지 않을 것이기 때문에 이걸 비활성화하는 코드를 작성해 주어야 합니다.

네 번째로, 우선 지금은 인증, 인가 관련 로직이 구현되어 있지 않아 모든 요청을 허용해주도록 설정했습니다. 추후 인증 로직이 구현되면, 인증이 필요없는 api를 제외하고, 다른 엔드포인트는 인증이 필요하도록 설정해 두면 됩니다!


### 4️⃣ Logging 관련 설정

에러 로그 뿐만 아니라 모든 요청에 대해 로그를 찍어야 언제 어떤  요청이 들어왔는지 알 수 있고, 예외 발생 시에도 전후 상황을 알기에 용이합니다. 그런데 저희가 모든 API를 구현할 때마다 서비스, 컨트롤러에 로그를 함께 작성하면 비즈니스 로직과 로그를 구분하기 어렵다는 단점이 있어요.

그래서 특정 API 요청이 들어왔을 때 필터 단에서 어떤 요청이 들어왔는지 알 수 있도록 자동으로 로그를 붙이는 코드(RequestLoggingFilter.java)를 작성했고 , 해당 API 서비스가 호출되었을 때 서비스의 성공 여부를 알 수 있도록 자동으로 로그를 붙이는 코드(ServiceLoggingAspect.java)를 작성했어요.

관련해서 [OncePerRequestFilter의 역할](https://junyharang.tistory.com/378), [AOP](https://adjh54.tistory.com/133) 알아두시면 도움 될 것 같아요!


## 🔍 To Reviewer

프로젝트 설정이 어려운 부분은 아니지만, 처음 잘못 설정하거나 설정 내용을 이해하지 못한 채로 프로젝트를 진행하면 추후 프로젝트 진행 시 어느 위치에 들어가야 하는 내용인지 헷갈릴 수 있어요. PR 꼼꼼히 확인해 주시고, 헷갈리거나 모르는 부분, 이상한 부분이 있으면 꼭 많이 많이 알려주세요! 😊

p.s. 저도 진짜 아직 부족한 게 많아요!!!! 제 로직이 당연히 틀릴 가능성이 매우 높으니 성하 = 소연 지식이라고 생각하고 조금이라도 이상하면 질문 & 제안 해주세요!!!!!!!