### PR TITLE
[FEAT] #5: CICD 구축

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Build (compile check)
+        run: ./gradlew assemble

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,58 @@
+name: Deploy - Dev
+
+on:
+  push:
+    branches: [ "develop" ]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build & Push Image
+        run: |
+          IMAGE_TAG=${GITHUB_SHA::7}
+          echo "IMAGE_TAG=$IMAGE_TAG" > image-tag
+
+          ./gradlew build -x test
+          docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/snapping-be-app:$IMAGE_TAG .
+          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/snapping-be-app:$IMAGE_TAG
+      
+      
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::252807701206:role/GithubActions-CodeDeploy-Dev
+          aws-region: ap-northeast-2
+
+      - name: Prepare deploy files
+        run: |
+          cp appspec.dev.yml appspec.yml
+
+          zip -r deploy.zip \
+            image-tag \
+            docker-compose.dev.yml \
+            deploy.dev.sh \
+            appspec.yml \
+            nginx/app.conf.template
+
+      - name: Upload to S3 & Deploy
+        run: |
+          aws s3 cp deploy.zip s3://${{ secrets.AWS_S3_BUCKET }}/deploy.zip
+          aws deploy create-deployment \
+            --application-name ${{ secrets.CODEDEPLOY_APP_NAME }} \
+            --deployment-group-name ${{ secrets.CODEDEPLOY_DG_NAME }} \
+            --s3-location bucket=${{ secrets.AWS_S3_BUCKET }},bundleType=zip,key=deploy.zip

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+/.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM eclipse-temurin:17-jdk-alpine
+
+WORKDIR /app
+
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/appspec.dev.yml
+++ b/appspec.dev.yml
@@ -1,0 +1,12 @@
+version: 0.0
+os: linux
+
+files:
+  - source: /
+    destination: /home/ubuntu/snapping-be-app
+
+hooks:
+  AfterInstall:
+    - location: deploy.dev.sh
+      timeout: 300
+      runas: root

--- a/deploy.dev.sh
+++ b/deploy.dev.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+cd /home/ubuntu/snapping-be-app
+
+mkdir -p nginx/conf.d
+
+set -a
+source .env
+source image-tag
+set +a
+
+COMPOSE_FILE="docker-compose.dev.yml"
+ACTIVE_COLOR_FILE=".active_color"
+APP_NAME="snapping-be-app"
+
+if [ ! -f "$ACTIVE_COLOR_FILE" ]; then
+  echo "blue" > "$ACTIVE_COLOR_FILE"
+fi
+
+ACTIVE_COLOR=$(cat "$ACTIVE_COLOR_FILE")
+NEW_COLOR=$([ "$ACTIVE_COLOR" = "blue" ] && echo "green" || echo "blue")
+
+NEW_SERVICE="app_${NEW_COLOR}"
+OLD_SERVICE="app_${ACTIVE_COLOR}"
+NEW_CONTAINER="${APP_NAME}-${NEW_COLOR}"
+
+docker pull ${DOCKER_HUB_USERNAME}/snapping-be-app:${IMAGE_TAG}
+docker-compose -f $COMPOSE_FILE up -d $NEW_SERVICE
+
+echo "Health check..."
+for i in {1..120}; do
+  STATUS=$(docker inspect -f '{{.State.Health.Status}}' "$NEW_CONTAINER" || true)
+  [ "$STATUS" = "healthy" ] && break
+  sleep 1
+done
+
+if [ "$STATUS" != "healthy" ]; then
+  docker-compose logs $NEW_SERVICE
+  exit 1
+fi
+
+sed "s|__UPSTREAM__|${NEW_CONTAINER}:8080|" nginx/app.conf.template \
+  > nginx/conf.d/app.conf
+
+docker-compose exec -T nginx nginx -t
+docker-compose exec -T nginx nginx -s reload
+
+echo "$NEW_COLOR" > "$ACTIVE_COLOR_FILE"
+
+docker-compose stop $OLD_SERVICE || true
+docker-compose rm -f $OLD_SERVICE || true
+
+docker image prune -f

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,62 @@
+version: "3.8"
+
+services:
+  app_blue:
+    image: "${DOCKER_HUB_USERNAME}/snapping-be-app:${IMAGE_TAG}"
+    container_name: snapping-be-app-blue
+    restart: always
+    env_file:
+      - /home/ubuntu/snapping-be-app/.env
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+      TZ: Asia/Seoul
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+      start_period: 120s
+    networks:
+      - backend
+
+  app_green:
+    image: "${DOCKER_HUB_USERNAME}/snapping-be-app:${IMAGE_TAG}"
+    container_name: snapping-be-app-green
+    restart: always
+    env_file:
+      - /home/ubuntu/snapping-be-app/.env
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+      TZ: Asia/Seoul
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+      start_period: 120s
+    networks:
+      - backend
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: snapping-be-app-nginx
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/conf.d:/etc/nginx/conf.d
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
+    networks:
+      - backend
+
+  certbot:
+    image: certbot/certbot
+    container_name: certbot
+    volumes:
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
+
+networks:
+  backend:

