### PR TITLE
[FIX] #53: 사진 테이블에서 vector 저장 삭제

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/photo/domain/entity/Photo.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photo/domain/entity/Photo.java
@@ -11,8 +11,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
 import org.sopt.snappinserver.domain.mood.repository.MoodWithScore;
 import org.sopt.snappinserver.domain.photo.domain.exception.PhotoErrorCode;
@@ -25,7 +23,6 @@ import org.sopt.snappinserver.global.entity.BaseEntity;
 public class Photo extends BaseEntity {
 
     private static final int MAX_IMAGE_URL_LENGTH = 1024;
-    private static final int EMBEDDING_DIMENSION = 512;
     private static final int FIRST_RANK = 1;
 
     @Id
@@ -35,21 +32,16 @@ public class Photo extends BaseEntity {
     @Column(nullable = false, length = MAX_IMAGE_URL_LENGTH)
     private String imageUrl;
 
-    @Column(columnDefinition = "vector(" + EMBEDDING_DIMENSION + ")")
-    @JdbcTypeCode(SqlTypes.VECTOR)
-    private List<Float> embedding;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Photo(String imageUrl, List<Float> embedding) {
+    private Photo(String imageUrl) {
         this.imageUrl = imageUrl;
-        this.embedding = embedding;
     }
 
-    public static Photo create(String imageUrl, List<Float> embedding) {
+    public static Photo create(String imageUrl) {
         validatePhoto(imageUrl);
         return Photo.builder()
             .imageUrl(imageUrl)
-            .embedding(embedding)
             .build();
     }
 

--- a/src/main/java/org/sopt/snappinserver/domain/photo/service/ProcessPhotoService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photo/service/ProcessPhotoService.java
@@ -3,6 +3,7 @@ package org.sopt.snappinserver.domain.photo.service;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
 import org.sopt.snappinserver.domain.mood.policy.MoodSelector;
 import org.sopt.snappinserver.domain.mood.repository.MoodRepository;
@@ -22,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class ProcessPhotoService implements ProcessPhotoUseCase {
 
     private static final int LAST_RANK = 3;
@@ -35,18 +37,23 @@ public class ProcessPhotoService implements ProcessPhotoUseCase {
     @Override
     public void linkPhotoWithMoodTags(PhotoProcessCommand photoProcessCommand) {
         validateImageUrlUnique(photoProcessCommand);
-        Photo photo = photoRepository.save(
-            Photo.create(photoProcessCommand.imageUrl(), photoProcessCommand.embedding())
-        );
+        log.info("성공1");
+        Photo photo = photoRepository.save(Photo.create(photoProcessCommand.imageUrl()));
+        log.info("성공2");
 
         List<MoodWithScore> candidates = moodVectorRepository.findTopCandidates(
             toVectorLiteral(photoProcessCommand.embedding())
         );
+        log.info("성공3");
         List<MoodWithScore> selectedScores = moodSelector.selectTop3(LAST_RANK, candidates);
+        log.info("성공4");
         List<Mood> selectedMood = getSelectedMood(selectedScores);
+        log.info("성공5");
         List<PhotoMood> linkedPhotoMoods = photo.linkMoods(selectedMood, selectedScores);
+        log.info("성공6");
 
         photoMoodRepository.saveAll(linkedPhotoMoods);
+        log.info("성공7");
     }
 
     private String toVectorLiteral(List<Float> embedding) {

--- a/src/main/resources/db/migration/V260110__drop_embedding_in_photo.sql
+++ b/src/main/resources/db/migration/V260110__drop_embedding_in_photo.sql
@@ -1,0 +1,2 @@
+ALTER TABLE photo
+    DROP COLUMN embedding;


### PR DESCRIPTION
## 👀 Summary

- close #53


## 🖇️ Tasks

- 로컬에서 임의로 벡터 보내서 확인해보았는데, jpa가 사진 테이블에 Pgvector를 맵핑을 못해서 삭제했습니다! 무드 태그 임베딩값은 DB에서 잘 꺼내오기 때문에 내비두었고, 사진의 경우 무드 태그와 다르게 태그와 한 번 연결된 이후에는 임베딩 값이 전혀 쓰이지 않아서 삭제했어요

## 🔍 To Reviewer

-