### PR TITLE
[FIX] #33: 헬스체크 url 엔드포인트 인증 제외

### DIFF
--- a/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
             .httpBasic(AbstractHttpConfigurer::disable)
 
             .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/actuator/health").permitAll()
                 .requestMatchers(SWAGGER_URLS).permitAll()
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers(AUTHENTICATED_URLS).authenticated()


### PR DESCRIPTION
## 👀 Summary

- close #33


## 🖇️ Tasks

- 헬스체크 api가 인증에 포함되어 CD 파이프라인에서 헬스체크가 실패하여, 헬스체크 api를 인증 제외로 설정했습니다.


## 🔍 To Reviewer

-