--- a/nginx/app.conf.template
+++ b/nginx/app.conf.template
@@ -1,0 +1,31 @@
+upstream backend {
+  server __UPSTREAM__;
+}
+
+server {
+  listen 80;
+  server_name snapping.co.kr;
+
+  location /.well-known/acme-challenge/ {
+    root /var/www/certbot;
+  }
+
+  location / {
+    return 301 https://$host$request_uri;
+  }
+}
+
+server {
+  listen 443 ssl;
+  server_name snapping.co.kr;
+
+  ssl_certificate /etc/letsencrypt/live/snapping.co.kr/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/snapping.co.kr/privkey.pem;
+
+  location / {
+    proxy_pass http://backend;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,11 +1,13 @@
 spring:
   datasource:
     url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,10 @@
 spring:
-  profiles:
-    active: local
   application:
     name: snappin
+
+  batch:
+    jdbc:
+      initialize-schema: never
 
 springdoc:
   swagger-ui:
@@ -10,4 +12,4 @@ springdoc:
     operations-sorter: alpha
 
 cors:
-  allowed-origins: "http://localhost:3000,http://localhost:8080"
+  allowed-origins: ${CORS_ALLOWED_ORIGINS}


### PR DESCRIPTION
## 👀 Summary

- close #5



## 🖇️ Tasks

- AWS 인프라 구축
- EC2 생성
- DB 생성
- 도메인 및 https 연결
- 블루그린 기반 CI/CD 구축


## 🔍 To Reviewer

### ❶ 전체 흐름
CI로 코드 품질을 검증하고, CD에서 Docker 이미지 빌드 및 태그 기반 배포를 수행합니다. 배포는 GitHub Actions → CodeDeploy → EC2 → docker-compose → Blue/Green → Nginx 전환 흐름으로 이루어집니다. dev 환경 변수는 ec2에 바로 넣어놓았고, local 환경 변수는 프로젝트 최상단에 넣어두고 사용하시면 됩니다! 노션 관리 정보 페이지에 설정 방법과, .env 파일 내용 넣어놓았어요.

### ❷ 각 파일별 흐름 설명
#### 1. ./github/workflows/ci.yml
PR 올라왔을 때, 컴파일 가능 여부를 검증합니다. Branch Ruleset에 CI 실패 시, 병합 불가하도록 추가할 예정입니다.

#### 2. .github/workflows/deploy-dev.yml
커밋 기반 IMAGE_TAG를 생성하고, 도커 이미지를 빌드해서 도커 허브에 푸시합니다. 생성한 IMAGE_TAG는 image-tag 파일을 생성해서 배포 단위를 식별하고, CodeDeploy용 zip 파일을 만들어 S3에 업로드 후, CodeDeploy 배포를 시작시키는 방식이에요.

#### 3. appspec.dev.yml
CodeDeploy 실행 시 배포 과정을 명시하는 파일입니다. deploy.dev.sh를 실행하도록 작성했습니다.

#### 4. deploy.dev.sh
ec2에서 실제 배포 로직을 수행하는 스크립트입니다. .env, image-tag 로드 후, Blue / Green 색상을 결정합니다. 이후, 신규 컨테이너를 실행하고, 헬스 체크 확인 후에 nginx upstream을 교체합니다. 마지막으로 기존에 실행되던 컨테이너를 종료하는 방식입니다.

#### 5. docker-compose.yml
어떤 컨테이너를 어떻게 실행할지 정의합니다. app_blue, app_green은 스프링 부트 앱이고, nginx는 외부 요청을 받았을 때, 어떤 스프링 부트 앱으로 요청을 전달할지 정해주는 역할을 합니다. 마지막으로 certbot은 https를 사용하기 위해 인증서를 관리하는 역할을 합니다.

#### 6. nginx/app.conf.template
nginx가 app_blue나 app_green에 요청을 전달할 수 있도록 설정합니다. 새로 뜬 컨테이너의 이름을 __UPSTREAM__에 넣을 수 있게 해서,  스프링 부트에 요청을 전달할 수 있습니다. 이런 방식으로 nginx 연결만 변경하고, reload하면 서버를 재시작하는 시간이 없어서 무중단 배포가 가능합니다.

#### 7. Dockerfile
자바 17 런타임이 포함된 베이스 이미지를 사용해 스프링 부트 실행 파일을 복사하고, 컨테이너 실행 시 애플리케이션이 자동으로 실행되며 8080 포트로 요청을 처리하도록 구성합니다.