### PR TITLE
[FIX] #50: 사진-무드 연결 api 인증 제외

### DIFF
--- a/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
                 .requestMatchers(AUTHENTICATED_URLS).authenticated()
                 .requestMatchers(HttpMethod.POST, "/api/v1/auth/login/kakao").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/v1/auth/reissue").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/v1/photos/process").permitAll()
                 .requestMatchers(HttpMethod.GET, PUBLIC_GET_URLS).permitAll()
                 .anyRequest().authenticated()
             )

--- a/src/main/java/org/sopt/snappinserver/global/security/TokenAuthenticationFilter.java
+++ b/src/main/java/org/sopt/snappinserver/global/security/TokenAuthenticationFilter.java
@@ -40,7 +40,9 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
-        return path.startsWith("/api/v1/auth/reissue") || path.startsWith("/api/v1/auth/login");
+
+        return path.equals("/api/v1/auth/reissue") || path.equals("/api/v1/auth/login")
+            || path.equals("/api/v1/photos/process");
     }
 
     @Override


### PR DESCRIPTION
## 👀 Summary

- close #50 


## 🖇️ Tasks

- 람다에서 사진-태그를 인증 없이 요청할 수 있도록 해당 API를 인증 제외합니다.


## 🔍 To Reviewer

-
