### PR TITLE
[FIX] #16: 도커 컴포즈 명령어 실행 시 도커 컴포즈 파일 지정

### DIFF
--- a/deploy.dev.sh
+++ b/deploy.dev.sh
@@ -64,12 +64,12 @@ done
 sed "s|__UPSTREAM__|${NEW_CONTAINER}:8080|" nginx/app.conf.template \
   > nginx/conf.d/app.conf
 
-docker-compose exec -T nginx nginx -t
-docker-compose exec -T nginx nginx -s reload
+docker-compose -f $COMPOSE_FILE exec -T nginx nginx -t
+docker-compose -f $COMPOSE_FILE exec -T nginx nginx -s reload
 
 echo "$NEW_COLOR" > "$ACTIVE_COLOR_FILE"
 
-docker-compose stop $OLD_SERVICE || true
-docker-compose rm -f $OLD_SERVICE || true
+docker-compose -f $COMPOSE_FILE stop $OLD_SERVICE || true
+docker-compose -f $COMPOSE_FILE rm -f $OLD_SERVICE || true
 
 docker image prune -f


### PR DESCRIPTION
## 👀 Summary

- close #16


## 🖇️ Tasks

- EC2 내부에서 도커 컴포즈 명령어 실행 시, 도커 컴포즈 파일이 지정되지 않아 오류가 발생하는 문제가 있어 도커 컴포즈 파일을 지정해주었습니다!


## 🔍 To Reviewer

-