### PR TITLE
[FIX] #10: image 태그 파일 내부 개행 제거 및 헬스 체크 예외 처리 로직 추가

### DIFF
--- a/deploy.dev.sh
+++ b/deploy.dev.sh
@@ -7,8 +7,14 @@ mkdir -p nginx/conf.d
 
 set -a
 source .env
-source image-tag
 set +a
+
+if [ ! -f image-tag ]; then
+  echo "image-tag file not found"
+  exit 1
+fi
+
+IMAGE_TAG=$(grep IMAGE_TAG image-tag | cut -d= -f2 | tr -d '\r\n')
 
 COMPOSE_FILE="docker-compose.dev.yml"
 ACTIVE_COLOR_FILE=".active_color"
@@ -25,21 +31,40 @@ NEW_SERVICE="app_${NEW_COLOR}"
 OLD_SERVICE="app_${ACTIVE_COLOR}"
 NEW_CONTAINER="${APP_NAME}-${NEW_COLOR}"
 
+echo "Pull image..."
 docker pull ${DOCKER_HUB_USERNAME}/snapping-be-app:${IMAGE_TAG}
+
+echo "Start new service: $NEW_SERVICE"
 docker-compose -f $COMPOSE_FILE up -d $NEW_SERVICE
 
 echo "Health check..."
+STATUS="starting"
+
 for i in {1..120}; do
-  STATUS=$(docker inspect -f '{{.State.Health.Status}}' "$NEW_CONTAINER" || true)
-  [ "$STATUS" = "healthy" ] && break
+  STATUS=$(docker inspect -f '{{.State.Health.Status}}' "$NEW_CONTAINER" 2>/dev/null || echo "not-found")
+  echo "[$i] status=$STATUS"
+
+  if [ "$STATUS" = "healthy" ]; then
+    echo "Container is healthy"
+    break
+  fi
+
+  if [ "$STATUS" = "unhealthy" ]; then
+    echo "Container is unhealthy"
+    docker logs "$NEW_CONTAINER"
+    exit 1
+  fi
+
   sleep 1
 done
 
 if [ "$STATUS" != "healthy" ]; then
-  docker-compose logs $NEW_SERVICE
+  echo "Health check timeout"
+  docker logs "$NEW_CONTAINER"
   exit 1
 fi
 
+echo "Update nginx upstream..."
 sed "s|__UPSTREAM__|${NEW_CONTAINER}:8080|" nginx/app.conf.template \
   > nginx/conf.d/app.conf
 
@@ -48,6 +73,7 @@ docker-compose exec -T nginx nginx -s reload
 
 echo "$NEW_COLOR" > "$ACTIVE_COLOR_FILE"
 
+echo "Stop old service: $OLD_SERVICE"
 docker-compose stop $OLD_SERVICE || true
 docker-compose rm -f $OLD_SERVICE || true
 


### PR DESCRIPTION
## 👀 Summary

- close #10


## 🖇️ Tasks

- CD 파이프라인에서 이미지 태그를 읽을 때 파일 내부 개행까지 같이 읽어 도커 이미지를 허브에서 못 찾는 문제가 있었습니다. CD 스크립트에서 해당 부분 예외처리와 함께 수정해서 올려두었습니다!
- 또한, 기존 파이프라인에서 헬스체크 타임아웃을 추가해서 헬스체크 실패했을 때, CodeDeploy 에서 성공하는 일이 없도록 수정했습니다.


## 🔍 To Reviewer

-
