### PR TITLE
[CHORE] #18: 코드래빗 PR Summary 비활성화

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,7 +11,7 @@ tone_instructions: |
 # 리뷰 동작 방식 설정
 reviews:
   profile: 'assertive'        # 리뷰 성향
-  high_level_summary: true    # PR 전체 변경 사항 요약 생성
+  high_level_summary: false   # PR 전체 변경 사항 요약 생성
   review_status: true         # PR에 리뷰 상태 표시
   changed_files_summary: true # 변경된 파일 목록 및 요약 제공
   collapse_walkthrough: true  # 상세 워크스루는 기본적으로 접어서 표시(노이즈 감소)


### PR DESCRIPTION
## 👀 Summary

- close #18 

코드 래빗의 PR Summary 기능 설정을 변경했습니다.


## 🖇️ Tasks

- [x] high level summary 기능 비활성화


## 🔍 To Reviewer

<img width="827" height="337" alt="스크린샷 2026-01-07 오후 2 07 30" src="https://github.com/user-attachments/assets/00b2106e-832d-4294-a946-776243013a08" />

위와 같이 코드래빗이 PR 작성 내용 자체를 수정해 추가하는 요약 기능을 비활성화했습니다.
