### PR TITLE
[FIX] #12: CD 파이프라인에 도커 로그인 추가 및 dozzle, swagger 도메인 연결 설정 (Nginx) 추가

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -29,8 +29,6 @@ jobs:
           ./gradlew build -x test
           docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/snapping-be-app:$IMAGE_TAG .
           docker push ${{ secrets.DOCKER_HUB_USERNAME }}/snapping-be-app:$IMAGE_TAG
-      
-      
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -47,7 +45,9 @@ jobs:
             docker-compose.dev.yml \
             deploy.dev.sh \
             appspec.yml \
-            nginx/app.conf.template
+            nginx/app.conf.template \
+            nginx/conf.d/devlog.conf \
+            nginx/conf.d/swagger.conf
 
       - name: Upload to S3 & Deploy
         run: |

--- a/deploy.dev.sh
+++ b/deploy.dev.sh
@@ -2,12 +2,16 @@
 set -e
 
 cd /home/ubuntu/snapping-be-app
-
 mkdir -p nginx/conf.d
 
 set -a
 source .env
 set +a
+
+echo "Docker login..."
+echo "$DOCKER_HUB_PASSWORD" | docker login \
+  -u "$DOCKER_HUB_USERNAME" \
+  --password-stdin
 
 if [ ! -f image-tag ]; then
   echo "image-tag file not found"
@@ -15,6 +19,10 @@ if [ ! -f image-tag ]; then
 fi
 
 IMAGE_TAG=$(grep IMAGE_TAG image-tag | cut -d= -f2 | tr -d '\r\n')
+export IMAGE_TAG
+
+echo "IMAGE_TAG=$IMAGE_TAG"
+echo "DOCKER_HUB_USERNAME=$DOCKER_HUB_USERNAME"
 
 COMPOSE_FILE="docker-compose.dev.yml"
 ACTIVE_COLOR_FILE=".active_color"
@@ -34,37 +42,25 @@ NEW_CONTAINER="${APP_NAME}-${NEW_COLOR}"
 echo "Pull image..."
 docker pull ${DOCKER_HUB_USERNAME}/snapping-be-app:${IMAGE_TAG}
 
+if ! docker ps --format '{{.Names}}' | grep -q snapping-be-app-nginx; then
+  echo "Start nginx (first deploy)"
+  docker-compose -f $COMPOSE_FILE up -d nginx
+fi
+
 echo "Start new service: $NEW_SERVICE"
 docker-compose -f $COMPOSE_FILE up -d $NEW_SERVICE
 
-echo "Health check..."
 STATUS="starting"
-
 for i in {1..120}; do
   STATUS=$(docker inspect -f '{{.State.Health.Status}}' "$NEW_CONTAINER" 2>/dev/null || echo "not-found")
   echo "[$i] status=$STATUS"
-
-  if [ "$STATUS" = "healthy" ]; then
-    echo "Container is healthy"
-    break
-  fi
-
-  if [ "$STATUS" = "unhealthy" ]; then
-    echo "Container is unhealthy"
-    docker logs "$NEW_CONTAINER"
-    exit 1
-  fi
-
+  [ "$STATUS" = "healthy" ] && break
+  [ "$STATUS" = "unhealthy" ] && exit 1
   sleep 1
 done
 
-if [ "$STATUS" != "healthy" ]; then
-  echo "Health check timeout"
-  docker logs "$NEW_CONTAINER"
-  exit 1
-fi
+[ "$STATUS" != "healthy" ] && exit 1
 
-echo "Update nginx upstream..."
 sed "s|__UPSTREAM__|${NEW_CONTAINER}:8080|" nginx/app.conf.template \
   > nginx/conf.d/app.conf
 
@@ -73,7 +69,6 @@ docker-compose exec -T nginx nginx -s reload
 
 echo "$NEW_COLOR" > "$ACTIVE_COLOR_FILE"
 
-echo "Stop old service: $OLD_SERVICE"
 docker-compose stop $OLD_SERVICE || true
 docker-compose rm -f $OLD_SERVICE || true
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,12 +12,7 @@ services:
       TZ: Asia/Seoul
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
-      start_period: 120s
-    networks:
-      - backend
+    networks: [backend]
 
   app_green:
     image: "${DOCKER_HUB_USERNAME}/snapping-be-app:${IMAGE_TAG}"
@@ -30,33 +25,27 @@ services:
       TZ: Asia/Seoul
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
-      start_period: 120s
-    networks:
-      - backend
+    networks: [backend]
+
+  dozzle:
+    image: amir20/dozzle
+    container_name: dozzle
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks: [backend]
 
   nginx:
     image: nginx:1.27-alpine
     container_name: snapping-be-app-nginx
