### PR TITLE
[FIX] #36: 예약 추가 금액 요청 엔티티에 BaseEntity 상속 코드 추가

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/ReservationAdditionalPayment.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/ReservationAdditionalPayment.java
@@ -14,11 +14,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.snappinserver.domain.reservation.domain.exception.ReservationErrorCode;
 import org.sopt.snappinserver.domain.reservation.domain.exception.ReservationException;
+import org.sopt.snappinserver.global.entity.BaseEntity;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class ReservationAdditionalPayment {
+public class ReservationAdditionalPayment extends BaseEntity {
 
     private static final int MAX_NAME_LENGTH = 100;
     private static final int MIN_AMOUNT_VALUE = 10;


### PR DESCRIPTION
## 👀 Summary

- close #36


## 🖇️ Tasks

- ReservationAdditionalPayment에 BaseEntity를 상속받지 않아 createdAt, updatedAt이 만들어지지 않는 문제가 있어서 BaseEntity를 상속받도록 구현했습니다.


## 🔍 To Reviewer

-