### PR TITLE
[FIX] #53: jpa, 일반 리포지토리 분리 후 리포지토리 파라미터 String 으로 변경

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/mood/policy/MoodSelector.java
+++ b/src/main/java/org/sopt/snappinserver/domain/mood/policy/MoodSelector.java
@@ -3,7 +3,7 @@ package org.sopt.snappinserver.domain.mood.policy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import org.sopt.snappinserver.domain.mood.repository.MoodRepository.MoodWithScore;
+import org.sopt.snappinserver.domain.mood.repository.MoodWithScore;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -18,8 +18,12 @@ public class MoodSelector {
         List<MoodWithScore> selected = new ArrayList<>();
 
         for (MoodWithScore candidate : candidates) {
-            if (selected.size() >= lastRank) break;
-            if (hasConflict(candidate, selected)) continue;
+            if (selected.size() >= lastRank) {
+                break;
+            }
+            if (hasConflict(candidate, selected)) {
+                continue;
+            }
             selected.add(candidate);
         }
         return selected;
@@ -27,7 +31,7 @@ public class MoodSelector {
 
     private boolean hasConflict(MoodWithScore candidate, List<MoodWithScore> selected) {
         return selected.stream()
-            .anyMatch(s -> isOpposite(candidate.getName(), s.getName()));
+            .anyMatch(s -> isOpposite(candidate.name(), s.name()));
     }
 
     private boolean isOpposite(String firstTag, String secondTag) {

--- a/src/main/java/org/sopt/snappinserver/domain/mood/repository/MoodRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/mood/repository/MoodRepository.java
@@ -1,30 +1,8 @@
 package org.sopt.snappinserver.domain.mood.repository;
 
-import java.util.List;
 import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface MoodRepository extends JpaRepository<Mood, Long> {
 
-    // Hibernate 6의 벡터 지원을 통해 처리됩니다.
-    @Query(value = """
-            SELECT m.id as id, 
-                   m.name as name, 
-                   (1 - (m.embedding <=> cast(:embedding as vector))) as score
-            FROM mood m
-            ORDER BY m.embedding <=> cast(:embedding as vector) ASC
-            LIMIT 10
-        """, nativeQuery = true)
-    List<MoodWithScore> findCandidates(@Param("embedding") List<Float> embedding);
-
-    interface MoodWithScore {
-
-        Long getId();
-
-        String getName();
-
-        Float getScore();
-    }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/mood/repository/MoodVectorRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/mood/repository/MoodVectorRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.mood.repository;
+
+import java.util.List;
+
+public interface MoodVectorRepository {
+
+    List<MoodWithScore> findTopCandidates(String embedding);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/mood/repository/MoodVectorRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/mood/repository/MoodVectorRepositoryImpl.java
@@ -1,0 +1,43 @@
+package org.sopt.snappinserver.domain.mood.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Tuple;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MoodVectorRepositoryImpl implements MoodVectorRepository {
+
+    @PersistenceContext
+    private final EntityManager em;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<MoodWithScore> findTopCandidates(String embedding) {
+        String sql = """
+                SELECT m.id as id,
+                       m.name as name,
+                       (1 - (m.embedding <=> cast(:embedding as vector))) as score
+                FROM mood m
+                WHERE m.embedding IS NOT NULL
+                ORDER BY m.embedding <=> cast(:embedding as vector)
+                LIMIT 10
+            """;
+
+        List<Tuple> tuples = (List<Tuple>) em.createNativeQuery(sql, Tuple.class)
+            .setParameter("embedding", embedding)
+            .getResultList();
+
+        return tuples.stream()
+            .map(t -> (MoodWithScore) new MoodWithScoreImpl(
+                    ((Number) t.get("id")).longValue(),
+                    t.get("name", String.class),
+                    t.get("score", Number.class).floatValue()
+                )
+            )
+            .toList();
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/mood/repository/MoodVectorRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/mood/repository/MoodVectorRepositoryImpl.java
@@ -4,15 +4,13 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Tuple;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@RequiredArgsConstructor
 public class MoodVectorRepositoryImpl implements MoodVectorRepository {
 
     @PersistenceContext
-    private final EntityManager em;
+    private EntityManager em;
 
     @SuppressWarnings("unchecked")
     @Override

--- a/src/main/java/org/sopt/snappinserver/domain/mood/repository/MoodWithScore.java
+++ b/src/main/java/org/sopt/snappinserver/domain/mood/repository/MoodWithScore.java
@@ -1,0 +1,11 @@
+package org.sopt.snappinserver.domain.mood.repository;
+
+public interface MoodWithScore {
+
+    Long id();
+
+    String name();
+
+    Float score();
+}
+

--- a/src/main/java/org/sopt/snappinserver/domain/mood/repository/MoodWithScoreImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/mood/repository/MoodWithScoreImpl.java
@@ -1,0 +1,9 @@
+package org.sopt.snappinserver.domain.mood.repository;
+
+public record MoodWithScoreImpl(
+    Long id,
+    String name,
+    Float score
+) implements MoodWithScore {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photo/domain/entity/Photo.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photo/domain/entity/Photo.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
-import org.sopt.snappinserver.domain.mood.repository.MoodRepository.MoodWithScore;
+import org.sopt.snappinserver.domain.mood.repository.MoodWithScore;
 import org.sopt.snappinserver.domain.photo.domain.exception.PhotoErrorCode;
 import org.sopt.snappinserver.domain.photo.domain.exception.PhotoException;
 import org.sopt.snappinserver.global.entity.BaseEntity;
@@ -77,7 +77,7 @@ public class Photo extends BaseEntity {
                     this,
                     moods.get(i),
                     FIRST_RANK + i,
-                    scores.get(i).getScore()
+                    scores.get(i).score()
                 )
             )
             .toList();

--- a/src/main/java/org/sopt/snappinserver/domain/photo/service/ProcessPhotoService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photo/service/ProcessPhotoService.java
@@ -1,11 +1,13 @@
 package org.sopt.snappinserver.domain.photo.service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
 import org.sopt.snappinserver.domain.mood.policy.MoodSelector;
 import org.sopt.snappinserver.domain.mood.repository.MoodRepository;
-import org.sopt.snappinserver.domain.mood.repository.MoodRepository.MoodWithScore;
+import org.sopt.snappinserver.domain.mood.repository.MoodVectorRepository;
+import org.sopt.snappinserver.domain.mood.repository.MoodWithScore;
 import org.sopt.snappinserver.domain.photo.domain.entity.Photo;
 import org.sopt.snappinserver.domain.photo.domain.entity.PhotoMood;
 import org.sopt.snappinserver.domain.photo.domain.exception.PhotoErrorCode;
@@ -25,6 +27,7 @@ public class ProcessPhotoService implements ProcessPhotoUseCase {
     private static final int LAST_RANK = 3;
 
     private final PhotoRepository photoRepository;
+    private final MoodVectorRepository moodVectorRepository;
     private final MoodRepository moodRepository;
     private final PhotoMoodRepository photoMoodRepository;
     private final MoodSelector moodSelector;
@@ -36,8 +39,8 @@ public class ProcessPhotoService implements ProcessPhotoUseCase {
             Photo.create(photoProcessCommand.imageUrl(), photoProcessCommand.embedding())
         );
 
-        List<MoodWithScore> candidates = moodRepository.findCandidates(
-            photoProcessCommand.embedding()
+        List<MoodWithScore> candidates = moodVectorRepository.findTopCandidates(
+            toVectorLiteral(photoProcessCommand.embedding())
         );
         List<MoodWithScore> selectedScores = moodSelector.selectTop3(LAST_RANK, candidates);
         List<Mood> selectedMood = getSelectedMood(selectedScores);
@@ -46,14 +49,20 @@ public class ProcessPhotoService implements ProcessPhotoUseCase {
         photoMoodRepository.saveAll(linkedPhotoMoods);
     }
 
+    private String toVectorLiteral(List<Float> embedding) {
+        return "[" + embedding.stream()
+            .map(String::valueOf)
+            .collect(Collectors.joining(",")) + "]";
+    }
+
     private List<Mood> getSelectedMood(List<MoodWithScore> selected) {
         return selected.stream()
-            .map(m -> moodRepository.getReferenceById(m.getId()))
+            .map(m -> moodRepository.getReferenceById(m.id()))
             .toList();
     }
 
     private void validateImageUrlUnique(PhotoProcessCommand photoProcessCommand) {
-        if(photoRepository.existsByImageUrl(photoProcessCommand.imageUrl())) {
+        if (photoRepository.existsByImageUrl(photoProcessCommand.imageUrl())) {
             throw new PhotoException(PhotoErrorCode.IMAGE_URL_ALREADY_SAVED);
         }
     }


### PR DESCRIPTION
## 👀 Summary

- close #53


## 🖇️ Tasks

- pgvector를 입력값으로 받을 때, 리포지토리 조회 시 List<Float>로 하면 바인딩이 안돼서 서비스 단에서 String 으로 바꾼 후 String으로 조회할 수 있도록 했습니다.

## 🔍 To Reviewer

-