### PR TITLE
[FEAT] #26: 상품 리뷰 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/product/code/ProductSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/code/ProductSuccessCode.java
@@ -8,11 +8,7 @@ import org.sopt.snappinserver.global.response.code.common.SuccessCode;
 @RequiredArgsConstructor
 public enum ProductSuccessCode implements SuccessCode {
 
-    GET_PRODUCT_REVIEWS_OK(
-            200,
-            "PRODUCT_200_001",
-            "상품 리뷰 목록 조회에 성공했습니다."
-    );
+    GET_PRODUCT_REVIEWS_OK(200, "PRODUCT_200_001", "상품 리뷰 목록 조회에 성공했습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/org/sopt/snappinserver/api/product/code/ProductSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/code/ProductSuccessCode.java
@@ -1,0 +1,20 @@
+package org.sopt.snappinserver.api.product.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.global.response.code.common.SuccessCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductSuccessCode implements SuccessCode {
+
+    GET_PRODUCT_REVIEWS_OK(
+            200,
+            "PRODUCT_200_001",
+            "상품 리뷰 목록 조회에 성공했습니다."
+    );
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -12,12 +12,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface ProductApi {
 
     @Operation(
-            summary = "상품 리뷰 목록 조회",
-            description = "커서 기반 페이지네이션 방식으로 상품 리뷰 목록을 조회합니다."
+        summary = "상품 리뷰 목록 조회",
+        description = "커서 기반 페이지네이션 방식으로 상품 리뷰 목록을 조회합니다."
     )
     @GetMapping("/{productId}/reviews")
     ApiResponseBody<ProductReviewsCursorResponse, Void> getProductReviews(
-            @PathVariable Long productId,
-            @RequestParam(required = false) Long cursor
+        @PathVariable Long productId,
+        @RequestParam(required = false) Long cursor
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -1,8 +1,23 @@
 package org.sopt.snappinserver.api.product.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "06 - Product", description = "상품 관련 API")
 public interface ProductApi {
 
+    @Operation(
+            summary = "상품 리뷰 목록 조회",
+            description = "커서 기반 페이지네이션 방식으로 상품 리뷰 목록을 조회합니다."
+    )
+    @GetMapping("/{productId}/reviews")
+    ApiResponseBody<ProductReviewsCursorResponse, Void> getProductReviews(
+            @PathVariable Long productId,
+            @RequestParam(required = false) Long cursor
+    );
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -3,6 +3,7 @@ package org.sopt.snappinserver.api.product.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
+import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaResponse;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,7 +17,8 @@ public interface ProductApi {
         description = "커서 기반 페이지네이션 방식으로 상품 리뷰 목록을 조회합니다."
     )
     @GetMapping("/{productId}/reviews")
-    ApiResponseBody<ProductReviewsCursorResponse, Void> getProductReviews(
+    ApiResponseBody<ProductReviewsCursorResponse, ProductReviewsMetaResponse>
+    getProductReviews(
         @PathVariable Long productId,
         @RequestParam(required = false) Long cursor
     );

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -2,7 +2,7 @@ package org.sopt.snappinserver.api.product.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
+import org.sopt.snappinserver.api.product.dto.response.ProductReviewsResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaResponse;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,7 +17,7 @@ public interface ProductApi {
         description = "커서 기반 페이지네이션 방식으로 상품 리뷰 목록을 조회합니다."
     )
     @GetMapping("/{productId}/reviews")
-    ApiResponseBody<ProductReviewsCursorResponse, ProductReviewsMetaResponse>
+    ApiResponseBody<ProductReviewsResponse, ProductReviewsMetaResponse>
     getProductReviews(
         @PathVariable Long productId,
         @RequestParam(required = false) Long cursor

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -1,12 +1,30 @@
 package org.sopt.snappinserver.api.product.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.category.code.CategorySuccessCode;
+import org.sopt.snappinserver.api.product.code.ProductSuccessCode;
+import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
+import org.sopt.snappinserver.domain.product.service.GetProductReviewsUseCase;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/products")
 @RequiredArgsConstructor
 @RestController
-public class ProductController {
+public class ProductController implements ProductApi {
 
+    private final GetProductReviewsUseCase getProductReviewsUseCase;
+
+    @Override
+    public ApiResponseBody<ProductReviewsCursorResponse, Void> getProductReviews(
+            Long productId,
+            Long cursor
+    ) {
+        ProductReviewsCursorResponse response =
+                getProductReviewsUseCase.getProductReviews(productId, cursor);
+
+        return ApiResponseBody.ok(ProductSuccessCode.GET_PRODUCT_REVIEWS_OK, response);
+    }
 }
+

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -3,6 +3,7 @@ package org.sopt.snappinserver.api.product.controller;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.product.code.ProductSuccessCode;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
+import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaResponse;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
 import org.sopt.snappinserver.domain.review.service.dto.response.ReviewPageResult;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
@@ -17,16 +18,25 @@ public class ProductController implements ProductApi {
     private final GetProductReviewsUseCase getProductReviewsUseCase;
 
     @Override
-    public ApiResponseBody<ProductReviewsCursorResponse, Void> getProductReviews(
-        Long productId,
-        Long cursor
-    ) {
+    public ApiResponseBody<ProductReviewsCursorResponse, ProductReviewsMetaResponse>
+    getProductReviews(Long productId, Long cursor) {
+
         ReviewPageResult result =
             getProductReviewsUseCase.getProductReviews(productId, cursor);
 
+        ProductReviewsCursorResponse data =
+            ProductReviewsCursorResponse.from(result);
+
+        ProductReviewsMetaResponse meta =
+            new ProductReviewsMetaResponse(
+                result.getNextCursor(),
+                result.isHasNext()
+            );
+
         return ApiResponseBody.ok(
             ProductSuccessCode.GET_PRODUCT_REVIEWS_OK,
-            ProductReviewsCursorResponse.from(result)
+            data,
+            meta
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -18,15 +18,15 @@ public class ProductController implements ProductApi {
 
     @Override
     public ApiResponseBody<ProductReviewsCursorResponse, Void> getProductReviews(
-            Long productId,
-            Long cursor
+        Long productId,
+        Long cursor
     ) {
         ReviewPageResult result =
-                getProductReviewsUseCase.getProductReviews(productId, cursor);
+            getProductReviewsUseCase.getProductReviews(productId, cursor);
 
         return ApiResponseBody.ok(
-                ProductSuccessCode.GET_PRODUCT_REVIEWS_OK,
-                ProductReviewsCursorResponse.from(result)
+            ProductSuccessCode.GET_PRODUCT_REVIEWS_OK,
+            ProductReviewsCursorResponse.from(result)
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -5,6 +5,7 @@ import org.sopt.snappinserver.api.category.code.CategorySuccessCode;
 import org.sopt.snappinserver.api.product.code.ProductSuccessCode;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
 import org.sopt.snappinserver.domain.product.service.GetProductReviewsUseCase;
+import org.sopt.snappinserver.domain.review.service.dto.response.ReviewPageResult;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,10 +22,13 @@ public class ProductController implements ProductApi {
             Long productId,
             Long cursor
     ) {
-        ProductReviewsCursorResponse response =
+        ReviewPageResult result =
                 getProductReviewsUseCase.getProductReviews(productId, cursor);
 
-        return ApiResponseBody.ok(ProductSuccessCode.GET_PRODUCT_REVIEWS_OK, response);
+        return ApiResponseBody.ok(
+                ProductSuccessCode.GET_PRODUCT_REVIEWS_OK,
+                ProductReviewsCursorResponse.from(result)
+        );
     }
 }
 

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -5,7 +5,7 @@ import org.sopt.snappinserver.api.product.code.ProductSuccessCode;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaResponse;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
-import org.sopt.snappinserver.domain.review.service.dto.response.ReviewPageResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewPageResult;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,7 +21,7 @@ public class ProductController implements ProductApi {
     public ApiResponseBody<ProductReviewsResponse, ProductReviewsMetaResponse>
     getProductReviews(Long productId, Long cursor) {
 
-        ReviewPageResult result =
+        ProductReviewPageResult result =
             getProductReviewsUseCase.getProductReviews(productId, cursor);
 
         ProductReviewsResponse data =

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -1,10 +1,9 @@
 package org.sopt.snappinserver.api.product.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.api.category.code.CategorySuccessCode;
 import org.sopt.snappinserver.api.product.code.ProductSuccessCode;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
-import org.sopt.snappinserver.domain.product.service.GetProductReviewsUseCase;
+import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
 import org.sopt.snappinserver.domain.review.service.dto.response.ReviewPageResult;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -29,8 +29,8 @@ public class ProductController implements ProductApi {
 
         ProductReviewsMetaResponse meta =
             new ProductReviewsMetaResponse(
-                result.getNextCursor(),
-                result.isHasNext()
+                result.nextCursor(),
+                result.hasNext()
             );
 
         return ApiResponseBody.ok(

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -28,10 +28,7 @@ public class ProductController implements ProductApi {
             ProductReviewsResponse.from(result);
 
         ProductReviewsMetaResponse meta =
-            new ProductReviewsMetaResponse(
-                result.nextCursor(),
-                result.hasNext()
-            );
+            ProductReviewsMetaResponse.from(result);
 
         return ApiResponseBody.ok(
             ProductSuccessCode.GET_PRODUCT_REVIEWS_OK,

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -2,7 +2,7 @@ package org.sopt.snappinserver.api.product.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.product.code.ProductSuccessCode;
-import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
+import org.sopt.snappinserver.api.product.dto.response.ProductReviewsResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaResponse;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
 import org.sopt.snappinserver.domain.review.service.dto.response.ReviewPageResult;
@@ -18,14 +18,14 @@ public class ProductController implements ProductApi {
     private final GetProductReviewsUseCase getProductReviewsUseCase;
 
     @Override
-    public ApiResponseBody<ProductReviewsCursorResponse, ProductReviewsMetaResponse>
+    public ApiResponseBody<ProductReviewsResponse, ProductReviewsMetaResponse>
     getProductReviews(Long productId, Long cursor) {
 
         ReviewPageResult result =
             getProductReviewsUseCase.getProductReviews(productId, cursor);
 
-        ProductReviewsCursorResponse data =
-            ProductReviewsCursorResponse.from(result);
+        ProductReviewsResponse data =
+            ProductReviewsResponse.from(result);
 
         ProductReviewsMetaResponse meta =
             new ProductReviewsMetaResponse(

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewResponse.java
@@ -1,0 +1,31 @@
+package org.sopt.snappinserver.api.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "상품 리뷰 응답 DTO")
+public class ProductReviewResponse {
+
+    @Schema(description = "리뷰 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "리뷰 작성자", example = "작성자")
+    private String reviewer;
+
+    @Schema(description = "평점", example = "5")
+    private int rating;
+
+    @Schema(description = "작성 일자", example = "2026-03-01")
+    private LocalDate createdAt;
+
+    @Schema(description = "리뷰 이미지 URL 목록")
+    private List<String> images;
+
+    @Schema(description = "리뷰 내용", example = "리뷰 내용")
+    private String content;
+}

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewResponse.java
@@ -32,12 +32,12 @@ public class ProductReviewResponse {
 
     public static ProductReviewResponse from(ReviewResult result) {
         return new ProductReviewResponse(
-                result.getId(),
-                result.getReviewer(),
-                result.getRating(),
-                result.getCreatedAt(),
-                result.getImages(),
-                result.getContent()
+            result.getId(),
+            result.getReviewer(),
+            result.getRating(),
+            result.getCreatedAt(),
+            result.getImages(),
+            result.getContent()
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewResponse.java
@@ -5,7 +5,7 @@ import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.sopt.snappinserver.domain.review.service.dto.response.ReviewResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewResult;
 
 @Getter
 @AllArgsConstructor
@@ -30,7 +30,7 @@ public class ProductReviewResponse {
     @Schema(description = "리뷰 내용", example = "리뷰 내용")
     private String content;
 
-    public static ProductReviewResponse from(ReviewResult result) {
+    public static ProductReviewResponse from(ProductReviewResult result) {
         return new ProductReviewResponse(
             result.getId(),
             result.getReviewer(),

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewResponse.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.sopt.snappinserver.domain.review.domain.entity.Review;
 import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
+import org.sopt.snappinserver.domain.review.service.dto.response.ReviewResult;
 
 @Getter
 @AllArgsConstructor
@@ -33,33 +34,14 @@ public class ProductReviewResponse {
     @Schema(description = "리뷰 내용", example = "리뷰 내용")
     private String content;
 
-    public static ProductReviewResponse from(Review review) {
+    public static ProductReviewResponse from(ReviewResult result) {
         return new ProductReviewResponse(
-                review.getId(),
-                getReviewerFrom(review),
-                review.getRating(),
-                getCreatedDateFrom(review),
-                getImagesFrom(review),
-                review.getContent()
+                result.getId(),
+                result.getReviewer(),
+                result.getRating(),
+                result.getCreatedAt(),
+                result.getImages(),
+                result.getContent()
         );
-    }
-
-    private static String getReviewerFrom(Review review) {
-        return review.getReservation()
-                .getUser()
-                .getName();
-    }
-
-    private static LocalDate getCreatedDateFrom(Review review) {
-        return review.getCreatedAt()
-                .atZone(ZoneId.systemDefault())
-                .toLocalDate();
-    }
-
-    private static List<String> getImagesFrom(Review review) {
-        return review.getReviewPhotos().stream()
-                .sorted(Comparator.comparingInt(ReviewPhoto::getDisplayOrder))
-                .map(rp -> rp.getPhoto().getImageUrl())
-                .toList();
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewResponse.java
@@ -2,13 +2,9 @@ package org.sopt.snappinserver.api.product.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.Comparator;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.sopt.snappinserver.domain.review.domain.entity.Review;
-import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
 import org.sopt.snappinserver.domain.review.service.dto.response.ReviewResult;
 
 @Getter

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewResponse.java
@@ -32,12 +32,12 @@ public class ProductReviewResponse {
 
     public static ProductReviewResponse from(ProductReviewResult result) {
         return new ProductReviewResponse(
-            result.getId(),
-            result.getReviewer(),
-            result.getRating(),
-            result.getCreatedAt(),
-            result.getImages(),
-            result.getContent()
+            result.id(),
+            result.reviewer(),
+            result.rating(),
+            result.createdAt(),
+            result.images(),
+            result.content()
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewResponse.java
@@ -2,9 +2,13 @@ package org.sopt.snappinserver.api.product.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Comparator;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.sopt.snappinserver.domain.review.domain.entity.Review;
+import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
 
 @Getter
 @AllArgsConstructor
@@ -28,4 +32,34 @@ public class ProductReviewResponse {
 
     @Schema(description = "리뷰 내용", example = "리뷰 내용")
     private String content;
+
+    public static ProductReviewResponse from(Review review) {
+        return new ProductReviewResponse(
+                review.getId(),
+                getReviewerFrom(review),
+                review.getRating(),
+                getCreatedDateFrom(review),
+                getImagesFrom(review),
+                review.getContent()
+        );
+    }
+
+    private static String getReviewerFrom(Review review) {
+        return review.getReservation()
+                .getUser()
+                .getName();
+    }
+
+    private static LocalDate getCreatedDateFrom(Review review) {
+        return review.getCreatedAt()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate();
+    }
+
+    private static List<String> getImagesFrom(Review review) {
+        return review.getReviewPhotos().stream()
+                .sorted(Comparator.comparingInt(ReviewPhoto::getDisplayOrder))
+                .map(rp -> rp.getPhoto().getImageUrl())
+                .toList();
+    }
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsCursorResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsCursorResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 @AllArgsConstructor
 @Schema(description = "상품 리뷰 커서 기반 목록 응답 DTO")
 public class ProductReviewsCursorResponse {
+
     @Schema(description = "상품 리뷰 목록")
     private List<ProductReviewResponse> reviews;
 
@@ -22,11 +23,11 @@ public class ProductReviewsCursorResponse {
 
     public static ProductReviewsCursorResponse from(ReviewPageResult result) {
         return new ProductReviewsCursorResponse(
-                result.getReviews().stream()
-                        .map(ProductReviewResponse::from)
-                        .toList(),
-                result.getNextCursor(),
-                result.isHasNext()
+            result.getReviews().stream()
+                .map(ProductReviewResponse::from)
+                .toList(),
+            result.getNextCursor(),
+            result.isHasNext()
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsCursorResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsCursorResponse.java
@@ -3,6 +3,7 @@ package org.sopt.snappinserver.api.product.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.sopt.snappinserver.domain.review.service.dto.response.ReviewPageResult;
 
 import java.util.List;
 
@@ -18,4 +19,14 @@ public class ProductReviewsCursorResponse {
 
     @Schema(description = "다음 페이지 존재 여부", example = "true")
     private boolean hasNext;
+
+    public static ProductReviewsCursorResponse from(ReviewPageResult result) {
+        return new ProductReviewsCursorResponse(
+                result.getReviews().stream()
+                        .map(ProductReviewResponse::from)
+                        .toList(),
+                result.getNextCursor(),
+                result.isHasNext()
+        );
+    }
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsCursorResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsCursorResponse.java
@@ -1,0 +1,21 @@
+package org.sopt.snappinserver.api.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "상품 리뷰 커서 기반 목록 응답 DTO")
+public class ProductReviewsCursorResponse {
+    @Schema(description = "상품 리뷰 목록")
+    private List<ProductReviewResponse> reviews;
+
+    @Schema(description = "다음 커서 값", example = "89", nullable = true)
+    private Long nextCursor;
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    private boolean hasNext;
+}

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsMetaResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsMetaResponse.java
@@ -18,8 +18,8 @@ public class ProductReviewsMetaResponse {
 
     public static ProductReviewsMetaResponse from(ProductReviewPageResult result) {
         return new ProductReviewsMetaResponse(
-            result.getNextCursor(),
-            result.isHasNext()
+            result.nextCursor(),
+            result.hasNext()
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsMetaResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsMetaResponse.java
@@ -1,0 +1,25 @@
+package org.sopt.snappinserver.api.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.sopt.snappinserver.domain.review.service.dto.response.ReviewPageResult;
+
+@Schema(description = "상품 리뷰 커서 기반 조회 메타 정보")
+@Getter
+@AllArgsConstructor
+public class ProductReviewsMetaResponse {
+
+    @Schema(description = "다음 커서 값", example = "6", nullable = true)
+    private Long nextCursor;
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    private boolean hasNext;
+
+    public static ProductReviewsMetaResponse from(ReviewPageResult result) {
+        return new ProductReviewsMetaResponse(
+            result.getNextCursor(),
+            result.isHasNext()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsMetaResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsMetaResponse.java
@@ -3,7 +3,7 @@ package org.sopt.snappinserver.api.product.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.sopt.snappinserver.domain.review.service.dto.response.ReviewPageResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewPageResult;
 
 @Schema(description = "상품 리뷰 커서 기반 조회 메타 정보")
 @Getter
@@ -16,7 +16,7 @@ public class ProductReviewsMetaResponse {
     @Schema(description = "다음 페이지 존재 여부", example = "true")
     private boolean hasNext;
 
-    public static ProductReviewsMetaResponse from(ReviewPageResult result) {
+    public static ProductReviewsMetaResponse from(ProductReviewPageResult result) {
         return new ProductReviewsMetaResponse(
             result.getNextCursor(),
             result.isHasNext()

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsResponse.java
@@ -3,7 +3,7 @@ package org.sopt.snappinserver.api.product.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.sopt.snappinserver.domain.review.service.dto.response.ReviewPageResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewPageResult;
 
 import java.util.List;
 
@@ -15,7 +15,7 @@ public class ProductReviewsResponse {
     @Schema(description = "상품 리뷰 목록")
     private List<ProductReviewResponse> reviews;
 
-    public static ProductReviewsResponse from(ReviewPageResult result) {
+    public static ProductReviewsResponse from(ProductReviewPageResult result) {
         return new ProductReviewsResponse(
             result.getReviews().stream()
                 .map(ProductReviewResponse::from)

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsResponse.java
@@ -17,7 +17,7 @@ public class ProductReviewsResponse {
 
     public static ProductReviewsResponse from(ProductReviewPageResult result) {
         return new ProductReviewsResponse(
-            result.getReviews().stream()
+            result.reviews().stream()
                 .map(ProductReviewResponse::from)
                 .toList()
         );

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductReviewsResponse.java
@@ -10,24 +10,16 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @Schema(description = "상품 리뷰 커서 기반 목록 응답 DTO")
-public class ProductReviewsCursorResponse {
+public class ProductReviewsResponse {
 
     @Schema(description = "상품 리뷰 목록")
     private List<ProductReviewResponse> reviews;
 
-    @Schema(description = "다음 커서 값", example = "89", nullable = true)
-    private Long nextCursor;
-
-    @Schema(description = "다음 페이지 존재 여부", example = "true")
-    private boolean hasNext;
-
-    public static ProductReviewsCursorResponse from(ReviewPageResult result) {
-        return new ProductReviewsCursorResponse(
+    public static ProductReviewsResponse from(ReviewPageResult result) {
+        return new ProductReviewsResponse(
             result.getReviews().stream()
                 .map(ProductReviewResponse::from)
-                .toList(),
-            result.getNextCursor(),
-            result.isHasNext()
+                .toList()
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/domain/exception/ProductErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/domain/exception/ProductErrorCode.java
@@ -27,12 +27,13 @@ public enum ProductErrorCode implements ErrorCode {
     PRODUCT_OPTION_CATEGORY_REQUIRED(400, "PRODUCT_400_016", ""),
     ANSWER_REQUIRED(400, "PRODUCT_400_017", ""),
     ANSWER_TOO_LONG(400, "PRODUCT_400_018", ""),
-
+    INVALID_CURSOR(400, "PRODUCT_400_019", "유효하지 않은 커서 값입니다."),
     // 401 UNAUTHORIZED
 
     // 403 FORBIDDEN
 
-    ;
+    // 404 NOT FOUND
+    PRODUCT_NOT_FOUND(404, "PRODUCT_404_001", "존재하지 않는 상품입니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
@@ -1,0 +1,30 @@
+package org.sopt.snappinserver.domain.product.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.product.dto.response.ProductReviewResponse;
+import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
+import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetProductReviewsService implements GetProductReviewsUseCase {
+    private static final int PAGE_SIZE = 5;
+
+    @Override
+    public ProductReviewsCursorResponse getProductReviews(
+            Long productId,
+            Long cursor
+    ) {
+        // TODO: Repository 연동 (커서 기반 조회)
+        List<ProductReviewResponse> reviews = List.of();
+
+        return new ProductReviewsCursorResponse(
+                reviews,
+                null,
+                false
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
@@ -1,15 +1,19 @@
 package org.sopt.snappinserver.domain.product.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.domain.product.domain.exception.ProductErrorCode;
 import org.sopt.snappinserver.domain.product.domain.exception.ProductException;
 import org.sopt.snappinserver.domain.product.repository.ProductRepository;
-import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
-import org.sopt.snappinserver.domain.review.domain.entity.Review;
-import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewPageResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewResult;
+import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
+import org.sopt.snappinserver.domain.review.domain.entity.Review;
+import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
+import org.sopt.snappinserver.domain.review.repository.ReviewPhotoRepository;
+import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -21,6 +25,7 @@ public class GetProductReviewsService implements GetProductReviewsUseCase {
 
     private final ProductRepository productRepository;
     private final ReviewRepository reviewRepository;
+    private final ReviewPhotoRepository reviewPhotoRepository;
 
     @Override
     public ProductReviewPageResult getProductReviews(Long productId, Long cursor) {
@@ -28,19 +33,48 @@ public class GetProductReviewsService implements GetProductReviewsUseCase {
         validateProductExist(productId);
         validateCursorSize(cursor);
 
-        // 커서 기준으로 리뷰 조회 (limit + 1)
+        // 리뷰 조회 (Review + Reservation + User fetch join)
         List<Review> reviews =
             (cursor == null)
-                ? reviewRepository.findTop6ByReservationProductIdOrderByIdDesc(productId)
-                : reviewRepository
-                    .findTop6ByReservationProductIdAndIdLessThanOrderByIdDesc(productId, cursor);
+                ? reviewRepository.findTop6WithUserByProductId(productId)
+                : reviewRepository.findTop6WithUserByProductIdAndCursor(productId, cursor);
 
         boolean hasNext = reviews.size() > PAGE_SIZE;
         if (hasNext) {
             reviews = reviews.subList(0, PAGE_SIZE);
         }
 
-        List<ProductReviewResult> results = ProductReviewResult.of(reviews);
+        // 리뷰가 없으면 바로 반환
+        if (reviews.isEmpty()) {
+            return new ProductReviewPageResult(List.of(), null, false);
+        }
+
+        // 리뷰 ID 추출
+        List<Long> reviewIds = reviews.stream()
+            .map(Review::getId)
+            .toList();
+
+        // 리뷰 사진 + 사진 정보 한 번에 조회
+        List<ReviewPhoto> reviewPhotos =
+            reviewPhotoRepository.findAllByReviewIds(reviewIds);
+
+        // reviewId 기준으로 그룹핑
+        Map<Long, List<ReviewPhoto>> photosByReviewId =
+            reviewPhotos.stream()
+                .collect(Collectors.groupingBy(
+                    rp -> rp.getReview().getId()
+                ));
+
+        // DTO 변환 (조합 책임은 Service)
+        List<ProductReviewResult> results =
+            reviews.stream()
+                .map(review ->
+                    ProductReviewResult.from(
+                        review,
+                        photosByReviewId.getOrDefault(review.getId(), List.of())
+                    )
+                )
+                .toList();
 
         Long nextCursor = hasNext
             ? reviews.get(reviews.size() - 1).getId()

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
@@ -19,8 +19,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GetProductReviewsService implements GetProductReviewsUseCase {
 
-    // 페이지 크기 설정
     private static final int PAGE_SIZE = 5;
+    private static final long MIN_CURSOR_VALUE = 1L;
 
     private final ProductRepository productRepository;
     private final ReviewRepository reviewRepository;
@@ -33,7 +33,7 @@ public class GetProductReviewsService implements GetProductReviewsUseCase {
             throw new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND);
         }
 
-        if (cursor != null && cursor < 0) {
+        if (cursor != null && cursor < MIN_CURSOR_VALUE) {
             throw new ProductException(ProductErrorCode.INVALID_CURSOR);
         }
 

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
@@ -39,8 +39,8 @@ public class GetProductReviewsService implements GetProductReviewsUseCase {
         Pageable pageable = PageRequest.of(0, PAGE_SIZE + 1);
         List<Review> reviews =
             (cursor == null)
-                ? reviewRepository.findTop6WithUserByProductId(productId, pageable)
-                : reviewRepository.findTop6WithUserByProductIdAndCursor(productId, cursor, pageable);
+                ? reviewRepository.findReviewsWithUserByProductId(productId, pageable)
+                : reviewRepository.findReviewsWithUserByProductIdAndCursor(productId, cursor, pageable);
 
         boolean hasNext = reviews.size() > PAGE_SIZE;
         if (hasNext) {

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.domain.product.domain.exception.ProductErrorCode;
 import org.sopt.snappinserver.domain.product.domain.exception.ProductException;
 import org.sopt.snappinserver.domain.product.repository.ProductRepository;
+import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
 import org.sopt.snappinserver.domain.review.domain.entity.Review;
 import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
 import org.sopt.snappinserver.domain.review.repository.ReviewRepository;

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
@@ -29,13 +29,9 @@ public class GetProductReviewsService implements GetProductReviewsUseCase {
     public ReviewPageResult getProductReviews(Long productId, Long cursor) {
 
         // 상품 및 커서 유효성 검증
-        if (!productRepository.existsById(productId)) {
-            throw new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND);
-        }
+        validateProductExist(productId);
 
-        if (cursor != null && cursor < MIN_CURSOR_VALUE) {
-            throw new ProductException(ProductErrorCode.INVALID_CURSOR);
-        }
+        validateCursorSize(cursor);
 
         // 커서 기준으로 리뷰 조회 (limit + 1)
         List<Review> reviews =
@@ -63,6 +59,18 @@ public class GetProductReviewsService implements GetProductReviewsUseCase {
             : null;
 
         return new ReviewPageResult(results, nextCursor, hasNext);
+    }
+
+    private void validateProductExist(Long productId) {
+        if (!productRepository.existsById(productId)) {
+            throw new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND);
+        }
+    }
+
+    private static void validateCursorSize(Long cursor) {
+        if (cursor != null && cursor < MIN_CURSOR_VALUE) {
+            throw new ProductException(ProductErrorCode.INVALID_CURSOR);
+        }
     }
 
     private ReviewResult toResult(Review review) {

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
@@ -14,6 +14,8 @@ import org.sopt.snappinserver.domain.review.domain.entity.Review;
 import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
 import org.sopt.snappinserver.domain.review.repository.ReviewPhotoRepository;
 import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -34,10 +36,11 @@ public class GetProductReviewsService implements GetProductReviewsUseCase {
         validateCursorSize(cursor);
 
         // 리뷰 조회 (Review + Reservation + User fetch join)
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE + 1);
         List<Review> reviews =
             (cursor == null)
-                ? reviewRepository.findTop6WithUserByProductId(productId)
-                : reviewRepository.findTop6WithUserByProductIdAndCursor(productId, cursor);
+                ? reviewRepository.findTop6WithUserByProductId(productId, pageable)
+                : reviewRepository.findTop6WithUserByProductIdAndCursor(productId, cursor, pageable);
 
         boolean hasNext = reviews.size() > PAGE_SIZE;
         if (hasNext) {

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
@@ -39,10 +39,10 @@ public class GetProductReviewsService implements GetProductReviewsUseCase {
 
         // 커서 기준으로 리뷰 조회 (limit + 1)
         List<Review> reviews =
-                (cursor == null)
-                        ? reviewRepository.findTop6ByReservationProductIdOrderByIdDesc(productId)
-                        : reviewRepository
-                        .findTop6ByReservationProductIdAndIdLessThanOrderByIdDesc(productId, cursor);
+            (cursor == null)
+                ? reviewRepository.findTop6ByReservationProductIdOrderByIdDesc(productId)
+                : reviewRepository
+                    .findTop6ByReservationProductIdAndIdLessThanOrderByIdDesc(productId, cursor);
 
         // 다음 페이지 존재 여부 판단
         boolean hasNext = reviews.size() > PAGE_SIZE;
@@ -53,31 +53,31 @@ public class GetProductReviewsService implements GetProductReviewsUseCase {
 
         // 엔티티를 도메인 결과 DTO로 변환
         List<ReviewResult> results =
-                reviews.stream()
-                        .map(this::toResult)
-                        .toList();
+            reviews.stream()
+                .map(this::toResult)
+                .toList();
 
         // 다음 커서 계산
         Long nextCursor = hasNext
-                ? reviews.get(reviews.size() - 1).getId()
-                : null;
+            ? reviews.get(reviews.size() - 1).getId()
+            : null;
 
         return new ReviewPageResult(results, nextCursor, hasNext);
     }
 
     private ReviewResult toResult(Review review) {
         return new ReviewResult(
-                review.getId(),
-                review.getReservation().getUser().getName(),
-                review.getRating(),
-                review.getCreatedAt()
-                        .atZone(ZoneId.systemDefault())
-                        .toLocalDate(),
-                review.getReviewPhotos().stream()
-                        .sorted(Comparator.comparingInt(ReviewPhoto::getDisplayOrder))
-                        .map(rp -> rp.getPhoto().getImageUrl())
-                        .toList(),
-                review.getContent()
+            review.getId(),
+            review.getReservation().getUser().getName(),
+            review.getRating(),
+            review.getCreatedAt()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate(),
+            review.getReviewPhotos().stream()
+                .sorted(Comparator.comparingInt(ReviewPhoto::getDisplayOrder))
+                .map(rp -> rp.getPhoto().getImageUrl())
+                .toList(),
+            review.getContent()
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
@@ -17,9 +17,11 @@ import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class GetProductReviewsService implements GetProductReviewsUseCase {
 
     private static final int PAGE_SIZE = 5;
@@ -65,7 +67,7 @@ public class GetProductReviewsService implements GetProductReviewsUseCase {
         Map<Long, List<ReviewPhoto>> photosByReviewId =
             reviewPhotos.stream()
                 .collect(Collectors.groupingBy(
-                    rp -> rp.getReview().getId()
+                    reviewPhoto -> reviewPhoto.getReview().getId()
                 ));
 
         // DTO 변환 (조합 책임은 Service)

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
@@ -4,6 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
+import org.sopt.snappinserver.domain.product.domain.exception.ProductErrorCode;
+import org.sopt.snappinserver.domain.product.domain.exception.ProductException;
+import org.sopt.snappinserver.domain.product.repository.ProductRepository;
+import org.sopt.snappinserver.domain.review.domain.entity.Review;
+import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,18 +18,54 @@ import java.util.List;
 public class GetProductReviewsService implements GetProductReviewsUseCase {
     private static final int PAGE_SIZE = 5;
 
+    private final ProductRepository productRepository;
+    private final ReviewRepository reviewRepository;
+
     @Override
     public ProductReviewsCursorResponse getProductReviews(
             Long productId,
             Long cursor
     ) {
-        // TODO: Repository 연동 (커서 기반 조회)
-        List<ProductReviewResponse> reviews = List.of();
+        // 상품 존재 검증
+        if (!productRepository.existsById(productId)) {
+            throw new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+        // cursor 검증
+        if (cursor != null && cursor < 0) {
+            throw new ProductException(ProductErrorCode.INVALID_CURSOR);
+        }
+
+        // 리뷰 조회 (limit + 1)
+        List<Review> reviews =
+                (cursor == null)
+                        ? reviewRepository.findTop6ByReservationProductIdOrderByIdDesc(productId)
+                        : reviewRepository.findTop6ByReservationProductIdAndIdLessThanOrderByIdDesc(
+                        productId, cursor
+                );
+
+        // hasNext 판단
+        boolean hasNext = reviews.size() > PAGE_SIZE;
+
+        if (hasNext) {
+            reviews = reviews.subList(0, PAGE_SIZE);
+        }
+
+        // DTO 변환
+        List<ProductReviewResponse> reviewResponses =
+                reviews.stream()
+                        .map(ProductReviewResponse::from)
+                        .toList();
+
+        // nextCursor 계산
+        Long nextCursor = hasNext
+                ? reviews.get(reviews.size() - 1).getId()
+                : null;
 
         return new ProductReviewsCursorResponse(
-                reviews,
-                null,
-                false
+                reviewResponses,
+                nextCursor,
+                hasNext
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
@@ -1,7 +1,5 @@
 package org.sopt.snappinserver.domain.product.service;
 
-import java.time.ZoneId;
-import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.domain.product.domain.exception.ProductErrorCode;
@@ -9,10 +7,9 @@ import org.sopt.snappinserver.domain.product.domain.exception.ProductException;
 import org.sopt.snappinserver.domain.product.repository.ProductRepository;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
 import org.sopt.snappinserver.domain.review.domain.entity.Review;
-import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
 import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
-import org.sopt.snappinserver.domain.review.service.dto.response.ReviewPageResult;
-import org.sopt.snappinserver.domain.review.service.dto.response.ReviewResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewPageResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewResult;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -26,7 +23,7 @@ public class GetProductReviewsService implements GetProductReviewsUseCase {
     private final ReviewRepository reviewRepository;
 
     @Override
-    public ReviewPageResult getProductReviews(Long productId, Long cursor) {
+    public ProductReviewPageResult getProductReviews(Long productId, Long cursor) {
 
         validateProductExist(productId);
         validateCursorSize(cursor);
@@ -43,13 +40,13 @@ public class GetProductReviewsService implements GetProductReviewsUseCase {
             reviews = reviews.subList(0, PAGE_SIZE);
         }
 
-        List<ReviewResult> results = ReviewResult.of(reviews);
+        List<ProductReviewResult> results = ProductReviewResult.of(reviews);
 
         Long nextCursor = hasNext
             ? reviews.get(reviews.size() - 1).getId()
             : null;
 
-        return new ReviewPageResult(results, nextCursor, hasNext);
+        return new ProductReviewPageResult(results, nextCursor, hasNext);
     }
 
     private void validateProductExist(Long productId) {

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
@@ -1,71 +1,76 @@
 package org.sopt.snappinserver.domain.product.service;
 
+import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.api.product.dto.response.ProductReviewResponse;
-import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
-import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
 import org.sopt.snappinserver.domain.product.domain.exception.ProductErrorCode;
 import org.sopt.snappinserver.domain.product.domain.exception.ProductException;
 import org.sopt.snappinserver.domain.product.repository.ProductRepository;
 import org.sopt.snappinserver.domain.review.domain.entity.Review;
+import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
 import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
+import org.sopt.snappinserver.domain.review.service.dto.response.ReviewPageResult;
+import org.sopt.snappinserver.domain.review.service.dto.response.ReviewResult;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class GetProductReviewsService implements GetProductReviewsUseCase {
+
     private static final int PAGE_SIZE = 5;
 
     private final ProductRepository productRepository;
     private final ReviewRepository reviewRepository;
 
     @Override
-    public ProductReviewsCursorResponse getProductReviews(
-            Long productId,
-            Long cursor
-    ) {
-        // 상품 존재 검증
+    public ReviewPageResult getProductReviews(Long productId, Long cursor) {
+
         if (!productRepository.existsById(productId)) {
             throw new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND);
         }
 
-        // cursor 검증
         if (cursor != null && cursor < 0) {
             throw new ProductException(ProductErrorCode.INVALID_CURSOR);
         }
 
-        // 리뷰 조회 (limit + 1)
         List<Review> reviews =
                 (cursor == null)
                         ? reviewRepository.findTop6ByReservationProductIdOrderByIdDesc(productId)
-                        : reviewRepository.findTop6ByReservationProductIdAndIdLessThanOrderByIdDesc(
-                        productId, cursor
-                );
+                        : reviewRepository
+                        .findTop6ByReservationProductIdAndIdLessThanOrderByIdDesc(productId, cursor);
 
-        // hasNext 판단
         boolean hasNext = reviews.size() > PAGE_SIZE;
 
         if (hasNext) {
             reviews = reviews.subList(0, PAGE_SIZE);
         }
 
-        // DTO 변환
-        List<ProductReviewResponse> reviewResponses =
+        List<ReviewResult> results =
                 reviews.stream()
-                        .map(ProductReviewResponse::from)
+                        .map(this::toResult)
                         .toList();
 
-        // nextCursor 계산
         Long nextCursor = hasNext
                 ? reviews.get(reviews.size() - 1).getId()
                 : null;
 
-        return new ProductReviewsCursorResponse(
-                reviewResponses,
-                nextCursor,
-                hasNext
+        return new ReviewPageResult(results, nextCursor, hasNext);
+    }
+
+    private ReviewResult toResult(Review review) {
+        return new ReviewResult(
+                review.getId(),
+                review.getReservation().getUser().getName(),
+                review.getRating(),
+                review.getCreatedAt()
+                        .atZone(ZoneId.systemDefault())
+                        .toLocalDate(),
+                review.getReviewPhotos().stream()
+                        .sorted(Comparator.comparingInt(ReviewPhoto::getDisplayOrder))
+                        .map(rp -> rp.getPhoto().getImageUrl())
+                        .toList(),
+                review.getContent()
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsUseCase.java
@@ -1,9 +1,9 @@
 package org.sopt.snappinserver.domain.product.service;
 
-import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
+import org.sopt.snappinserver.domain.review.service.dto.response.ReviewPageResult;
 
 public interface GetProductReviewsUseCase {
-    ProductReviewsCursorResponse getProductReviews(
+    ReviewPageResult getProductReviews(
             Long productId,
             Long cursor
     );

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsUseCase.java
@@ -1,0 +1,10 @@
+package org.sopt.snappinserver.domain.product.service;
+
+import org.sopt.snappinserver.api.product.dto.response.ProductReviewsCursorResponse;
+
+public interface GetProductReviewsUseCase {
+    ProductReviewsCursorResponse getProductReviews(
+            Long productId,
+            Long cursor
+    );
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewPageResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewPageResult.java
@@ -1,15 +1,9 @@
 package org.sopt.snappinserver.domain.product.service.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.util.List;
 
-@Getter
-@AllArgsConstructor
-public class ProductReviewPageResult {
-
-    private List<ProductReviewResult> reviews;
-    private Long nextCursor;
-    private boolean hasNext;
-}
+public record ProductReviewPageResult(
+    List<ProductReviewResult> reviews,
+    Long nextCursor,
+    boolean hasNext
+) {}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewPageResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewPageResult.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.domain.review.service.dto.response;
+package org.sopt.snappinserver.domain.product.service.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,9 +7,9 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
-public class ReviewPageResult {
+public class ProductReviewPageResult {
 
-    private List<ReviewResult> reviews;
+    private List<ProductReviewResult> reviews;
     private Long nextCursor;
     private boolean hasNext;
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewResult.java
@@ -4,21 +4,17 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.sopt.snappinserver.domain.review.domain.entity.Review;
 import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
 
-@Getter
-@AllArgsConstructor
-public class ProductReviewResult {
-
-    private Long id;
-    private String reviewer;
-    private int rating;
-    private LocalDate createdAt;
-    private List<String> images;
-    private String content;
+public record ProductReviewResult(
+    Long id,
+    String reviewer,
+    int rating,
+    LocalDate createdAt,
+    List<String> images,
+    String content
+) {
 
     public static ProductReviewResult from(Review review) {
         return new ProductReviewResult(
@@ -36,6 +32,7 @@ public class ProductReviewResult {
             .map(ProductReviewResult::from)
             .toList();
     }
+
     private static String extractReviewer(Review review) {
         return review.getReservation()
             .getUser()
@@ -51,7 +48,7 @@ public class ProductReviewResult {
     private static List<String> extractImages(Review review) {
         return review.getReviewPhotos().stream()
             .sorted(Comparator.comparingInt(ReviewPhoto::getDisplayOrder))
-            .map(rp -> rp.getPhoto().getImageUrl())
+            .map(reviewPhoto -> reviewPhoto.getPhoto().getImageUrl())
             .toList();
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewResult.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.domain.review.service.dto.response;
+package org.sopt.snappinserver.domain.product.service.dto.response;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -11,7 +11,7 @@ import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
 
 @Getter
 @AllArgsConstructor
-public class ReviewResult {
+public class ProductReviewResult {
 
     private Long id;
     private String reviewer;
@@ -20,8 +20,8 @@ public class ReviewResult {
     private List<String> images;
     private String content;
 
-    public static ReviewResult from(Review review) {
-        return new ReviewResult(
+    public static ProductReviewResult from(Review review) {
+        return new ProductReviewResult(
             review.getId(),
             extractReviewer(review),
             review.getRating(),
@@ -31,9 +31,9 @@ public class ReviewResult {
         );
     }
 
-    public static List<ReviewResult> of(List<Review> reviews) {
+    public static List<ProductReviewResult> of(List<Review> reviews) {
         return reviews.stream()
-            .map(ReviewResult::from)
+            .map(ProductReviewResult::from)
             .toList();
     }
     private static String extractReviewer(Review review) {

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewResult.java
@@ -16,21 +16,18 @@ public record ProductReviewResult(
     String content
 ) {
 
-    public static ProductReviewResult from(Review review) {
+    public static ProductReviewResult from(
+        Review review,
+        List<ReviewPhoto> reviewPhotos
+    ) {
         return new ProductReviewResult(
             review.getId(),
             extractReviewer(review),
             review.getRating(),
             extractCreatedDate(review),
-            extractImages(review),
+            extractImages(reviewPhotos),
             review.getContent()
         );
-    }
-
-    public static List<ProductReviewResult> of(List<Review> reviews) {
-        return reviews.stream()
-            .map(ProductReviewResult::from)
-            .toList();
     }
 
     private static String extractReviewer(Review review) {
@@ -45,8 +42,8 @@ public record ProductReviewResult(
             .toLocalDate();
     }
 
-    private static List<String> extractImages(Review review) {
-        return review.getReviewPhotos().stream()
+    private static List<String> extractImages(List<ReviewPhoto> reviewPhotos) {
+        return reviewPhotos.stream()
             .sorted(Comparator.comparingInt(ReviewPhoto::getDisplayOrder))
             .map(reviewPhoto -> reviewPhoto.getPhoto().getImageUrl())
             .toList();

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductReviewsUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductReviewsUseCase.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.domain.product.service;
+package org.sopt.snappinserver.domain.product.service.usecase;
 
 import org.sopt.snappinserver.domain.review.service.dto.response.ReviewPageResult;
 

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductReviewsUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductReviewsUseCase.java
@@ -3,8 +3,9 @@ package org.sopt.snappinserver.domain.product.service.usecase;
 import org.sopt.snappinserver.domain.review.service.dto.response.ReviewPageResult;
 
 public interface GetProductReviewsUseCase {
+
     ReviewPageResult getProductReviews(
-            Long productId,
-            Long cursor
+        Long productId,
+        Long cursor
     );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductReviewsUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductReviewsUseCase.java
@@ -1,10 +1,10 @@
 package org.sopt.snappinserver.domain.product.service.usecase;
 
-import org.sopt.snappinserver.domain.review.service.dto.response.ReviewPageResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewPageResult;
 
 public interface GetProductReviewsUseCase {
 
-    ReviewPageResult getProductReviews(
+    ProductReviewPageResult getProductReviews(
         Long productId,
         Long cursor
     );

--- a/src/main/java/org/sopt/snappinserver/domain/review/domain/entity/Review.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/domain/entity/Review.java
@@ -1,13 +1,6 @@
 package org.sopt.snappinserver.domain.review.domain.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +9,9 @@ import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
 import org.sopt.snappinserver.domain.review.domain.exception.ReviewErrorCode;
 import org.sopt.snappinserver.domain.review.domain.exception.ReviewException;
 import org.sopt.snappinserver.global.entity.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -39,6 +35,9 @@ public class Review extends BaseEntity {
 
     @Column(nullable = false, length = MAX_CONTENT_LENGTH)
     private String content;
+
+    @OneToMany(mappedBy = "review", fetch = FetchType.LAZY)
+    private List<ReviewPhoto> reviewPhotos = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Review(Reservation reservation, Integer rating, String content) {

--- a/src/main/java/org/sopt/snappinserver/domain/review/domain/entity/Review.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/domain/entity/Review.java
@@ -10,9 +10,6 @@ import org.sopt.snappinserver.domain.review.domain.exception.ReviewErrorCode;
 import org.sopt.snappinserver.domain.review.domain.exception.ReviewException;
 import org.sopt.snappinserver.global.entity.BaseEntity;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -35,9 +32,6 @@ public class Review extends BaseEntity {
 
     @Column(nullable = false, length = MAX_CONTENT_LENGTH)
     private String content;
-
-    @OneToMany(mappedBy = "review", fetch = FetchType.LAZY)
-    private List<ReviewPhoto> reviewPhotos = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Review(Reservation reservation, Integer rating, String content) {

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewPhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewPhotoRepository.java
@@ -1,0 +1,23 @@
+package org.sopt.snappinserver.domain.review.repository;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewPhotoRepository extends JpaRepository<ReviewPhoto, Long> {
+
+    @Query("""
+            select reviewPhoto
+            from ReviewPhoto reviewPhoto
+            join fetch reviewPhoto.photo
+            where reviewPhoto.review.id in :reviewIds
+            order by reviewPhoto.review.id, reviewPhoto.displayOrder
+        """)
+    List<ReviewPhoto> findAllByReviewIds(
+        @Param("reviewIds") List<Long> reviewIds
+    );
+}

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
@@ -8,14 +8,15 @@ import java.util.List;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
     // 첫 페이지
     List<Review> findTop6ByReservationProductIdOrderByIdDesc(
-            Long productId
+        Long productId
     );
 
     // 커서 이후 페이지
     List<Review> findTop6ByReservationProductIdAndIdLessThanOrderByIdDesc(
-            Long productId,
-            Long cursor
+        Long productId,
+        Long cursor
     );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
@@ -21,7 +21,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         where reservation.product.id = :productId
         order by review.id desc
     """)
-    List<Review> findTop6WithUserByProductId(
+    List<Review> findReviewsWithUserByProductId(
         @Param("productId") Long productId,
         Pageable pageable
     );
@@ -36,7 +36,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
           and review.id < :cursor
         order by review.id desc
     """)
-    List<Review> findTop6WithUserByProductIdAndCursor(
+    List<Review> findReviewsWithUserByProductIdAndCursor(
         @Param("productId") Long productId,
         @Param("cursor") Long cursor,
         Pageable pageable

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
@@ -4,7 +4,18 @@ import org.sopt.snappinserver.domain.review.domain.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    // 첫 페이지
+    List<Review> findTop6ByReservationProductIdOrderByIdDesc(
+            Long productId
+    );
 
+    // 커서 이후 페이지
+    List<Review> findTop6ByReservationProductIdAndIdLessThanOrderByIdDesc(
+            Long productId,
+            Long cursor
+    );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.snappinserver.domain.review.repository;
 
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 import org.sopt.snappinserver.domain.review.domain.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,29 +14,31 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     // 첫 페이지 조회 (cursor 없음)
     @Query("""
-        select r
-        from Review r
-        join fetch r.reservation res
-        join fetch res.user u
-        where res.product.id = :productId
-        order by r.id desc
+        select review
+        from Review review
+        join fetch review.reservation reservation
+        join fetch reservation.user user
+        where reservation.product.id = :productId
+        order by review.id desc
     """)
     List<Review> findTop6WithUserByProductId(
-        @Param("productId") Long productId
+        @Param("productId") Long productId,
+        Pageable pageable
     );
 
     // 커서 이후 페이지 조회
     @Query("""
-        select r
-        from Review r
-        join fetch r.reservation res
-        join fetch res.user u
-        where res.product.id = :productId
-          and r.id < :cursor
-        order by r.id desc
+        select review
+        from Review review
+        join fetch review.reservation reservation
+        join fetch reservation.user u
+        where reservation.product.id = :productId
+          and review.id < :cursor
+        order by review.id desc
     """)
     List<Review> findTop6WithUserByProductIdAndCursor(
         @Param("productId") Long productId,
-        @Param("cursor") Long cursor
+        @Param("cursor") Long cursor,
+        Pageable pageable
     );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
@@ -1,22 +1,41 @@
 package org.sopt.snappinserver.domain.review.repository;
 
+import java.util.List;
 import org.sopt.snappinserver.domain.review.domain.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    // 첫 페이지
-    List<Review> findTop6ByReservationProductIdOrderByIdDesc(
-        Long productId
+
+    // 첫 페이지 조회 (cursor 없음)
+    @Query("""
+        select r
+        from Review r
+        join fetch r.reservation res
+        join fetch res.user u
+        where res.product.id = :productId
+        order by r.id desc
+    """)
+    List<Review> findTop6WithUserByProductId(
+        @Param("productId") Long productId
     );
 
-    // 커서 이후 페이지
-    List<Review> findTop6ByReservationProductIdAndIdLessThanOrderByIdDesc(
-        Long productId,
-        Long cursor
+    // 커서 이후 페이지 조회
+    @Query("""
+        select r
+        from Review r
+        join fetch r.reservation res
+        join fetch res.user u
+        where res.product.id = :productId
+          and r.id < :cursor
+        order by r.id desc
+    """)
+    List<Review> findTop6WithUserByProductIdAndCursor(
+        @Param("productId") Long productId,
+        @Param("cursor") Long cursor
     );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
@@ -31,7 +31,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         select review
         from Review review
         join fetch review.reservation reservation
-        join fetch reservation.user u
+        join fetch reservation.user user
         where reservation.product.id = :productId
           and review.id < :cursor
         order by review.id desc

--- a/src/main/java/org/sopt/snappinserver/domain/review/service/dto/response/ReviewPageResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/service/dto/response/ReviewPageResult.java
@@ -8,6 +8,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class ReviewPageResult {
+
     private List<ReviewResult> reviews;
     private Long nextCursor;
     private boolean hasNext;

--- a/src/main/java/org/sopt/snappinserver/domain/review/service/dto/response/ReviewPageResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/service/dto/response/ReviewPageResult.java
@@ -1,0 +1,14 @@
+package org.sopt.snappinserver.domain.review.service.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ReviewPageResult {
+    private List<ReviewResult> reviews;
+    private Long nextCursor;
+    private boolean hasNext;
+}

--- a/src/main/java/org/sopt/snappinserver/domain/review/service/dto/response/ReviewResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/service/dto/response/ReviewResult.java
@@ -1,9 +1,13 @@
 package org.sopt.snappinserver.domain.review.service.dto.response;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Comparator;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.sopt.snappinserver.domain.review.domain.entity.Review;
+import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
 
 @Getter
 @AllArgsConstructor
@@ -15,4 +19,39 @@ public class ReviewResult {
     private LocalDate createdAt;
     private List<String> images;
     private String content;
+
+    public static ReviewResult from(Review review) {
+        return new ReviewResult(
+            review.getId(),
+            extractReviewer(review),
+            review.getRating(),
+            extractCreatedDate(review),
+            extractImages(review),
+            review.getContent()
+        );
+    }
+
+    public static List<ReviewResult> of(List<Review> reviews) {
+        return reviews.stream()
+            .map(ReviewResult::from)
+            .toList();
+    }
+    private static String extractReviewer(Review review) {
+        return review.getReservation()
+            .getUser()
+            .getName();
+    }
+
+    private static LocalDate extractCreatedDate(Review review) {
+        return review.getCreatedAt()
+            .atZone(ZoneId.systemDefault())
+            .toLocalDate();
+    }
+
+    private static List<String> extractImages(Review review) {
+        return review.getReviewPhotos().stream()
+            .sorted(Comparator.comparingInt(ReviewPhoto::getDisplayOrder))
+            .map(rp -> rp.getPhoto().getImageUrl())
+            .toList();
+    }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/review/service/dto/response/ReviewResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/service/dto/response/ReviewResult.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class ReviewResult {
+
     private Long id;
     private String reviewer;
     private int rating;

--- a/src/main/java/org/sopt/snappinserver/domain/review/service/dto/response/ReviewResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/service/dto/response/ReviewResult.java
@@ -1,0 +1,17 @@
+package org.sopt.snappinserver.domain.review.service.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReviewResult {
+    private Long id;
+    private String reviewer;
+    private int rating;
+    private LocalDate createdAt;
+    private List<String> images;
+    private String content;
+}


### PR DESCRIPTION
## 👀 Summary

- close #26

커서 기반 페이지네이션을 적용하여 상품의 리뷰 목록을 조회하는 API를 구현했습니다.

## 🖇️ Tasks

### ❶ 상품 리뷰 목록 조회 API 설계 및 엔드포인트 구현
- 커서 기반 페이지네이션 방식으로 상품 리뷰 목록을 조회하도록 설계
- 내부 조회 시 PAGE_SIZE + 1 개를 조회하여 hasNext 여부 판단

### ❷ 컨트롤러–서비스–레포지토리 계층 분리 및 역할 정리
- Controller는 요청/응답 변환 및 공통 응답 래핑 역할만 담당
- Service(UseCase)는 상품 리뷰 조회 useCase 단위의 비즈니스 흐름을 담당
- Repository는 커서 기반 조회 책임만 가지도록 분리
- 컨트롤러에서 엔티티를 직접 노출하지 않도록 구조 정리

### ❸ 상품 리뷰 조회 전용 UseCase / Service 구조 도입
- GetProductReviewsUseCase 인터페이스 정의
- GetProductReviewsService 구현체에서 실제 조회 로직 수행
- 조회 결과를 API DTO가 아닌 도메인 결과 객체(ReviewPageResult) 로 반환하도록 설계

### ❹ 커서 기반 조회를 위한 ReviewRepository 구현
- Spring Data JPA 메서드 네이밍을 활용하여 커서 기반 조회 메서드 정의


### ❺ Review–ReviewPhoto 연관관계 정비 및 이미지 조회 처리
- 리뷰 이미지가 중간 엔티티(ReviewPhoto)로 관리되고 있어, 
Review → ReviewPhoto → Photo 구조로 접근 가능하도록 연관관계 컬렉션 추가
- API 응답에서 리뷰에 연결된 모든 이미지 URL을 포함하도록 처리

### ❻ 상품 리뷰 API 응답 DTO 분리 및 구조 정리
- 리뷰 단일 응답 DTO(ProductReviewResponse) 분리
- 커서 기반 목록 응답 DTO(ProductReviewsCursorResponse) 분리
- API 응답 DTO가 도메인 결과를 기반으로 생성되도록 구조 리팩토링

### ❼ 유효성 검증 및 성공/에러 코드 추가

- ReviewErrorCode 및 ReviewException 추가
- ProductSuccessCode 추가

## 🔍 To Reviewer

#### 상품-리뷰 도메인 간 조회 책임 분리
> 상품에 대한 리뷰 조회에서  ReviewRepository를 ProductService가 직접 사용하는 구조가 적절한지 고민하는 과정에서 리뷰 조회의 책임은 Review 도메인에 있다고 판단하여, 상품 리뷰 조회 전용 UseCase에서 ReviewRepository를 사용하도록 설계했습니다.

#### 커서 기반 페이지네이션과 계층 간 역할 분리
> 커서 기반 페이지네이션 구현 과정에서 API 계층과 도메인 계층의 역할을 분리하고자, 조회 결과를 표현하는 도메인 결과 객체를 도입했습니다.

#### DTO 변환 로직의 책임 위치 결정
> DTO 변환 로직의 위치를 고려하면서 해당 로직이 비즈니스 로직이 아닌 ‘응답 형태 변환’에 집중된 역할이라고 판단하여
서비스가 아닌 DTO 내부에 책임을 두는 방향으로 유지했습니다.

<br>

연관관계가 얽혀 있는 도메인들을 다루다보니 구조에 대한 고민이 많았습니다 (ㅠㅠ)

리뷰 도메인과 상품 도메인의 책임 분리가 자연스러운지, 계층간 책임 분리가 적절한지를 중심으로 봐주시면 감사하겠습니다!