### PR TITLE
[FEAT] #20: 촬영 상황 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.9'
+    id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/src/main/java/org/sopt/snappinserver/api/category/code/CategorySuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/category/code/CategorySuccessCode.java
@@ -1,0 +1,20 @@
+package org.sopt.snappinserver.api.category.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.global.response.code.common.SuccessCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum CategorySuccessCode implements SuccessCode {
+
+    GET_CATEGORIES_OK(
+            200,
+            "CATEGORY_200_001",
+            "촬영 상황 카테고리 조회에 성공했습니다."
+    );
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/sopt/snappinserver/api/category/controller/CategoryApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/category/controller/CategoryApi.java
@@ -1,8 +1,17 @@
 package org.sopt.snappinserver.api.category.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.snappinserver.api.category.dto.response.CategoriesResponse;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @Tag(name = "02 - Category", description = "촬영 상황 관련 API")
 public interface CategoryApi {
 
+    @Operation(
+            summary = "촬영 상황 조회",
+            description = "촬영 상황 옵션으로 사용될 스냅 유형 전체 목록을 조회합니다."
+    )
+    @GetMapping
+    CategoriesResponse getCategories();
 }

--- a/src/main/java/org/sopt/snappinserver/api/category/controller/CategoryApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/category/controller/CategoryApi.java
@@ -3,6 +3,7 @@ package org.sopt.snappinserver.api.category.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sopt.snappinserver.api.category.dto.response.CategoriesResponse;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Tag(name = "02 - Category", description = "촬영 상황 관련 API")
@@ -13,5 +14,5 @@ public interface CategoryApi {
             description = "촬영 상황 옵션으로 사용될 스냅 유형 전체 목록을 조회합니다."
     )
     @GetMapping
-    CategoriesResponse getCategories();
+    ApiResponseBody<CategoriesResponse, Void> getCategories();
 }

--- a/src/main/java/org/sopt/snappinserver/api/category/controller/CategoryController.java
+++ b/src/main/java/org/sopt/snappinserver/api/category/controller/CategoryController.java
@@ -1,12 +1,26 @@
 package org.sopt.snappinserver.api.category.controller;
 
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.category.dto.response.CategoriesResponse;
+import org.sopt.snappinserver.api.category.dto.response.CategoryResponse;
+import org.sopt.snappinserver.global.enums.SnapCategory;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/categories")
 @RequiredArgsConstructor
 @RestController
-public class CategoryController {
+public class CategoryController implements CategoryApi {
 
+    @Override
+    public CategoriesResponse getCategories() {
+        List<CategoryResponse> categories =
+                Arrays.stream(SnapCategory.values())
+                        .map(CategoryResponse::from)
+                        .toList();
+
+        return CategoriesResponse.from(categories);
+    }
 }

--- a/src/main/java/org/sopt/snappinserver/api/category/controller/CategoryController.java
+++ b/src/main/java/org/sopt/snappinserver/api/category/controller/CategoryController.java
@@ -3,9 +3,11 @@ package org.sopt.snappinserver.api.category.controller;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.category.code.CategorySuccessCode;
 import org.sopt.snappinserver.api.category.dto.response.CategoriesResponse;
 import org.sopt.snappinserver.api.category.dto.response.CategoryResponse;
 import org.sopt.snappinserver.global.enums.SnapCategory;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,12 +17,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class CategoryController implements CategoryApi {
 
     @Override
-    public CategoriesResponse getCategories() {
+    public ApiResponseBody<CategoriesResponse, Void> getCategories() {
         List<CategoryResponse> categories =
                 Arrays.stream(SnapCategory.values())
                         .map(CategoryResponse::from)
                         .toList();
 
-        return CategoriesResponse.from(categories);
+        CategoriesResponse response = CategoriesResponse.from(categories);
+        return ApiResponseBody.ok(CategorySuccessCode.GET_CATEGORIES_OK, response);
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/category/dto/response/CategoriesResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/category/dto/response/CategoriesResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.snappinserver.api.category.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CategoriesResponse {
+
+    private List<CategoryResponse> categories;
+
+    public static CategoriesResponse from(List<CategoryResponse> categories) {
+        return new CategoriesResponse(categories);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/category/dto/response/CategoryResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/category/dto/response/CategoryResponse.java
@@ -1,0 +1,20 @@
+package org.sopt.snappinserver.api.category.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.sopt.snappinserver.global.enums.SnapCategory;
+
+@Getter
+@AllArgsConstructor
+public class CategoryResponse {
+
+    private String key;
+    private String label;
+
+    public static CategoryResponse from(SnapCategory category) {
+        return new CategoryResponse(
+                category.name(),
+                category.getCategory()
+        );
+    }
+}


### PR DESCRIPTION
## 👀 Summary

- close #20

검색창에서 촬영 상황 옵션으로 사용될 스냅 유형 전체 목록 조회 API를 구현했습니다.


## 🖇️ Tasks

- [x] Spring Boot 버전 3.5.9 → 3.3.4 수정으로 의존성 충돌 및 Swagger 500 에러 해결
- [x] 카테고리 단일 응답 DTO 추가 (key, label 구조)
- [x] 카테고리 목록 응답 Wrapper DTO 추가
- [x] Swagger 문서화를 위한 Category API 명세 인터페이스 추가
- [x] Enum 기반으로 카테고리 목록 조회


## 🔍 To Reviewer

### ❶ Spring Boot 버전 변경 

Spring Boot 버전을 **3.3.4**로 변경했습니다.

1. build.gradle의 `org.springframework.boot` 플러그인 버전 수정
2. `/gradlew clean` 실행 
3. IntelliJ 캐시 초기화

기존 3.5.9는 존재하지 않는 버전으로, Swagger 및 Spring 내부 의존성 충돌을 유발하던 상태였으며, 버전 변경 외에 기존 로직/구조에는 따로 영향 없으니 참고해주세요!


### ❷ Category API 설계

Category API는 서비스 계층을 두지 않고 컨트롤러에서 직접 처리했습니다.

카테고리는 고정된 Enum 값이며, 별도의 엔티티나 DB 테이블로 관리하지 않는 메타 데이터입니다. 비즈니스 로직이나 상태 변경이 없어, 서비스 계층에서 관리할 필요 없이 Enum 값을 DTO로 변환하여 컨트롤러에서 바로 응답하도록 구현했습니다. 

추후 카테고리를 DB로 관리하거나 비즈니스 로직이 추가될 경우에 서비스 계층으로 분리하면 좋을 듯 합니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 촬영 상황 카테고리 조회 API 엔드포인트를 추가했습니다. 사용자는 이제 이용 가능한 모든 촬영 카테고리를 조회하고, 각 카테고리의 식별자와 이름을 확인할 수 있습니다.

* **기타**
  * Spring Boot Gradle 플러그인 버전을 업데이트했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->