-    restart: always
     ports:
       - "80:80"
       - "443:443"
     volumes:
       - ./nginx/conf.d:/etc/nginx/conf.d
+      - ./nginx/.htpasswd:/etc/nginx/.htpasswd
       - ./certbot/conf:/etc/letsencrypt
       - ./certbot/www:/var/www/certbot
-    networks:
-      - backend
-
-  certbot:
-    image: certbot/certbot
-    container_name: certbot
-    volumes:
-      - ./certbot/conf:/etc/letsencrypt
-      - ./certbot/www:/var/www/certbot
+    networks: [backend]
 
 networks:
   backend:

--- a/nginx/app.conf.template
+++ b/nginx/app.conf.template
@@ -4,7 +4,7 @@ upstream backend {
 
 server {
   listen 80;
-  server_name snapping.co.kr;
+  server_name dev-api.snapping.co.kr;
 
   location /.well-known/acme-challenge/ {
     root /var/www/certbot;
@@ -17,15 +17,14 @@ server {
 
 server {
   listen 443 ssl;
-  server_name snapping.co.kr;
+  server_name dev-api.snapping.co.kr;
 
-  ssl_certificate /etc/letsencrypt/live/snapping.co.kr/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/snapping.co.kr/privkey.pem;
+  ssl_certificate /etc/letsencrypt/live/dev-api.snapping.co.kr/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/dev-api.snapping.co.kr/privkey.pem;
 
   location / {
     proxy_pass http://backend;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto https;
   }
 }

--- a/nginx/conf.d/devlog.conf
+++ b/nginx/conf.d/devlog.conf
@@ -1,0 +1,26 @@
+server {
+  listen 80;
+  server_name dev-log.snapping.co.kr;
+  location /.well-known/acme-challenge/ {
+      root /var/www/certbot;
+    }
+
+    location / {
+      return 301 https://$host$request_uri;
+    }
+}
+
+server {
+  listen 443 ssl;
+  server_name dev-log.snapping.co.kr;
+
+  ssl_certificate /etc/letsencrypt/live/dev-log.snapping.co.kr/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/dev-log.snapping.co.kr/privkey.pem;
+
+  auth_basic "Restricted";
+  auth_basic_user_file /etc/nginx/.htpasswd;
+
+  location / {
+    proxy_pass http://dozzle:8080;
+  }
+}

--- a/nginx/conf.d/swagger.conf
+++ b/nginx/conf.d/swagger.conf
@@ -1,0 +1,32 @@
+server {
+  listen 80;
+  server_name dev-docs.snapping.co.kr;
+  location /.well-known/acme-challenge/ {
+      root /var/www/certbot;
+    }
+
+    location / {
+      return 301 https://$host$request_uri;
+    }
+}
+
+server {
+  listen 443 ssl;
+  server_name dev-docs.snapping.co.kr;
+
+  ssl_certificate /etc/letsencrypt/live/dev-docs.snapping.co.kr/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/dev-docs.snapping.co.kr/privkey.pem;
+
+  auth_basic "Swagger Restricted";
+  auth_basic_user_file /etc/nginx/.htpasswd;
+
+  location ~ ^/(swagger-ui|v3/api-docs) {
+    proxy_pass http://backend;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+
+  location / {
+    return 403;
+  }
+}


### PR DESCRIPTION
## 👀 Summary

- close #12


## 🖇️ Tasks

- [x] CD 스크립트에 도커 로그인 추가
- [x] dozzle 추가
- [x] dozzle, swagger 도메인 연결



## 🔍 To Reviewer

### ❶ CD 스크립트에 도커 로그인 추가
기존에 도커 허브 레포지토리 public인 채로 이미지를 올리는데, 보안 문제가 있을 것 같아 private 으로 바꾸면서 cd 파이프라인에서도 도커 로그인을 추가했습니다.

### ❷ dozzle 추가
dozzle은 도커 컨테이너 로그를 시각화할 수 있는 앱입니다! 저희 프로젝트에 도커로 관리하는 도구들이 많아질 것 같아 추가했어요.

### ❸ dozzle, swagger 도메인 연결
nginx에 도메인 별로 컨테이너를 볼 수 있도록 하면 컨테이너 별로 각 서브도메인에 연결돼서 배포가 가능합니다! 추후 컨테이너 로그, 스웨거를 웹에서 편리하게 볼 수 있도록 하기 위해서 작성했어요. 스웨거의 경우 api 엔드포인트와 분리하기 위해 /swagger-ui, /v3로 시작하는 엔드포인트를 스웨거 전용 도메인에서 사용할 수 있도록 했습니다.
