### PR TITLE
[FEAT] #21: Swagger, api 도메인 분리 및 Swagger에 dev 서버 추가

### DIFF
--- a/nginx/app.conf.template
+++ b/nginx/app.conf.template
@@ -22,6 +22,14 @@ server {
   ssl_certificate /etc/letsencrypt/live/dev-api.snapping.co.kr/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/dev-api.snapping.co.kr/privkey.pem;
 
+  location ~* ^/(swagger-ui|v3/api-docs|swagger-resources) {
+    return 404;
+  }
+
+  location ~ /\. {
+    return 404;
+  }
+
   location / {
     proxy_pass http://backend;
     proxy_set_header Host $host;

--- a/nginx/conf.d/swagger.conf
+++ b/nginx/conf.d/swagger.conf
@@ -20,10 +20,11 @@ server {
   auth_basic "Swagger Restricted";
   auth_basic_user_file /etc/nginx/.htpasswd;
 
-  location ~ ^/(swagger-ui|v3/api-docs) {
+  location ~ ^/(swagger-ui|v3/api-docs)(/|$) {
     proxy_pass http://backend;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
   }
 
   location / {

--- a/src/main/java/org/sopt/snappinserver/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/swagger/SwaggerConfig.java
@@ -15,12 +15,14 @@ import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
     servers = {
-        @Server(url="http://localhost:8080", description = "로컬 서버 주소")
+        @Server(url = "https://dev-api.snapping.co.kr", description = "dev 서버 주소"),
+        @Server(url = "http://localhost:8080", description = "로컬 서버 주소")
     }
 )
 @Configuration
 public class SwaggerConfig {
 
+    private static final String DEV_ORIGIN = "https://dev-api.snapping.co.kr";
     private static final String LOCAL_ORIGIN = "http://localhost:8080";
 
     @Bean
@@ -80,6 +82,11 @@ public class SwaggerConfig {
 
             List<io.swagger.v3.oas.models.servers.Server> servers = new ArrayList<>();
 
+            servers.add(
+                new io.swagger.v3.oas.models.servers.Server()
+                    .url(DEV_ORIGIN + fullPrefix)
+                    .description("dev")
+            );
             servers.add(
                 new io.swagger.v3.oas.models.servers.Server()
                     .url(LOCAL_ORIGIN + fullPrefix)


### PR DESCRIPTION
## 👀 Summary

- close #21


## 🖇️ Tasks

- Swagger, Api 서브도메인을 분리했습니다.
- Swagger 접속 시  백엔드 dev 환경에 요청을 보낼 수 있도록 서버 정보를 추가했습니다.


## 🔍 To Reviewer

-
