### PR TITLE
[FEAT] #42: 시간대별 예약 가능 여부 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/category/controller/CategoryApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/category/controller/CategoryApi.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sopt.snappinserver.api.category.dto.response.CategoriesResponse;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
-import org.springframework.web.bind.annotation.GetMapping;
 
 @Tag(name = "02 - Category", description = "촬영 상황 관련 API")
 public interface CategoryApi {
@@ -13,6 +12,5 @@ public interface CategoryApi {
             summary = "촬영 상황 조회",
             description = "촬영 상황 옵션으로 사용될 스냅 유형 전체 목록을 조회합니다."
     )
-    @GetMapping
     ApiResponseBody<CategoriesResponse, Void> getCategories();
 }

--- a/src/main/java/org/sopt/snappinserver/api/category/controller/CategoryController.java
+++ b/src/main/java/org/sopt/snappinserver/api/category/controller/CategoryController.java
@@ -8,6 +8,7 @@ import org.sopt.snappinserver.api.category.dto.response.CategoriesResponse;
 import org.sopt.snappinserver.api.category.dto.response.CategoryResponse;
 import org.sopt.snappinserver.global.enums.SnapCategory;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CategoryController implements CategoryApi {
 
     @Override
+    @GetMapping
     public ApiResponseBody<CategoriesResponse, Void> getCategories() {
         List<CategoryResponse> categories =
                 Arrays.stream(SnapCategory.values())

--- a/src/main/java/org/sopt/snappinserver/api/product/code/ProductSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/code/ProductSuccessCode.java
@@ -10,7 +10,8 @@ public enum ProductSuccessCode implements SuccessCode {
 
     GET_PRODUCT_REVIEWS_OK(200, "PRODUCT_200_001", "상품 리뷰 목록 조회에 성공했습니다."),
     GET_PRODUCT_PEOPLE_RANGE_OK(200, "PRODUCT_200_002", "상품의 촬영 가능 인원 수 조회에 성공했습니다."),
-    GET_PRODUCT_AVAILABLE_DATE_OK(200, "PRODUCT_200_003", "상품의 날짜별 예약 가능 여부 조회에 성공했습니다.");
+    GET_PRODUCT_AVAILABLE_DATE_OK(200, "PRODUCT_200_003", "상품의 날짜별 예약 가능 여부 조회에 성공했습니다."),
+    GET_PRODUCT_AVAILABLE_TIMES_OK(200, "PRODUCT_200_004", "상품의 시간대별 예약 가능 여부 조회에 성공했습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -1,7 +1,6 @@
 package org.sopt.snappinserver.api.product.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sopt.snappinserver.api.product.dto.response.ProductAvailableTimesResponse;
@@ -11,10 +10,6 @@ import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaRespons
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "06 - Product", description = "상품 관련 API")
 public interface ProductApi {
@@ -23,13 +18,10 @@ public interface ProductApi {
         summary = "상품 리뷰 목록 조회",
         description = "커서 기반 페이지네이션 방식으로 상품 리뷰 목록을 조회합니다."
     )
-    @GetMapping("/{productId}/reviews")
     ApiResponseBody<ProductReviewsResponse, ProductReviewsMetaResponse> getProductReviews(
-        @PathVariable
         @Schema(description = "상품 아이디", example = "1")
         Long productId,
 
-        @RequestParam(required = false)
         @Schema(description = "다음 페이지 조회를 위한 커서 값", example = "6")
         Long cursor
     );
@@ -38,12 +30,9 @@ public interface ProductApi {
         summary = "촬영 가능 인원 수 조회",
         description = "예약 과정에서 상품의 촬영 가능 최대/최소 인원 수를 조회합니다."
     )
-    @GetMapping("/{productId}/available/people-range")
     ApiResponseBody<ProductPeopleRangeResponse, Void> getProductPeopleRange(
-        @Parameter(hidden = true)
-        @AuthenticationPrincipal CustomUserInfo principal,
+        CustomUserInfo principal,
 
-        @PathVariable
         @Schema(description = "상품 아이디", example = "1")
         Long productId
     );
@@ -52,16 +41,12 @@ public interface ProductApi {
         summary = "날짜별 예약 가능 여부 조회",
         description = "상품 예약 과정에서 달별 휴무일을 조회합니다."
     )
-    @GetMapping("/{productId}/closed-dates")
     ApiResponseBody<ProductClosedDatesResponse, Void> getProductClosedDates(
-        @Parameter(hidden = true)
-        @AuthenticationPrincipal CustomUserInfo principal,
+        CustomUserInfo principal,
 
-        @PathVariable
         @Schema(description = "상품 아이디", example = "1")
         Long productId,
 
-        @RequestParam
         @Schema(description = "조회할 연/월 (yyyy-MM)", example = "2026-03", required = true)
         String date
     );
@@ -70,16 +55,12 @@ public interface ProductApi {
         summary = "시간대별 예약 가능 여부 조회",
         description = "상품 예약 과정에서 각 일자의 시간대별 예약 가능 여부를 조회합니다."
     )
-    @GetMapping("/{productId}/available/times")
     ApiResponseBody<ProductAvailableTimesResponse, Void> getProductAvailableTimes(
-        @Parameter(hidden = true)
-        @AuthenticationPrincipal CustomUserInfo principal,
+        CustomUserInfo principal,
 
-        @PathVariable
         @Schema(description = "상품 아이디", example = "1")
         Long productId,
 
-        @RequestParam
         @Schema(description = "조회할 날짜 (yyyy-MM-dd)", example = "2026-03-15", required = true)
         String date
     );

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -3,6 +3,7 @@ package org.sopt.snappinserver.api.product.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
 import org.sopt.snappinserver.api.product.dto.response.ProductAvailableTimesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductClosedDatesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductPeopleRangeResponse;
@@ -62,7 +63,7 @@ public interface ProductApi {
         Long productId,
 
         @Schema(description = "조회할 날짜 (yyyy-MM-dd)", example = "2026-03-15", required = true)
-        String date
+        LocalDate date
     );
 
 

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -1,6 +1,7 @@
 package org.sopt.snappinserver.api.product.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
@@ -11,6 +12,7 @@ import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaRespons
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 @Tag(name = "06 - Product", description = "상품 관련 API")
 public interface ProductApi {
@@ -32,7 +34,8 @@ public interface ProductApi {
         description = "예약 과정에서 상품의 촬영 가능 최대/최소 인원 수를 조회합니다."
     )
     ApiResponseBody<ProductPeopleRangeResponse, Void> getProductPeopleRange(
-        CustomUserInfo principal,
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal CustomUserInfo principal,
 
         @Schema(description = "상품 아이디", example = "1")
         Long productId
@@ -43,7 +46,8 @@ public interface ProductApi {
         description = "상품 예약 과정에서 달별 휴무일을 조회합니다."
     )
     ApiResponseBody<ProductClosedDatesResponse, Void> getProductClosedDates(
-        CustomUserInfo principal,
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal CustomUserInfo principal,
 
         @Schema(description = "상품 아이디", example = "1")
         Long productId,
@@ -57,7 +61,8 @@ public interface ProductApi {
         description = "상품 예약 과정에서 각 일자의 시간대별 예약 가능 여부를 조회합니다."
     )
     ApiResponseBody<ProductAvailableTimesResponse, Void> getProductAvailableTimes(
-        CustomUserInfo principal,
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal CustomUserInfo principal,
 
         @Schema(description = "상품 아이디", example = "1")
         Long productId,

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.snappinserver.api.product.dto.response.ProductAvailableTimesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductClosedDatesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductPeopleRangeResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaResponse;
@@ -64,5 +65,24 @@ public interface ProductApi {
         @Schema(description = "조회할 연/월 (yyyy-MM)", example = "2026-03", required = true)
         String date
     );
+
+    @Operation(
+        summary = "시간대별 예약 가능 여부 조회",
+        description = "상품 예약 과정에서 각 일자의 시간대별 예약 가능 여부를 조회합니다."
+    )
+    @GetMapping("/{productId}/available/times")
+    ApiResponseBody<ProductAvailableTimesResponse, Void> getProductAvailableTimes(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal CustomUserInfo principal,
+
+        @PathVariable
+        @Schema(description = "상품 아이디", example = "1")
+        Long productId,
+
+        @RequestParam
+        @Schema(description = "조회할 날짜 (yyyy-MM-dd)", example = "2026-03-15", required = true)
+        String date
+    );
+
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import org.sopt.snappinserver.api.product.dto.response.ProductAvailableTimesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductClosedDatesResponse;
@@ -23,7 +25,7 @@ public interface ProductApi {
     )
     ApiResponseBody<ProductReviewsResponse, ProductReviewsMetaResponse> getProductReviews(
         @Schema(description = "상품 아이디", example = "1")
-        Long productId,
+        @NotNull Long productId,
 
         @Schema(description = "다음 페이지 조회를 위한 커서 값", example = "6")
         Long cursor
@@ -38,7 +40,7 @@ public interface ProductApi {
         @AuthenticationPrincipal CustomUserInfo principal,
 
         @Schema(description = "상품 아이디", example = "1")
-        Long productId
+        @NotNull Long productId
     );
 
     @Operation(
@@ -50,10 +52,10 @@ public interface ProductApi {
         @AuthenticationPrincipal CustomUserInfo principal,
 
         @Schema(description = "상품 아이디", example = "1")
-        Long productId,
+        @NotNull Long productId,
 
         @Schema(description = "조회할 연/월 (yyyy-MM)", example = "2026-03", required = true)
-        String date
+        @NotBlank String date
     );
 
     @Operation(
@@ -65,10 +67,10 @@ public interface ProductApi {
         @AuthenticationPrincipal CustomUserInfo principal,
 
         @Schema(description = "상품 아이디", example = "1")
-        Long productId,
+        @NotNull Long productId,
 
         @Schema(description = "조회할 날짜 (yyyy-MM-dd)", example = "2026-03-15", required = true)
-        LocalDate date
+        @NotNull LocalDate date
     );
 
 

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -14,7 +14,11 @@ import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaRespons
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "06 - Product", description = "상품 관련 API")
 public interface ProductApi {
@@ -23,53 +27,58 @@ public interface ProductApi {
         summary = "상품 리뷰 목록 조회",
         description = "커서 기반 페이지네이션 방식으로 상품 리뷰 목록을 조회합니다."
     )
+    @GetMapping("/{productId}/reviews")
     ApiResponseBody<ProductReviewsResponse, ProductReviewsMetaResponse> getProductReviews(
         @Schema(description = "상품 아이디", example = "1")
-        @NotNull Long productId,
+        @PathVariable @NotNull Long productId,
 
         @Schema(description = "다음 페이지 조회를 위한 커서 값", example = "6")
-        Long cursor
+        @RequestParam(value = "cursor", required = false) Long cursor
     );
 
     @Operation(
         summary = "촬영 가능 인원 수 조회",
         description = "예약 과정에서 상품의 촬영 가능 최대/최소 인원 수를 조회합니다."
     )
+    @GetMapping("/{productId}/available/people-range")
     ApiResponseBody<ProductPeopleRangeResponse, Void> getProductPeopleRange(
         @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
 
         @Schema(description = "상품 아이디", example = "1")
-        @NotNull Long productId
+        @PathVariable @NotNull Long productId
     );
 
     @Operation(
         summary = "날짜별 예약 가능 여부 조회",
         description = "상품 예약 과정에서 달별 휴무일을 조회합니다."
     )
+    @GetMapping("/{productId}/closed-dates")
     ApiResponseBody<ProductClosedDatesResponse, Void> getProductClosedDates(
         @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
 
         @Schema(description = "상품 아이디", example = "1")
-        @NotNull Long productId,
+        @PathVariable @NotNull Long productId,
 
         @Schema(description = "조회할 연/월 (yyyy-MM)", example = "2026-03", required = true)
-        @NotBlank String date
+        @RequestParam(value = "date") @NotBlank String date
     );
 
     @Operation(
         summary = "시간대별 예약 가능 여부 조회",
         description = "상품 예약 과정에서 각 일자의 시간대별 예약 가능 여부를 조회합니다."
     )
+    @GetMapping("/{productId}/available/times")
     ApiResponseBody<ProductAvailableTimesResponse, Void> getProductAvailableTimes(
         @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
 
         @Schema(description = "상품 아이디", example = "1")
-        @NotNull Long productId,
+        @PathVariable @NotNull Long productId,
 
         @Schema(description = "조회할 날짜 (yyyy-MM-dd)", example = "2026-03-15", required = true)
+        @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         @NotNull LocalDate date
     );
 

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -1,15 +1,19 @@
 package org.sopt.snappinserver.api.product.controller;
 
+import java.time.LocalDate;
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.product.code.ProductSuccessCode;
+import org.sopt.snappinserver.api.product.dto.response.ProductAvailableTimesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductClosedDatesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductPeopleRangeResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductAvailableTimesResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductClosedDatesResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductPeopleRangeResult;
+import org.sopt.snappinserver.domain.product.service.usecase.GetProductAvailableTimesUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductClosedDatesUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductPeopleRangeUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
@@ -27,6 +31,7 @@ public class ProductController implements ProductApi {
     private final GetProductReviewsUseCase getProductReviewsUseCase;
     private final GetProductPeopleRangeUseCase getProductPeopleRangeUseCase;
     private final GetProductClosedDatesUseCase getProductClosedDatesUseCase;
+    private final GetProductAvailableTimesUseCase getProductAvailableTimesUseCase;
 
     @Override
     public ApiResponseBody<ProductReviewsResponse, ProductReviewsMetaResponse> getProductReviews(Long productId, Long cursor) {
@@ -62,5 +67,24 @@ public class ProductController implements ProductApi {
         return ApiResponseBody.ok(ProductSuccessCode.GET_PRODUCT_AVAILABLE_DATE_OK, response);
     }
 
+    @Override
+    public ApiResponseBody<ProductAvailableTimesResponse, Void> getProductAvailableTimes(
+        @AuthenticationPrincipal CustomUserInfo principal,
+        Long productId,
+        String date
+    ) {
+        LocalDate targetDate = LocalDate.parse(date);
+
+        ProductAvailableTimesResult result =
+            getProductAvailableTimesUseCase.getProductAvailableTimes(productId, targetDate);
+
+        ProductAvailableTimesResponse response =
+            ProductAvailableTimesResponse.from(result);
+
+        return ApiResponseBody.ok(
+            ProductSuccessCode.GET_PRODUCT_AVAILABLE_TIMES_OK,
+            response
+        );
+    }
 }
 

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -63,7 +63,6 @@ public class ProductController implements ProductApi {
     public ApiResponseBody<ProductPeopleRangeResponse, Void> getProductPeopleRange(
         @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
-
         @NotNull @PathVariable Long productId
     ) {
         ProductPeopleRangeResult result =
@@ -80,7 +79,6 @@ public class ProductController implements ProductApi {
     public ApiResponseBody<ProductClosedDatesResponse, Void> getProductClosedDates(
         @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
-
         @NotNull @PathVariable Long productId,
         @NotBlank @RequestParam(value = "date") String date
     ) {
@@ -100,9 +98,7 @@ public class ProductController implements ProductApi {
     public ApiResponseBody<ProductAvailableTimesResponse, Void> getProductAvailableTimes(
         @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
-
         @NotNull @PathVariable Long productId,
-
         @NotNull @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         LocalDate date
     ) {

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -46,7 +46,7 @@ public class ProductController implements ProductApi {
     @GetMapping("/{productId}/reviews")
     public ApiResponseBody<ProductReviewsResponse, ProductReviewsMetaResponse> getProductReviews(
         @NotNull @PathVariable Long productId,
-        @RequestParam(required = false) Long cursor
+        @RequestParam(value = "cursor", required = false) Long cursor
     ) {
         ProductReviewPageResult result =
             getProductReviewsUseCase.getProductReviews(productId, cursor);
@@ -61,6 +61,7 @@ public class ProductController implements ProductApi {
     @Override
     @GetMapping("/{productId}/available/people-range")
     public ApiResponseBody<ProductPeopleRangeResponse, Void> getProductPeopleRange(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
 
         @NotNull @PathVariable Long productId
@@ -77,10 +78,11 @@ public class ProductController implements ProductApi {
     @Override
     @GetMapping("/{productId}/closed-dates")
     public ApiResponseBody<ProductClosedDatesResponse, Void> getProductClosedDates(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
 
         @NotNull @PathVariable Long productId,
-        @NotBlank @RequestParam String date
+        @NotBlank @RequestParam(value = "date") String date
     ) {
         YearMonth yearMonth = YearMonth.parse(date);
 
@@ -96,11 +98,12 @@ public class ProductController implements ProductApi {
     @Override
     @GetMapping("/{productId}/available/times")
     public ApiResponseBody<ProductAvailableTimesResponse, Void> getProductAvailableTimes(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
 
         @NotNull @PathVariable Long productId,
 
-        @NotNull @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        @NotNull @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         LocalDate date
     ) {
         ProductAvailableTimesResult result =

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -22,6 +22,7 @@ import org.sopt.snappinserver.domain.product.service.usecase.GetProductClosedDat
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductPeopleRangeUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -100,15 +101,19 @@ public class ProductController implements ProductApi {
         @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
 
-        @PathVariable @NotNull Long productId,
-        @RequestParam @NotBlank String date
-    ) {
-        LocalDate targetDate = LocalDate.parse(date);
+        @PathVariable
+        @NotNull
+        Long productId,
 
+        @RequestParam
+        @NotBlank
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        LocalDate date
+    ) {
         ProductAvailableTimesResult result =
             getProductAvailableTimesUseCase.getProductAvailableTimes(
                 productId,
-                targetDate
+                date
             );
 
         return ApiResponseBody.ok(

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -1,5 +1,7 @@
 package org.sopt.snappinserver.api.product.controller;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
@@ -70,7 +72,11 @@ public class ProductController implements ProductApi {
     @Override
     public ApiResponseBody<ProductAvailableTimesResponse, Void> getProductAvailableTimes(
         @AuthenticationPrincipal CustomUserInfo principal,
+
+        @NotNull
         Long productId,
+
+        @NotBlank
         String date
     ) {
         LocalDate targetDate = LocalDate.parse(date);

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -1,8 +1,5 @@
 package org.sopt.snappinserver.api.product.controller;
 
-import io.swagger.v3.oas.annotations.Parameter;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
@@ -22,13 +19,8 @@ import org.sopt.snappinserver.domain.product.service.usecase.GetProductClosedDat
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductPeopleRangeUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/products")

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -106,7 +106,7 @@ public class ProductController implements ProductApi {
         Long productId,
 
         @RequestParam
-        @NotBlank
+        @NotNull
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         LocalDate date
     ) {

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -45,7 +45,7 @@ public class ProductController implements ProductApi {
     @Override
     @GetMapping("/{productId}/reviews")
     public ApiResponseBody<ProductReviewsResponse, ProductReviewsMetaResponse> getProductReviews(
-        @NotNull @PathVariable Long productId,
+        @PathVariable Long productId,
         @RequestParam(value = "cursor", required = false) Long cursor
     ) {
         ProductReviewPageResult result =
@@ -61,9 +61,8 @@ public class ProductController implements ProductApi {
     @Override
     @GetMapping("/{productId}/available/people-range")
     public ApiResponseBody<ProductPeopleRangeResponse, Void> getProductPeopleRange(
-        @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
-        @NotNull @PathVariable Long productId
+        @PathVariable Long productId
     ) {
         ProductPeopleRangeResult result =
             getProductPeopleRangeUseCase.getProductPeopleRange(productId);
@@ -77,10 +76,9 @@ public class ProductController implements ProductApi {
     @Override
     @GetMapping("/{productId}/closed-dates")
     public ApiResponseBody<ProductClosedDatesResponse, Void> getProductClosedDates(
-        @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
-        @NotNull @PathVariable Long productId,
-        @NotBlank @RequestParam(value = "date") String date
+        @PathVariable Long productId,
+        @RequestParam(value = "date") String date
     ) {
         YearMonth yearMonth = YearMonth.parse(date);
 
@@ -96,10 +94,9 @@ public class ProductController implements ProductApi {
     @Override
     @GetMapping("/{productId}/available/times")
     public ApiResponseBody<ProductAvailableTimesResponse, Void> getProductAvailableTimes(
-        @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
-        @NotNull @PathVariable Long productId,
-        @NotNull @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        @PathVariable Long productId,
+        @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         LocalDate date
     ) {
         ProductAvailableTimesResult result =

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -43,10 +43,9 @@ public class ProductController implements ProductApi {
     private final GetProductAvailableTimesUseCase getProductAvailableTimesUseCase;
 
     @Override
-    @GetMapping("/{productId}/reviews")
     public ApiResponseBody<ProductReviewsResponse, ProductReviewsMetaResponse> getProductReviews(
-        @PathVariable Long productId,
-        @RequestParam(value = "cursor", required = false) Long cursor
+        Long productId,
+        Long cursor
     ) {
         ProductReviewPageResult result =
             getProductReviewsUseCase.getProductReviews(productId, cursor);
@@ -59,10 +58,9 @@ public class ProductController implements ProductApi {
     }
 
     @Override
-    @GetMapping("/{productId}/available/people-range")
     public ApiResponseBody<ProductPeopleRangeResponse, Void> getProductPeopleRange(
-        @AuthenticationPrincipal CustomUserInfo principal,
-        @PathVariable Long productId
+        CustomUserInfo principal,
+        Long productId
     ) {
         ProductPeopleRangeResult result =
             getProductPeopleRangeUseCase.getProductPeopleRange(productId);
@@ -74,11 +72,10 @@ public class ProductController implements ProductApi {
     }
 
     @Override
-    @GetMapping("/{productId}/closed-dates")
     public ApiResponseBody<ProductClosedDatesResponse, Void> getProductClosedDates(
-        @AuthenticationPrincipal CustomUserInfo principal,
-        @PathVariable Long productId,
-        @RequestParam(value = "date") String date
+        CustomUserInfo principal,
+        Long productId,
+        String date
     ) {
         YearMonth yearMonth = YearMonth.parse(date);
 
@@ -92,11 +89,9 @@ public class ProductController implements ProductApi {
     }
 
     @Override
-    @GetMapping("/{productId}/available/times")
     public ApiResponseBody<ProductAvailableTimesResponse, Void> getProductAvailableTimes(
-        @AuthenticationPrincipal CustomUserInfo principal,
-        @PathVariable Long productId,
-        @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        CustomUserInfo principal,
+        Long productId,
         LocalDate date
     ) {
         ProductAvailableTimesResult result =

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -45,7 +45,7 @@ public class ProductController implements ProductApi {
     @Override
     @GetMapping("/{productId}/reviews")
     public ApiResponseBody<ProductReviewsResponse, ProductReviewsMetaResponse> getProductReviews(
-        @PathVariable @NotNull Long productId,
+        @NotNull @PathVariable Long productId,
         @RequestParam(required = false) Long cursor
     ) {
         ProductReviewPageResult result =
@@ -61,10 +61,9 @@ public class ProductController implements ProductApi {
     @Override
     @GetMapping("/{productId}/available/people-range")
     public ApiResponseBody<ProductPeopleRangeResponse, Void> getProductPeopleRange(
-        @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
 
-        @PathVariable @NotNull Long productId
+        @NotNull @PathVariable Long productId
     ) {
         ProductPeopleRangeResult result =
             getProductPeopleRangeUseCase.getProductPeopleRange(productId);
@@ -78,11 +77,10 @@ public class ProductController implements ProductApi {
     @Override
     @GetMapping("/{productId}/closed-dates")
     public ApiResponseBody<ProductClosedDatesResponse, Void> getProductClosedDates(
-        @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
 
-        @PathVariable @NotNull Long productId,
-        @RequestParam @NotBlank String date
+        @NotNull @PathVariable Long productId,
+        @NotBlank @RequestParam String date
     ) {
         YearMonth yearMonth = YearMonth.parse(date);
 
@@ -98,16 +96,11 @@ public class ProductController implements ProductApi {
     @Override
     @GetMapping("/{productId}/available/times")
     public ApiResponseBody<ProductAvailableTimesResponse, Void> getProductAvailableTimes(
-        @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo principal,
 
-        @PathVariable
-        @NotNull
-        Long productId,
+        @NotNull @PathVariable Long productId,
 
-        @RequestParam
-        @NotNull
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        @NotNull @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         LocalDate date
     ) {
         ProductAvailableTimesResult result =

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductAvailableTimeResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductAvailableTimeResponse.java
@@ -1,0 +1,23 @@
+package org.sopt.snappinserver.api.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductAvailableTimeResult;
+
+@Schema(description = "상품 예약 가능 단일 시간대 응답 DTO")
+public record ProductAvailableTimeResponse(
+    @Schema(description = "타임슬롯 시작 시간", example = "\"09:00\"")
+    String time,
+
+    @Schema(description = "예약 가능 여부", example = "true")
+    boolean isAvailable
+) {
+
+    public static ProductAvailableTimeResponse from(
+        ProductAvailableTimeResult result
+    ) {
+        return new ProductAvailableTimeResponse(
+            result.time().toString(),
+            result.isAvailable()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductAvailableTimesResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductAvailableTimesResponse.java
@@ -1,0 +1,27 @@
+package org.sopt.snappinserver.api.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductAvailableTimesResult;
+
+@Schema(description = "상품 예약 가능 시간대 목록 응답 DTO")
+public record ProductAvailableTimesResponse(
+
+    @Schema(description = "조회 기준 날짜", example = "2026-03-15")
+    String date,
+
+    @Schema(description = "시간대별 예약 가능 여부 목록")
+    List<ProductAvailableTimeResponse> times
+) {
+
+    public static ProductAvailableTimesResponse from(
+        ProductAvailableTimesResult result
+    ) {
+        return new ProductAvailableTimesResponse(
+            result.date().toString(),
+            result.times().stream()
+                .map(ProductAvailableTimeResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/domain/exception/PhotographerErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/domain/exception/PhotographerErrorCode.java
@@ -28,7 +28,7 @@ public enum PhotographerErrorCode implements ErrorCode {
     // 403 FORBIDDEN
 
     // 404 NOT FOUND
-    SCHEDULE_NOT_FOUND(404, "PHOTOGRAPHER_404_002", "해당 요일에 대한 작가 스케줄이 존재하지 않습니다."),
+    SCHEDULE_NOT_FOUND(404, "PHOTOGRAPHER_404_001", "해당 요일에 대한 작가 스케줄이 존재하지 않습니다."),
 
     ;
 

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/domain/exception/PhotographerErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/domain/exception/PhotographerErrorCode.java
@@ -20,14 +20,15 @@ public enum PhotographerErrorCode implements ErrorCode {
     WEEK_DAY_REQUIRED(400, "PHOTOGRAPHER_400_009", "요일은 필수입니다."),
     START_TIME_REQUIRED(400, "PHOTOGRAPHER_400_010", "시작 시각은 필수입니다."),
     END_TIME_REQUIRED(400, "PHOTOGRAPHER_400_011", "종료 시각은 필수입니다."),
-    START_TIME_AFTER_THAN_END_TIME(400, "PHOTOGRAPHER_400_012", "스케쥴 시작 시간이 종료 시간보다 앞서야 합니다."),
+    START_TIME_AFTER_THAN_END_TIME(400, "PHOTOGRAPHER_400_012", "스케줄 시작 시간이 종료 시간보다 앞서야 합니다."),
     BIO_TOO_LONG(400, "PHOTOGRAPHER_400_013", "한 줄 소개 길이는 200자 이하입니다."),
 
     // 401 UNAUTHORIZED
 
-    // 403 FORBIDDENa
+    // 403 FORBIDDEN
 
     // 404 NOT FOUND
+    SCHEDULE_NOT_FOUND(404, "PHOTOGRAPHER_404_002", "해당 요일에 대한 작가 스케줄이 존재하지 않습니다."),
 
     ;
 

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/domain/exception/PhotographerErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/domain/exception/PhotographerErrorCode.java
@@ -20,7 +20,7 @@ public enum PhotographerErrorCode implements ErrorCode {
     WEEK_DAY_REQUIRED(400, "PHOTOGRAPHER_400_009", "요일은 필수입니다."),
     START_TIME_REQUIRED(400, "PHOTOGRAPHER_400_010", "시작 시각은 필수입니다."),
     END_TIME_REQUIRED(400, "PHOTOGRAPHER_400_011", "종료 시각은 필수입니다."),
-    START_TIME_AFTER_THAN_END_TIME(400, "PHOTOGRAPHER_400_012", "스케줄 시작 시간이 종료 시간보다 앞서야 합니다."),
+    START_TIME_AFTER_THAN_END_TIME(400, "PHOTOGRAPHER_400_012", "스케줄 시작 시간이 종료 시간보다 늦을 수 없습니다."),
     BIO_TOO_LONG(400, "PHOTOGRAPHER_400_013", "한 줄 소개 길이는 200자 이하입니다."),
 
     // 401 UNAUTHORIZED

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/repository/PhotographerScheduleRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/repository/PhotographerScheduleRepository.java
@@ -1,13 +1,20 @@
 package org.sopt.snappinserver.domain.photographer.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
 import org.sopt.snappinserver.domain.photographer.domain.entity.PhotographerSchedule;
+import org.sopt.snappinserver.global.enums.WeekDay;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PhotographerScheduleRepository extends JpaRepository<PhotographerSchedule, Long> {
 
     List<PhotographerSchedule> findAllByPhotographerAndDayOffTrue(
         Photographer photographer
+    );
+
+    Optional<PhotographerSchedule> findByPhotographerAndWeekDay(
+        Photographer photographer,
+        WeekDay weekDay
     );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/domain/exception/ProductErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/domain/exception/ProductErrorCode.java
@@ -29,6 +29,7 @@ public enum ProductErrorCode implements ErrorCode {
     ANSWER_TOO_LONG(400, "PRODUCT_400_018", ""),
     INVALID_CURSOR(400, "PRODUCT_400_019", "유효하지 않은 커서 값입니다."),
     DURATION_TIME_REQUIRED(400, "PRODUCT_400_020", "촬영 시간 옵션은 필수입니다."),
+    PRODUCT_UNAVAILABLE_DATE(400, "PRODUCT_400_021", "예약이 불가능한 날짜입니다."),
     // 401 UNAUTHORIZED
 
     // 403 FORBIDDEN

--- a/src/main/java/org/sopt/snappinserver/domain/product/domain/exception/ProductErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/domain/exception/ProductErrorCode.java
@@ -28,6 +28,7 @@ public enum ProductErrorCode implements ErrorCode {
     ANSWER_REQUIRED(400, "PRODUCT_400_017", ""),
     ANSWER_TOO_LONG(400, "PRODUCT_400_018", ""),
     INVALID_CURSOR(400, "PRODUCT_400_019", "유효하지 않은 커서 값입니다."),
+    DURATION_TIME_REQUIRED(400, "PRODUCT_400_020", "촬영 시간 옵션은 필수입니다."),
     // 401 UNAUTHORIZED
 
     // 403 FORBIDDEN

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductOptionRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductOptionRepository.java
@@ -1,6 +1,8 @@
 package org.sopt.snappinserver.domain.product.repository;
 
 import java.util.List;
+import java.util.Optional;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.sopt.snappinserver.domain.product.domain.entity.ProductOption;
 import org.sopt.snappinserver.domain.product.domain.enums.ProductOptionCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,5 +12,10 @@ public interface ProductOptionRepository extends JpaRepository<ProductOption, Lo
     List<ProductOption> findByProductIdAndProductOptionCategoryIn(
         Long productId,
         List<ProductOptionCategory> categories
+    );
+
+    Optional<ProductOption> findByProductAndProductOptionCategory(
+        Product product,
+        ProductOptionCategory productOptionCategory
     );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
@@ -26,9 +26,11 @@ import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
 import org.sopt.snappinserver.domain.reservation.repository.ReservationRepository;
 import org.sopt.snappinserver.global.enums.WeekDay;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class GetProductAvailableTimesService implements GetProductAvailableTimesUseCase {
 
     private static final int ONE_DAY = 1;

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
@@ -1,7 +1,5 @@
 package org.sopt.snappinserver.domain.product.service;
 
-import static org.sopt.snappinserver.domain.product.domain.exception.ProductErrorCode.PRODUCT_NOT_FOUND;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -51,7 +49,7 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
 
         // 휴무일인 경우 예약 불가
         if (schedule.isDayOff()) {
-            return new ProductAvailableTimesResult(date, List.of());
+            throw new ProductException(ProductErrorCode.PRODUCT_UNAVAILABLE_DATE);
         }
 
         int durationMinutes = getDurationMinutes(product);
@@ -79,7 +77,7 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
     // 상품 조회
     private Product getProduct(Long productId) {
         return productRepository.findById(productId)
-            .orElseThrow(() -> new ProductException(PRODUCT_NOT_FOUND));
+            .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
     }
 
     // 작가의 요일별 스케줄 조회

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
@@ -98,6 +98,17 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
         return Integer.parseInt(durationOption.getAnswer());
     }
 
+    // 업무 시간 기준 30분 단위의 시작 시간 슬롯 생성
+    private List<LocalTime> createTimeSlots(LocalTime workStart, LocalTime lastStartTime) {
+        List<LocalTime> slots = new ArrayList<>();
+
+        for (LocalTime time = workStart; !time.isAfter(lastStartTime);
+            time = time.plusMinutes(TIME_SLOT_INTERVAL_MINUTES)) {
+            slots.add(time);
+        }
+        return slots;
+    }
+
     // 시간 슬롯별 예약 가능 여부 계산
     private List<Reservation> getConfirmedReservations(LocalDate date, Product product) {
         LocalDateTime startOfDay = date.atStartOfDay();
@@ -125,26 +136,6 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
             .toList();
     }
 
-    // 업무 시간 기준 30분 단위의 시작 시간 슬롯 생성
-    private List<LocalTime> createTimeSlots(LocalTime workStart, LocalTime lastStartTime) {
-        List<LocalTime> slots = new ArrayList<>();
-
-        for (LocalTime time = workStart; !time.isAfter(lastStartTime);
-            time = time.plusMinutes(TIME_SLOT_INTERVAL_MINUTES)) {
-            slots.add(time);
-        }
-        return slots;
-    }
-
-    // 시간 슬롯과 예약 시간대가 겹치는지 판단
-    private boolean isOverlapping(LocalTime slot, Reservation reservation, int durationMinutes) {
-        LocalTime reservedStart = reservation.getReservedAt().toLocalTime();
-        LocalTime reservedEnd = reservedStart.plusMinutes(reservation.getDurationTime());
-
-        return slot.isBefore(reservedEnd) && slot.plusMinutes(durationMinutes)
-            .isAfter(reservedStart);
-    }
-
     // 특정 시작 시간 슬롯이 예약 가능한지 판단
     private boolean isAvailableTimeSlot(
         LocalTime slot,
@@ -154,5 +145,14 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
         return reservations.stream().noneMatch(
             reservation -> isOverlapping(slot, reservation, durationMinutes)
         );
+    }
+
+    // 시간 슬롯과 예약 시간대가 겹치는지 판단
+    private boolean isOverlapping(LocalTime slot, Reservation reservation, int durationMinutes) {
+        LocalTime reservedStart = reservation.getReservedAt().toLocalTime();
+        LocalTime reservedEnd = reservedStart.plusMinutes(reservation.getDurationTime());
+
+        return slot.isBefore(reservedEnd) && slot.plusMinutes(durationMinutes)
+            .isAfter(reservedStart);
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
@@ -93,7 +93,15 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
             .findByProductAndProductOptionCategory(product, ProductOptionCategory.DURATION_TIME)
             .orElseThrow(() -> new ProductException(ProductErrorCode.DURATION_TIME_REQUIRED));
 
-        return Integer.parseInt(durationOption.getAnswer());
+        try {
+            int duration = Integer.parseInt(durationOption.getAnswer());
+            if (duration <= 0) {
+                throw new ProductException(ProductErrorCode.INVALID_PRODUCT_OPTION_FORMAT);
+            }
+            return duration;
+        } catch (NumberFormatException e) {
+            throw new ProductException(ProductErrorCode.INVALID_PRODUCT_OPTION_FORMAT);
+        }
     }
 
     // 업무 시간 기준 30분 단위의 시작 시간 슬롯 생성

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
@@ -1,0 +1,158 @@
+package org.sopt.snappinserver.domain.product.service;
+
+import static org.sopt.snappinserver.domain.product.domain.exception.ProductErrorCode.PRODUCT_NOT_FOUND;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+import org.sopt.snappinserver.domain.photographer.domain.entity.PhotographerSchedule;
+import org.sopt.snappinserver.domain.photographer.domain.exception.PhotographerErrorCode;
+import org.sopt.snappinserver.domain.photographer.domain.exception.PhotographerException;
+import org.sopt.snappinserver.domain.photographer.repository.PhotographerScheduleRepository;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.domain.product.domain.entity.ProductOption;
+import org.sopt.snappinserver.domain.product.domain.enums.ProductOptionCategory;
+import org.sopt.snappinserver.domain.product.domain.exception.ProductErrorCode;
+import org.sopt.snappinserver.domain.product.domain.exception.ProductException;
+import org.sopt.snappinserver.domain.product.repository.ProductOptionRepository;
+import org.sopt.snappinserver.domain.product.repository.ProductRepository;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductAvailableTimeResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductAvailableTimesResult;
+import org.sopt.snappinserver.domain.product.service.usecase.GetProductAvailableTimesUseCase;
+import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
+import org.sopt.snappinserver.domain.reservation.repository.ReservationRepository;
+import org.sopt.snappinserver.global.enums.WeekDay;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetProductAvailableTimesService implements GetProductAvailableTimesUseCase {
+
+    private static final int ONE_DAY = 1;
+    private static final int TIME_SLOT_INTERVAL_MINUTES = 30;
+
+    private final ProductRepository productRepository;
+    private final ProductOptionRepository productOptionRepository;
+    private final PhotographerScheduleRepository photographerScheduleRepository;
+    private final ReservationRepository reservationRepository;
+
+    @Override
+    public ProductAvailableTimesResult getProductAvailableTimes(Long productId, LocalDate date) {
+
+        Product product = getProduct(productId);
+        Photographer photographer = product.getPhotographer();
+        WeekDay weekDay = WeekDay.from(date.getDayOfWeek());
+        PhotographerSchedule schedule = getPhotographerSchedule(photographer, weekDay);
+
+        // 휴무일인 경우 예약 불가
+        if (schedule.isDayOff()) {
+            return new ProductAvailableTimesResult(date, List.of());
+        }
+
+        int durationMinutes = getDurationMinutes(product);
+
+        LocalTime workStart = schedule.getStartTime();
+        LocalTime workEnd = schedule.getEndTime();
+        LocalTime lastStartTime = workEnd.minusMinutes(durationMinutes);
+
+        // 촬영 시간이 너무 길어 시작 가능한 시간이 없는 경우 예약 불가
+        if (lastStartTime.isBefore(workStart)) {
+            return new ProductAvailableTimesResult(date, List.of());
+        }
+
+        List<LocalTime> slots = createTimeSlots(workStart, lastStartTime);
+        List<Reservation> reservations = getConfirmedReservations(date, product);
+        List<ProductAvailableTimeResult> results = getProductAvailableTimeResults(
+            slots,
+            reservations,
+            durationMinutes
+        );
+
+        return new ProductAvailableTimesResult(date, results);
+    }
+
+    // 상품 조회
+    private Product getProduct(Long productId) {
+        return productRepository.findById(productId)
+            .orElseThrow(() -> new ProductException(PRODUCT_NOT_FOUND));
+    }
+
+    // 작가의 요일별 스케줄 조회
+    private PhotographerSchedule getPhotographerSchedule(Photographer photographer,
+        WeekDay weekDay) {
+        return photographerScheduleRepository.findByPhotographerAndWeekDay(photographer, weekDay)
+            .orElseThrow(() -> new PhotographerException(PhotographerErrorCode.SCHEDULE_NOT_FOUND));
+    }
+
+    // 상품 옵션에서 촬영 시간 조회
+    private int getDurationMinutes(Product product) {
+        ProductOption durationOption = productOptionRepository
+            .findByProductAndProductOptionCategory(product, ProductOptionCategory.DURATION_TIME)
+            .orElseThrow(() -> new ProductException(ProductErrorCode.DURATION_TIME_REQUIRED));
+
+        return Integer.parseInt(durationOption.getAnswer());
+    }
+
+    // 시간 슬롯별 예약 가능 여부 계산
+    private List<Reservation> getConfirmedReservations(LocalDate date, Product product) {
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime endOfDay = date.plusDays(ONE_DAY).atStartOfDay();
+
+        return reservationRepository.findAllByProductAndReservedAtBetweenAndReservationStatusIn(
+            product,
+            startOfDay,
+            endOfDay,
+            List.of(ReservationStatus.RESERVATION_CONFIRMED, ReservationStatus.SHOOT_COMPLETED)
+        );
+    }
+
+    // 시간대별 예약 가능 여부 목록 생성
+    private List<ProductAvailableTimeResult> getProductAvailableTimeResults(
+        List<LocalTime> slots,
+        List<Reservation> reservations,
+        int durationMinutes
+    ) {
+        return slots.stream()
+            .map(slot -> new ProductAvailableTimeResult(
+                slot,
+                isAvailableTimeSlot(slot, reservations, durationMinutes)
+            ))
+            .toList();
+    }
+
+    // 업무 시간 기준 30분 단위의 시작 시간 슬롯 생성
+    private List<LocalTime> createTimeSlots(LocalTime workStart, LocalTime lastStartTime) {
+        List<LocalTime> slots = new ArrayList<>();
+
+        for (LocalTime time = workStart; !time.isAfter(lastStartTime);
+            time = time.plusMinutes(TIME_SLOT_INTERVAL_MINUTES)) {
+            slots.add(time);
+        }
+        return slots;
+    }
+
+    // 시간 슬롯과 예약 시간대가 겹치는지 판단
+    private boolean isOverlapping(LocalTime slot, Reservation reservation, int durationMinutes) {
+        LocalTime reservedStart = reservation.getReservedAt().toLocalTime();
+        LocalTime reservedEnd = reservedStart.plusMinutes(reservation.getDurationTime());
+
+        return slot.isBefore(reservedEnd) && slot.plusMinutes(durationMinutes)
+            .isAfter(reservedStart);
+    }
+
+    // 특정 시작 시간 슬롯이 예약 가능한지 판단
+    private boolean isAvailableTimeSlot(
+        LocalTime slot,
+        List<Reservation> reservations,
+        int durationMinutes
+    ) {
+        return reservations.stream().noneMatch(
+            reservation -> isOverlapping(slot, reservation, durationMinutes)
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductAvailableTimeResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductAvailableTimeResult.java
@@ -1,0 +1,7 @@
+package org.sopt.snappinserver.domain.product.service.dto.response;
+
+import java.time.LocalTime;
+
+public record ProductAvailableTimeResult(LocalTime time, boolean isAvailable) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductAvailableTimesResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductAvailableTimesResult.java
@@ -1,0 +1,10 @@
+package org.sopt.snappinserver.domain.product.service.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record ProductAvailableTimesResult(
+    LocalDate date,
+    List<ProductAvailableTimeResult> times
+) {
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductAvailableTimesUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductAvailableTimesUseCase.java
@@ -1,0 +1,9 @@
+package org.sopt.snappinserver.domain.product.service.usecase;
+
+import java.time.LocalDate;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductAvailableTimesResult;
+
+public interface GetProductAvailableTimesUseCase {
+
+    ProductAvailableTimesResult getProductAvailableTimes(Long productId, LocalDate date);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepository.java
@@ -1,10 +1,20 @@
 package org.sopt.snappinserver.domain.reservation.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    List<Reservation> findAllByProductAndReservedAtBetweenAndReservationStatusIn(
+        Product product,
+        LocalDateTime startOfDay,
+        LocalDateTime endOfDay,
+        List<ReservationStatus> statuses
+    );
 
 }


### PR DESCRIPTION
## 👀 Summary

- close #42

상품 예약 과정에서 일자별 예약 가능 시간대 조회 API를 구현했습니다.
상품에 연결된 예약 정보, 작가의 업무 시간, 상품 촬영 시간을 모두 고려하여 예약 시작이 가능한 시간대만 노출합니다.



## 🖇️ Tasks

- [x] 예약 가능 시간대 계산 책임을 Product 도메인 Service로 집중
- [x] 예약 조회를 위한 날짜 범위 + 상태 조건 Repository 메서드 추가
- [x] 촬영 시간 조회를 위한 상품 옵션 Repository 메서드 추가
- [x] 예약 가능 시간대 조회 UseCase 인터페이스 추가
- [x] 시간대 계산 결과를 표현하는 Domain Result DTO 정의
- [x] Domain Result와 API Response DTO 분리
- [x] 예약 가능 시간대 조회 API 엔드포인트 연결



## 🔍 To Reviewer

### ❶ 전체 흐름

1. 상품과 연결된 예약 중 예약 확정 / 촬영 완료 상태의 예약만 조회
2. 작가의 업무 종료 시간과 상품 촬영 시간을 기준으로 촬영이 종료 시간 이전에 완료 가능한 시작 시간대만 계산
3. 계산된 범위 내에서 30분 단위 시작 시간 슬롯 생성
4. 각 슬롯마다 기존 예약과 시간 구간 단위로 겹침 여부를 판단
5. 겹치는 경우에만 isAvailable = false 처리
6. 업무 시간 외 슬롯은 응답에 포함하지 않음

> 응답의 time 값은 예약 시작 시각을 의미합니다.

조회해야 하는 값과 처리해야하는 로직이 복잡하다보니 서비스 계층이 뚱뚱해졌어요 (ㅠㅠ) 
가독성 개선을 위해 메서드를 최대한 분리하고 시간대 처리 과정별로 주석을 달아놓았으니 확인해보시고 피드백 주시면 감사하겠습니다!

<br>

### ❷ 촬영 시간이 30분 배수가 아닐 때의 처리

```
촬영 시간 duration = 45분 / 기존 예약: 10:00 ~ 10:45 인 경우

10:00 슬롯 → 예약 불가
10:30 슬롯 → 촬영 구간이 겹치므로 예약 불가 처리 필요
```

이를 위해 시작 시간이 같은지가 아니라, 시간 구간 단위로 겹침 여부를 판단하도록 로직을 구성했습니다.

슬롯은 30분 단위, 촬영 시간은 가변(45/50/70분 etc) 단위로 잡고, `slot ~ slot + duration` 과 `reservedStart ~ reservedEnd` 구간이 겹치는지 판단하는 방식으로 촬영 시간이 30분 배수가 아니더라도 예약 가능 여부를 계산할 수 있도록 했습니다.

<br>

### ❸ 도메인 및 책임 분리
이 API에서 확인해야 하는 도메인 엔티티는 다음과 같습니다.

```
- 상품
- 상품 옵션 (촬영 시간)
- 예약
- 작가
- 작가 스케줄
```
각 엔티티를 조회하는 책임은 각 도메인의 레포지토리 상에 두고,  예약 가능 시간대 계산 책임은 Product 도메인 Service에만 집중하도록 설계했습니다. 전체적으로 로직이 복잡한데 더미데이터가 없어서 아직 확인이 필요한 상황입니다. 추후 테스트를 통해 지속적으로 체크해나갈 예정이니 이 점 참고해주세요!