### PR TITLE
[FEAT] #60: 무드 큐레이션 질문/사진 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     testImplementation 'org.springframework.batch:spring-batch-test'
 
     // AWS
-    implementation platform("software.amazon.awssdk:bom:2.25.64")
+    implementation platform("software.amazon.awssdk:bom:2.34.0")
     implementation "software.amazon.awssdk:s3"
 
     // Swagger

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     testImplementation 'org.springframework.batch:spring-batch-test'
 
     // AWS
-    implementation platform("software.amazon.awssdk:bom:2.34.0")
+    implementation platform("software.amazon.awssdk:bom:2.40.16")
     implementation "software.amazon.awssdk:s3"
 
     // Swagger

--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ dependencies {
     testImplementation 'org.springframework.batch:spring-batch-test'
 
     // AWS
-    implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.681')
-    implementation 'com.amazonaws:aws-java-sdk-s3'
+    implementation platform("software.amazon.awssdk:bom:2.25.64")
+    implementation "software.amazon.awssdk:s3"
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'

--- a/src/main/java/org/sopt/snappinserver/api/curation/code/CurationSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/code/CurationSuccessCode.java
@@ -1,0 +1,21 @@
+package org.sopt.snappinserver.api.curation.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.global.response.code.common.SuccessCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum CurationSuccessCode implements SuccessCode {
+
+    // 200 OK
+    GET_CURATION_QUESTION_SUCCESS(200, "CURATION_200_001", "무드 큐레이션 질문을 성공적으로 조회했습니다."),
+
+    // 201 CREATED
+
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationApi.java
@@ -10,7 +10,6 @@ import jakarta.validation.constraints.NotNull;
 import org.sopt.snappinserver.api.curation.dto.response.GetCurationQuestionPhotosResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -30,7 +29,7 @@ public interface CurationApi {
         @Schema(description = "조회할 단계", example = "1")
         @NotNull(message = "단계는 필수입니다.")
         @Min(value = 1, message = "단계는 1 이상이어야 합니다.")
-        @Max(value = 5, message = "단계는 10 이하여야 합니다.")
+        @Max(value = 5, message = "단계는 5 이하여야 합니다.")
         @RequestParam Integer step
     );
 

--- a/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationApi.java
@@ -4,14 +4,18 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import org.sopt.snappinserver.api.curation.dto.response.GetCurationQuestionPhotosResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "03 - Curation", description = "무드 큐레이션 관련 API")
+@Validated
 public interface CurationApi {
 
     @Operation(
@@ -21,10 +25,13 @@ public interface CurationApi {
     ApiResponseBody<GetCurationQuestionPhotosResponse, Void> getCurationQuestion(
 
         @Parameter(hidden = true)
-        @AuthenticationPrincipal CustomUserInfo userInfo,
+        CustomUserInfo userInfo,
 
         @Schema(description = "조회할 단계", example = "1")
-        @NotNull(message = "단계는 필수입니다.") @RequestParam Integer step
+        @NotNull(message = "단계는 필수입니다.")
+        @Min(value = 1, message = "단계는 1 이상이어야 합니다.")
+        @Max(value = 5, message = "단계는 10 이하여야 합니다.")
+        @RequestParam Integer step
     );
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationApi.java
@@ -24,7 +24,7 @@ public interface CurationApi {
         @AuthenticationPrincipal CustomUserInfo userInfo,
 
         @Schema(description = "조회할 단계", example = "1")
-        @RequestParam Integer step
+        @NotNull(message = "단계는 필수입니다.") @RequestParam Integer step
     );
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationApi.java
@@ -1,8 +1,30 @@
 package org.sopt.snappinserver.api.curation.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
+import org.sopt.snappinserver.api.curation.dto.response.GetCurationQuestionPhotosResponse;
+import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "03 - Curation", description = "무드 큐레이션 관련 API")
 public interface CurationApi {
+
+    @Operation(
+        summary = "큐레이션 단계별 질문/사진 조회",
+        description = "로그인한 사용자가 큐레이션 별로 질문 / 사진을 조회할 수 있도록 합니다."
+    )
+    ApiResponseBody<GetCurationQuestionPhotosResponse, Void> getCurationQuestion(
+
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+
+        @Schema(description = "조회할 단계", example = "1")
+        @RequestParam Integer step
+    );
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationApi.java
@@ -1,8 +1,30 @@
 package org.sopt.snappinserver.api.curation.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
+import org.sopt.snappinserver.api.curation.dto.response.GetCurationQuestionPhotosResponse;
+import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "03 - Curation", description = "무드 큐레이션 관련 API")
 public interface CurationApi {
+
+    @Operation(
+        summary = "큐레이션 단계별 질문/사진 조회",
+        description = "로그인한 사용자가 큐레이션 별로 질문 / 사진을 조회할 수 있도록 합니다."
+    )
+    ApiResponseBody<GetCurationQuestionPhotosResponse, Void> getCurationQuestion(
+
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+
+        @Schema(description = "조회할 단계", example = "1")
+        @NotNull @RequestParam Integer step
+    );
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
@@ -7,6 +7,7 @@ import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.curation.service.dto.response.GetCurationQuestionResult;
 import org.sopt.snappinserver.domain.curation.service.usecase.GetCurationQuestionUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,7 +22,7 @@ public class CurationController implements CurationApi {
     @Override
     @GetMapping
     public ApiResponseBody<GetCurationQuestionPhotosResponse, Void> getCurationQuestion(
-        CustomUserInfo userInfo,
+        @AuthenticationPrincipal CustomUserInfo userInfo,
         Integer step
     ) {
         GetCurationQuestionResult result = getCurationQuestionUseCase.retrieveCurationQuestionPhotos(

--- a/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.curation.code.CurationSuccessCode;
 import org.sopt.snappinserver.api.curation.dto.response.GetCurationQuestionPhotosResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.domain.curation.domain.exception.CurationErrorCode;
+import org.sopt.snappinserver.domain.curation.domain.exception.CurationException;
 import org.sopt.snappinserver.domain.curation.service.dto.response.GetCurationQuestionResult;
 import org.sopt.snappinserver.domain.curation.service.usecase.GetCurationQuestionUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
@@ -27,6 +29,7 @@ public class CurationController implements CurationApi {
         @AuthenticationPrincipal CustomUserInfo userInfo,
         @NotNull(message = "단계는 필수입니다.") @RequestParam Integer step
     ) {
+        validateLoginUser(userInfo);
         GetCurationQuestionResult result = getCurationQuestionUseCase.getCurationQuestionPhotos(
             userInfo.userId(),
             step
@@ -34,5 +37,11 @@ public class CurationController implements CurationApi {
         GetCurationQuestionPhotosResponse response = GetCurationQuestionPhotosResponse.from(result);
 
         return ApiResponseBody.ok(CurationSuccessCode.GET_CURATION_QUESTION_SUCCESS, response);
+    }
+
+    private void validateLoginUser(CustomUserInfo userInfo) {
+        if(userInfo == null) {
+            throw new CurationException(CurationErrorCode.CURATION_LOGIN_REQUIRED);
+        }
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
@@ -29,7 +29,7 @@ public class CurationController implements CurationApi {
         @RequestParam Integer step
     ) {
         validateLoginUser(userInfo);
-        GetCurationQuestionResult result = getCurationQuestionUseCase.getCurationQuestionPhotos(
+        GetCurationQuestionResult result = getCurationQuestionUseCase.retrieveCurationQuestionPhotos(
             userInfo.userId(),
             step
         );
@@ -39,7 +39,7 @@ public class CurationController implements CurationApi {
     }
 
     private void validateLoginUser(CustomUserInfo userInfo) {
-        if(userInfo == null) {
+        if (userInfo == null) {
             throw new CurationException(CurationErrorCode.CURATION_LOGIN_REQUIRED);
         }
     }

--- a/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
@@ -1,6 +1,5 @@
 package org.sopt.snappinserver.api.curation.controller;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.curation.code.CurationSuccessCode;
 import org.sopt.snappinserver.api.curation.dto.response.GetCurationQuestionPhotosResponse;
@@ -27,7 +26,7 @@ public class CurationController implements CurationApi {
     @GetMapping
     public ApiResponseBody<GetCurationQuestionPhotosResponse, Void> getCurationQuestion(
         @AuthenticationPrincipal CustomUserInfo userInfo,
-        @NotNull(message = "단계는 필수입니다.") @RequestParam Integer step
+        @RequestParam Integer step
     ) {
         validateLoginUser(userInfo);
         GetCurationQuestionResult result = getCurationQuestionUseCase.getCurationQuestionPhotos(

--- a/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
@@ -1,5 +1,6 @@
 package org.sopt.snappinserver.api.curation.controller;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.curation.code.CurationSuccessCode;
 import org.sopt.snappinserver.api.curation.dto.response.GetCurationQuestionPhotosResponse;
@@ -24,7 +25,7 @@ public class CurationController implements CurationApi {
     @GetMapping
     public ApiResponseBody<GetCurationQuestionPhotosResponse, Void> getCurationQuestion(
         @AuthenticationPrincipal CustomUserInfo userInfo,
-        @RequestParam(required = false) Integer step
+        @NotNull(message = "단계는 필수입니다.") @RequestParam Integer step
     ) {
         GetCurationQuestionResult result = getCurationQuestionUseCase.getCurationQuestionPhotos(
             userInfo.userId(),

--- a/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
@@ -1,7 +1,16 @@
 package org.sopt.snappinserver.api.curation.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.curation.code.CurationSuccessCode;
+import org.sopt.snappinserver.api.curation.dto.response.GetCurationQuestionPhotosResponse;
+import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.domain.curation.service.dto.response.GetCurationQuestionResult;
+import org.sopt.snappinserver.domain.curation.service.usecase.GetCurationQuestionUseCase;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/curation")
@@ -9,4 +18,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class CurationController implements CurationApi {
 
+    private final GetCurationQuestionUseCase getCurationQuestionUseCase;
+
+    @Override
+    @GetMapping
+    public ApiResponseBody<GetCurationQuestionPhotosResponse, Void> getCurationQuestion(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        @RequestParam(required = false) Integer step
+    ) {
+        GetCurationQuestionResult result = getCurationQuestionUseCase.getCurationQuestionPhotos(
+            userInfo.userId(),
+            step
+        );
+        GetCurationQuestionPhotosResponse response = GetCurationQuestionPhotosResponse.from(result);
+
+        return ApiResponseBody.ok(CurationSuccessCode.GET_CURATION_QUESTION_SUCCESS, response);
+    }
 }

--- a/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
@@ -7,10 +7,8 @@ import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.curation.service.dto.response.GetCurationQuestionResult;
 import org.sopt.snappinserver.domain.curation.service.usecase.GetCurationQuestionUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/curation")
@@ -23,8 +21,8 @@ public class CurationController implements CurationApi {
     @Override
     @GetMapping
     public ApiResponseBody<GetCurationQuestionPhotosResponse, Void> getCurationQuestion(
-        @AuthenticationPrincipal CustomUserInfo userInfo,
-        @RequestParam(required = false) Integer step
+        CustomUserInfo userInfo,
+        Integer step
     ) {
         GetCurationQuestionResult result = getCurationQuestionUseCase.retrieveCurationQuestionPhotos(
             userInfo.userId(),

--- a/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/controller/CurationController.java
@@ -26,7 +26,7 @@ public class CurationController implements CurationApi {
         @AuthenticationPrincipal CustomUserInfo userInfo,
         @RequestParam(required = false) Integer step
     ) {
-        GetCurationQuestionResult result = getCurationQuestionUseCase.getCurationQuestionPhotos(
+        GetCurationQuestionResult result = getCurationQuestionUseCase.retrieveCurationQuestionPhotos(
             userInfo.userId(),
             step
         );

--- a/src/main/java/org/sopt/snappinserver/api/curation/dto/response/GetCurationQuestionPhotosResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/dto/response/GetCurationQuestionPhotosResponse.java
@@ -1,0 +1,27 @@
+package org.sopt.snappinserver.api.curation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.curation.service.dto.response.GetCurationQuestionResult;
+
+@Schema(description = "무드 큐레이션 단계별 질문/사진 조회 DTO")
+public record GetCurationQuestionPhotosResponse(
+
+    @Schema(description = "질문 내용 DTO")
+    GetQuestionResponse question,
+
+    @Schema(description = "관련 사진 DTO")
+    List<GetPhotoResponse> photos
+) {
+
+    public static GetCurationQuestionPhotosResponse from(
+        GetCurationQuestionResult getCurationQuestionResult
+    ) {
+        return new GetCurationQuestionPhotosResponse(
+            GetQuestionResponse.from(getCurationQuestionResult.question()),
+            getCurationQuestionResult.photos().stream()
+                .map(GetPhotoResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/curation/dto/response/GetPhotoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/dto/response/GetPhotoResponse.java
@@ -1,0 +1,26 @@
+package org.sopt.snappinserver.api.curation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.curation.service.dto.response.GetPhotoResult;
+
+@Schema(description = "질문과 연관된 사진 응답 DTO")
+public record GetPhotoResponse(
+
+    @Schema(description = "사진 ID", example = "1")
+    Long id,
+
+    @Schema(description = "사진 presigned url", example = "https://abc.com")
+    String imageUrl,
+
+    @Schema(description = "사진 순서", example = "1")
+    Integer order
+) {
+
+    public static GetPhotoResponse from(GetPhotoResult getPhotoResult) {
+        return new GetPhotoResponse(
+            getPhotoResult.id(),
+            getPhotoResult.imageUrl(),
+            getPhotoResult.order()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/curation/dto/response/GetQuestionResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/curation/dto/response/GetQuestionResponse.java
@@ -1,0 +1,26 @@
+package org.sopt.snappinserver.api.curation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.curation.service.dto.response.GetQuestionResult;
+
+@Schema(description = "질문 내용 DTO")
+public record GetQuestionResponse(
+
+    @Schema(description = "질문 id", example = "1")
+    Long id,
+
+    @Schema(description = "질문 내용", example = "어떤 장소 무드를 선호하시나요?")
+    String contents,
+
+    @Schema(description = "질문 단계", example = "1")
+    Integer step
+) {
+
+    public static GetQuestionResponse from(GetQuestionResult getQuestionResult) {
+        return new GetQuestionResponse(
+            getQuestionResult.id(),
+            getQuestionResult.contents(),
+            getQuestionResult.step()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/auth/domain/exception/AuthErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/auth/domain/exception/AuthErrorCode.java
@@ -26,6 +26,7 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_OAUTH_TOKEN(401, "AUTH_401_003", "카카오 로그인 접근 실패"),
     INVALID_REFRESH_TOKEN(401, "AUTH_401_004", "잘못된 리프레시 토큰입니다."),
     REFRESH_TOKEN_COOKIE_REQUIRED(401, "AUTH_401_005", "리프레시 토큰 쿠키는 필수입니다."),
+    LOGIN_REQUIRED(401, "AUTH_401_006", "로그인이 필요한 API입니다."),
 
     // 403 FORBIDDEN
     LOGOUT_FORBIDDEN(403, "AUTH_403_001", "다른 사용자를 로그아웃할 수 없습니다."),

--- a/src/main/java/org/sopt/snappinserver/domain/curation/domain/exception/CurationErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/domain/exception/CurationErrorCode.java
@@ -12,12 +12,17 @@ public enum CurationErrorCode implements ErrorCode {
     USER_REQUIRED(400, "CURATION_400_001", "큐레이션을 진행한 유저는 필수입니다."),
     MOOD_REQUIRED(400, "CURATION_400_002", "유저 맞춤 무드는 필수입니다."),
     RANK_REQUIRED(400, "CURATION_400_003", "무드 순위는 필수입니다."),
+    STEP_REQUIRED(400, "CURATION_400_004", "무드 큐레이션 단계는 필수입니다."),
+    INVALID_STEP_RANGE(400, "CURATION_400_005", "무드 큐레이션 단계는 1 이상 5 이하입니다."),
 
     // 401 UNAUTHORIZED
+    CURATION_LOGIN_REQUIRED(400, "CURATION_400_001", "무드 큐레이션은 로그인이 필요합니다."),
 
     // 403 FORBIDDEN
 
     // 404 NOT FOUND
+    QUESTION_NOT_FOUND(404, "CURATION_404_001", "해당 무드 큐레이션 질문을 찾을 수 없습니다."),
+    PHOTO_NOT_FOUND(404, "CURATION_404_002", "해당 이미지를 찾을 수 없습니다."),
 
     ;
 

--- a/src/main/java/org/sopt/snappinserver/domain/curation/domain/exception/CurationErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/domain/exception/CurationErrorCode.java
@@ -16,7 +16,7 @@ public enum CurationErrorCode implements ErrorCode {
     INVALID_STEP_RANGE(400, "CURATION_400_005", "무드 큐레이션 단계는 1 이상 5 이하입니다."),
 
     // 401 UNAUTHORIZED
-    CURATION_LOGIN_REQUIRED(400, "CURATION_400_001", "무드 큐레이션은 로그인이 필요합니다."),
+    CURATION_LOGIN_REQUIRED(401, "CURATION_401_001", "무드 큐레이션은 로그인이 필요합니다."),
 
     // 403 FORBIDDEN
 

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/GetCurationQuestionService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/GetCurationQuestionService.java
@@ -30,14 +30,14 @@ public class GetCurationQuestionService implements GetCurationQuestionUseCase {
     private final S3Service s3Service;
 
     @Override
-    public GetCurationQuestionResult getCurationQuestionPhotos(Long userId, Integer step) {
+    public GetCurationQuestionResult retrieveCurationQuestionPhotos(Long userId, Integer step) {
         validateLoginUser(userId);
         validateStep(step);
 
         Question question = getMoodCurationQuestionByStep(step);
         List<QuestionPhoto> questionPhotos = questionPhotoRepository
             .findQuestionPhotoByQuestion(question);
-        List<GetPhotoResult> photos = getGetPhotoResults(questionPhotos);
+        List<GetPhotoResult> photos = mapToPhotoResults(questionPhotos);
 
         return GetCurationQuestionResult.of(question, photos);
     }
@@ -70,7 +70,7 @@ public class GetCurationQuestionService implements GetCurationQuestionUseCase {
             .orElseThrow(() -> new CurationException(CurationErrorCode.QUESTION_NOT_FOUND));
     }
 
-    private List<GetPhotoResult> getGetPhotoResults(List<QuestionPhoto> questionPhotos) {
+    private List<GetPhotoResult> mapToPhotoResults(List<QuestionPhoto> questionPhotos) {
         return questionPhotos.stream()
             .map(questionPhoto -> {
                 Photo photo = questionPhoto.getPhoto();

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/GetCurationQuestionService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/GetCurationQuestionService.java
@@ -36,7 +36,7 @@ public class GetCurationQuestionService implements GetCurationQuestionUseCase {
 
         Question question = getMoodCurationQuestionByStep(step);
         List<QuestionPhoto> questionPhotos = questionPhotoRepository
-            .findQuestionPhotoByQuestion(question);
+            .findAllByQuestion(question);
         List<GetPhotoResult> photos = mapToPhotoResults(questionPhotos);
 
         return GetCurationQuestionResult.of(question, photos);

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/GetCurationQuestionService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/GetCurationQuestionService.java
@@ -16,7 +16,9 @@ import org.sopt.snappinserver.domain.question.repository.QuestionPhotoRepository
 import org.sopt.snappinserver.domain.question.repository.QuestionRepository;
 import org.sopt.snappinserver.global.response.S3Service;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class GetCurationQuestionService implements GetCurationQuestionUseCase {

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/GetCurationQuestionService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/GetCurationQuestionService.java
@@ -53,7 +53,7 @@ public class GetCurationQuestionService implements GetCurationQuestionUseCase {
         validateStepRange(step);
     }
 
-    private static void validateStepExists(Integer step) {
+    private void validateStepExists(Integer step) {
         if (step == null) {
             throw new CurationException(CurationErrorCode.STEP_REQUIRED);
         }
@@ -66,10 +66,7 @@ public class GetCurationQuestionService implements GetCurationQuestionUseCase {
     }
 
     private Question getMoodCurationQuestionByStep(Integer step) {
-        return questionRepository.findByQuestionDomainAndStep(
-                QuestionDomain.MOOD_CURATION,
-                step
-            )
+        return questionRepository.findByQuestionDomainAndStep(QuestionDomain.MOOD_CURATION, step)
             .orElseThrow(() -> new CurationException(CurationErrorCode.QUESTION_NOT_FOUND));
     }
 

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/GetCurationQuestionService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/GetCurationQuestionService.java
@@ -1,0 +1,89 @@
+package org.sopt.snappinserver.domain.curation.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.curation.domain.exception.CurationErrorCode;
+import org.sopt.snappinserver.domain.curation.domain.exception.CurationException;
+import org.sopt.snappinserver.domain.curation.service.dto.response.GetCurationQuestionResult;
+import org.sopt.snappinserver.domain.curation.service.dto.response.GetPhotoResult;
+import org.sopt.snappinserver.domain.curation.service.usecase.GetCurationQuestionUseCase;
+import org.sopt.snappinserver.domain.photo.domain.entity.Photo;
+import org.sopt.snappinserver.domain.photo.repository.PhotoRepository;
+import org.sopt.snappinserver.domain.question.domain.entity.Question;
+import org.sopt.snappinserver.domain.question.domain.entity.QuestionPhoto;
+import org.sopt.snappinserver.domain.question.domain.enums.QuestionDomain;
+import org.sopt.snappinserver.domain.question.repository.QuestionPhotoRepository;
+import org.sopt.snappinserver.domain.question.repository.QuestionRepository;
+import org.sopt.snappinserver.global.response.S3Service;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class GetCurationQuestionService implements GetCurationQuestionUseCase {
+
+    private static final int MIN_STEP = 1;
+    private static final int MAX_STEP = 5;
+
+    private final QuestionRepository questionRepository;
+    private final QuestionPhotoRepository questionPhotoRepository;
+    private final PhotoRepository photoRepository;
+    private final S3Service s3Service;
+
+    @Override
+    public GetCurationQuestionResult getCurationQuestionPhotos(Long userId, Integer step) {
+        validateLoginUser(userId);
+        validateStep(step);
+
+        Question question = getMoodCurationQuestionByStep(step);
+        List<QuestionPhoto> questionPhotos = questionPhotoRepository
+            .findQuestionPhotoByQuestion(question);
+        List<GetPhotoResult> photos = getGetPhotoResults(questionPhotos);
+
+        return GetCurationQuestionResult.of(question, photos);
+    }
+
+    private static void validateLoginUser(Long userId) {
+        if (userId == null) {
+            throw new CurationException(CurationErrorCode.CURATION_LOGIN_REQUIRED);
+        }
+    }
+
+    private void validateStep(Integer step) {
+        validateStepExists(step);
+        validateStepRange(step);
+    }
+
+    private static void validateStepExists(Integer step) {
+        if (step == null) {
+            throw new CurationException(CurationErrorCode.STEP_REQUIRED);
+        }
+    }
+
+    private void validateStepRange(Integer step) {
+        if (step < MIN_STEP || step > MAX_STEP) {
+            throw new CurationException(CurationErrorCode.INVALID_STEP_RANGE);
+        }
+    }
+
+    private Question getMoodCurationQuestionByStep(Integer step) {
+        return questionRepository.findByQuestionDomainAndStep(
+                QuestionDomain.MOOD_CURATION,
+                step
+            )
+            .orElseThrow(() -> new CurationException(CurationErrorCode.QUESTION_NOT_FOUND));
+    }
+
+    private List<GetPhotoResult> getGetPhotoResults(List<QuestionPhoto> questionPhotos) {
+        return questionPhotos.stream()
+            .map(questionPhoto -> {
+                Photo photo = questionPhoto.getPhoto();
+                String presignedUrl = s3Service.getPresignedUrl(photo.getImageUrl());
+                return new GetPhotoResult(
+                    photo.getId(),
+                    presignedUrl,
+                    questionPhoto.getDisplayOrder()
+                );
+            })
+            .toList();
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/GetCurationQuestionService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/GetCurationQuestionService.java
@@ -8,7 +8,6 @@ import org.sopt.snappinserver.domain.curation.service.dto.response.GetCurationQu
 import org.sopt.snappinserver.domain.curation.service.dto.response.GetPhotoResult;
 import org.sopt.snappinserver.domain.curation.service.usecase.GetCurationQuestionUseCase;
 import org.sopt.snappinserver.domain.photo.domain.entity.Photo;
-import org.sopt.snappinserver.domain.photo.repository.PhotoRepository;
 import org.sopt.snappinserver.domain.question.domain.entity.Question;
 import org.sopt.snappinserver.domain.question.domain.entity.QuestionPhoto;
 import org.sopt.snappinserver.domain.question.domain.enums.QuestionDomain;
@@ -28,7 +27,6 @@ public class GetCurationQuestionService implements GetCurationQuestionUseCase {
 
     private final QuestionRepository questionRepository;
     private final QuestionPhotoRepository questionPhotoRepository;
-    private final PhotoRepository photoRepository;
     private final S3Service s3Service;
 
     @Override

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/GetCurationQuestionService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/GetCurationQuestionService.java
@@ -13,7 +13,7 @@ import org.sopt.snappinserver.domain.question.domain.entity.QuestionPhoto;
 import org.sopt.snappinserver.domain.question.domain.enums.QuestionDomain;
 import org.sopt.snappinserver.domain.question.repository.QuestionPhotoRepository;
 import org.sopt.snappinserver.domain.question.repository.QuestionRepository;
-import org.sopt.snappinserver.global.response.S3Service;
+import org.sopt.snappinserver.global.s3.S3Service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/dto/response/GetCurationQuestionResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/dto/response/GetCurationQuestionResult.java
@@ -1,6 +1,7 @@
 package org.sopt.snappinserver.domain.curation.service.dto.response;
 
 import java.util.List;
+import java.util.Objects;
 import org.sopt.snappinserver.domain.question.domain.entity.Question;
 
 public record GetCurationQuestionResult(
@@ -12,6 +13,10 @@ public record GetCurationQuestionResult(
         Question question,
         List<GetPhotoResult> photos
     ) {
-        return new GetCurationQuestionResult(GetQuestionResult.from(question), photos);
+        Objects.requireNonNull(question, "질문은 null일 수 없습니다.");
+        return new GetCurationQuestionResult(
+            GetQuestionResult.from(question),
+            photos == null ? List.of(): List.copyOf(photos)
+        );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/dto/response/GetCurationQuestionResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/dto/response/GetCurationQuestionResult.java
@@ -1,0 +1,17 @@
+package org.sopt.snappinserver.domain.curation.service.dto.response;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.question.domain.entity.Question;
+
+public record GetCurationQuestionResult(
+    GetQuestionResult question,
+    List<GetPhotoResult> photos
+) {
+
+    public static GetCurationQuestionResult of(
+        Question question,
+        List<GetPhotoResult> photos
+    ) {
+        return new GetCurationQuestionResult(GetQuestionResult.from(question), photos);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/dto/response/GetPhotoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/dto/response/GetPhotoResult.java
@@ -1,5 +1,5 @@
 package org.sopt.snappinserver.domain.curation.service.dto.response;
 
-public record GetPhotoResult(Long id, String imageUrl, Integer order) {
+public record GetPhotoResult(Long id, String imageUrl, int order) {
 
 }

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/dto/response/GetPhotoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/dto/response/GetPhotoResult.java
@@ -1,0 +1,5 @@
+package org.sopt.snappinserver.domain.curation.service.dto.response;
+
+public record GetPhotoResult(Long id, String imageUrl, Integer order) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/dto/response/GetQuestionResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/dto/response/GetQuestionResult.java
@@ -1,0 +1,10 @@
+package org.sopt.snappinserver.domain.curation.service.dto.response;
+
+import org.sopt.snappinserver.domain.question.domain.entity.Question;
+
+public record GetQuestionResult(Long id, String contents, Integer step) {
+
+    public static GetQuestionResult from(Question question) {
+        return new GetQuestionResult(question.getId(), question.getContents(), question.getStep());
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/usecase/GetCurationQuestionUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/usecase/GetCurationQuestionUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.curation.service.usecase;
+
+import org.sopt.snappinserver.domain.curation.service.dto.response.GetCurationQuestionResult;
+
+public interface GetCurationQuestionUseCase {
+
+    GetCurationQuestionResult getCurationQuestionPhotos(Long userId, Integer step);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/usecase/GetCurationQuestionUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/usecase/GetCurationQuestionUseCase.java
@@ -4,5 +4,5 @@ import org.sopt.snappinserver.domain.curation.service.dto.response.GetCurationQu
 
 public interface GetCurationQuestionUseCase {
 
-    GetCurationQuestionResult getCurationQuestionPhotos(Long userId, Integer step);
+    GetCurationQuestionResult retrieveCurationQuestionPhotos(Long userId, Integer step);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/question/domain/entity/Question.java
+++ b/src/main/java/org/sopt/snappinserver/domain/question/domain/entity/Question.java
@@ -45,10 +45,10 @@ public class Question extends BaseEntity {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(name = "question_domain", nullable = false)
     private QuestionDomain questionDomain;
 
-    @Column(nullable = false)
+    @Column(name = "step", nullable = false)
     private Integer step;
 
     @Column(nullable = false, length = MAX_CONTENTS_LENGTH)

--- a/src/main/java/org/sopt/snappinserver/domain/question/domain/entity/Question.java
+++ b/src/main/java/org/sopt/snappinserver/domain/question/domain/entity/Question.java
@@ -65,6 +65,7 @@ public class Question extends BaseEntity {
         validateQuestion(questionDomain, step, contents);
         return Question.builder()
             .questionDomain(questionDomain)
+            .step(step)
             .contents(contents)
             .build();
     }

--- a/src/main/java/org/sopt/snappinserver/domain/question/domain/entity/Question.java
+++ b/src/main/java/org/sopt/snappinserver/domain/question/domain/entity/Question.java
@@ -8,6 +8,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +22,15 @@ import org.sopt.snappinserver.global.entity.BaseEntity;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Table(
+    name = "question",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_question_domain_step",
+            columnNames = {"question_domain", "step"}
+        )
+    }
+)
 public class Question extends BaseEntity {
 
     private static final int MAX_CONTENTS_LENGTH = 200;

--- a/src/main/java/org/sopt/snappinserver/domain/question/repository/QuestionPhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/question/repository/QuestionPhotoRepository.java
@@ -1,0 +1,13 @@
+package org.sopt.snappinserver.domain.question.repository;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.question.domain.entity.Question;
+import org.sopt.snappinserver.domain.question.domain.entity.QuestionPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuestionPhotoRepository extends JpaRepository<QuestionPhoto, Long> {
+
+    List<QuestionPhoto> findQuestionPhotoByQuestion(Question question);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/question/repository/QuestionPhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/question/repository/QuestionPhotoRepository.java
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface QuestionPhotoRepository extends JpaRepository<QuestionPhoto, Long> {
 
-    List<QuestionPhoto> findQuestionPhotoByQuestion(Question question);
+    List<QuestionPhoto> findAllByQuestion(Question question);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/question/repository/QuestionRepository.java
@@ -1,10 +1,14 @@
 package org.sopt.snappinserver.domain.question.repository;
 
+import java.util.Optional;
 import org.sopt.snappinserver.domain.question.domain.entity.Question;
+import org.sopt.snappinserver.domain.question.domain.enums.QuestionDomain;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    Optional<Question> findByQuestionDomainAndStep(QuestionDomain questionDomain, Integer step);
 
 }

--- a/src/main/java/org/sopt/snappinserver/global/config/s3/S3Config.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/s3/S3Config.java
@@ -7,7 +7,9 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
+@Profile("!test")
 @Configuration
 public class S3Config {
 

--- a/src/main/java/org/sopt/snappinserver/global/config/s3/S3Config.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/s3/S3Config.java
@@ -4,6 +4,7 @@ import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,12 +14,15 @@ import org.springframework.context.annotation.Profile;
 @Configuration
 public class S3Config {
 
+    @NotBlank
     @Value("${cloud.aws.credentials.access-key}")
     private String accessKey;
 
+    @NotBlank
     @Value("${cloud.aws.credentials.secret-key}")
     private String secretKey;
 
+    @NotBlank
     @Value("${cloud.aws.region.static}")
     private String region;
 

--- a/src/main/java/org/sopt/snappinserver/global/config/s3/S3Config.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/s3/S3Config.java
@@ -14,15 +14,12 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 @Configuration
 public class S3Config {
 
-    @NotBlank
     @Value("${cloud.aws.credentials.access-key}")
     private String accessKey;
 
-    @NotBlank
     @Value("${cloud.aws.credentials.secret-key}")
     private String secretKey;
 
-    @NotBlank
     @Value("${cloud.aws.region.static}")
     private String region;
 

--- a/src/main/java/org/sopt/snappinserver/global/config/s3/S3Config.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/s3/S3Config.java
@@ -1,6 +1,5 @@
 package org.sopt.snappinserver.global.config.s3;
 
-import jakarta.validation.constraints.NotBlank;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/org/sopt/snappinserver/global/config/s3/S3Config.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/s3/S3Config.java
@@ -1,0 +1,32 @@
+package org.sopt.snappinserver.global.config.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder.standard()
+            .withRegion(region)
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .build();
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/global/config/s3/S3Config.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/s3/S3Config.java
@@ -1,14 +1,14 @@
 package org.sopt.snappinserver.global.config.s3;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Profile("!test")
 @Configuration
@@ -26,13 +26,17 @@ public class S3Config {
     @Value("${cloud.aws.region.static}")
     private String region;
 
-    @Bean
-    public AmazonS3 amazonS3() {
-        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+    private StaticCredentialsProvider credentialsProvider() {
+        AwsBasicCredentials credentials =
+            AwsBasicCredentials.create(accessKey, secretKey);
+        return StaticCredentialsProvider.create(credentials);
+    }
 
-        return AmazonS3ClientBuilder.standard()
-            .withRegion(region)
-            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+            .region(Region.of(region))
+            .credentialsProvider(credentialsProvider())
             .build();
     }
 }

--- a/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package org.sopt.snappinserver.global.config.security;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.global.security.CustomAuthenticationEntryPoint;
 import org.sopt.snappinserver.global.security.JwtAccessDeniedHandler;
 import org.sopt.snappinserver.global.security.TokenAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
@@ -42,6 +43,7 @@ public class SecurityConfig {
     };
 
     private final TokenAuthenticationFilter tokenAuthenticationFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     @Bean
@@ -56,6 +58,7 @@ public class SecurityConfig {
             .httpBasic(AbstractHttpConfigurer::disable)
             .anonymous(AbstractHttpConfigurer::disable)
             .exceptionHandling(e -> e
+                .authenticationEntryPoint(customAuthenticationEntryPoint)
                 .accessDeniedHandler(jwtAccessDeniedHandler)
             )
             .authorizeHttpRequests(auth -> auth

--- a/src/main/java/org/sopt/snappinserver/global/exception/CommonErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/exception/CommonErrorCode.java
@@ -10,8 +10,7 @@ public enum CommonErrorCode implements ErrorCode {
 
     // 400 BAD REQUEST
     INVALID_MAPPING_PARAMETER(400, "COMMON_400_001", "매핑할 수 없는 값입니다."),
-    INVALID_REQUEST_BODY(400, "COMMON_400_002", "잘못된 Request Body 입니다."),
-    INVALID_REQUEST_VARIABLE(400, "COMMON_400_003", "엔드포인트에 잘못된 요청값이 있습니다."),
+    INVALID_REQUEST_VARIABLE(400, "COMMON_400_002", "엔드포인트에 잘못된 요청값이 있습니다."),
 
     // 401 UNAUTHENTICATED
     UNAUTHORIZED(401, "COMMON_401_001", "인증에 실패했습니다."),

--- a/src/main/java/org/sopt/snappinserver/global/exception/CommonErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/exception/CommonErrorCode.java
@@ -10,6 +10,8 @@ public enum CommonErrorCode implements ErrorCode {
 
     // 400 BAD REQUEST
     INVALID_MAPPING_PARAMETER(400, "COMMON_400_001", "매핑할 수 없는 값입니다."),
+    INVALID_REQUEST_BODY(400, "COMMON_400_002", "잘못된 Request Body 입니다."),
+    INVALID_REQUEST_VARIABLE(400, "COMMON_400_003", "엔드포인트에 잘못된 요청값이 있습니다."),
 
     // 401 UNAUTHENTICATED
     UNAUTHORIZED(401, "COMMON_401_001", "인증에 실패했습니다."),

--- a/src/main/java/org/sopt/snappinserver/global/response/S3Service.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/S3Service.java
@@ -1,0 +1,36 @@
+package org.sopt.snappinserver.global.response;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import java.net.URL;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String getPresignedUrl(String storedFileName) {
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += 1000 * 60 * 10;
+        expiration.setTime(expTimeMillis);
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+            new GeneratePresignedUrlRequest(bucketName, storedFileName)
+                .withMethod(HttpMethod.GET)
+                .withExpiration(expiration);
+
+        URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
+
+        return url.toString();
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/global/s3/S3ErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/s3/S3ErrorCode.java
@@ -12,7 +12,7 @@ public enum S3ErrorCode implements ErrorCode {
     S3_KEY_REQUIRED(400, "S3_400_001", "S3 키는 필수입니다."),
 
     // 503 Service Unavailable
-    S3_SERVICE_UNAVAILABLE(503, "S3_503_001", "Presigned Url 발급에 실패했습니다."),
+    S3_SERVICE_UNAVAILABLE(503, "S3_503_001", "Presigned URL 발급에 실패했습니다."),
     ;
 
     private final int status;

--- a/src/main/java/org/sopt/snappinserver/global/s3/S3ErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/s3/S3ErrorCode.java
@@ -8,6 +8,9 @@ import org.sopt.snappinserver.global.response.code.common.ErrorCode;
 @RequiredArgsConstructor
 public enum S3ErrorCode implements ErrorCode {
 
+    // 400 BAD REQUEST
+    S3_KEY_REQUIRED(400, "S3_400_001", "S3 키는 필수입니다."),
+
     // 503 Service Unavailable
     S3_SERVICE_UNAVAILABLE(503, "S3_503_001", "Presigned Url 발급에 실패했습니다."),
     ;

--- a/src/main/java/org/sopt/snappinserver/global/s3/S3ErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/s3/S3ErrorCode.java
@@ -1,0 +1,18 @@
+package org.sopt.snappinserver.global.s3;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.global.response.code.common.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum S3ErrorCode implements ErrorCode {
+
+    // 503 Service Unavailable
+    S3_SERVICE_UNAVAILABLE(503, "S3_503_001", "Presigned Url 발급에 실패했습니다."),
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/sopt/snappinserver/global/s3/S3Exception.java
+++ b/src/main/java/org/sopt/snappinserver/global/s3/S3Exception.java
@@ -1,0 +1,10 @@
+package org.sopt.snappinserver.global.s3;
+
+import org.sopt.snappinserver.global.exception.BusinessException;
+
+public class S3Exception extends BusinessException {
+
+    public S3Exception(S3ErrorCode s3ErrorCode) {
+        super(s3ErrorCode);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/global/s3/S3Service.java
+++ b/src/main/java/org/sopt/snappinserver/global/s3/S3Service.java
@@ -1,6 +1,5 @@
 package org.sopt.snappinserver.global.s3;
 
-import jakarta.validation.constraints.NotBlank;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,7 +21,7 @@ public class S3Service {
 
     public String getPresignedUrl(String storedFileName) {
         try {
-            validateStoredFileNameExsits(storedFileName);
+            validateStoredFileNameExists(storedFileName);
             GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucketName)
                 .key(storedFileName)
@@ -40,7 +39,7 @@ public class S3Service {
         }
     }
 
-    private static void validateStoredFileNameExsits(String storedFileName) {
+    private static void validateStoredFileNameExists(String storedFileName) {
         if(storedFileName == null || storedFileName.isBlank()) {
             throw new S3Exception(S3ErrorCode.S3_KEY_REQUIRED);
         }

--- a/src/main/java/org/sopt/snappinserver/global/s3/S3Service.java
+++ b/src/main/java/org/sopt/snappinserver/global/s3/S3Service.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.global.response;
+package org.sopt.snappinserver.global.s3;
 
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;

--- a/src/main/java/org/sopt/snappinserver/global/s3/S3Service.java
+++ b/src/main/java/org/sopt/snappinserver/global/s3/S3Service.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
@@ -34,7 +35,7 @@ public class S3Service {
                 );
 
             return presignedRequest.url().toString();
-        } catch (Exception e) {
+        } catch (SdkException e) {
             throw new S3Exception(S3ErrorCode.S3_SERVICE_UNAVAILABLE);
         }
     }

--- a/src/main/java/org/sopt/snappinserver/global/s3/S3Service.java
+++ b/src/main/java/org/sopt/snappinserver/global/s3/S3Service.java
@@ -3,6 +3,7 @@ package org.sopt.snappinserver.global.s3;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import jakarta.validation.constraints.NotBlank;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,6 +15,7 @@ public class S3Service {
 
     private final AmazonS3 amazonS3;
 
+    @NotBlank
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 

--- a/src/main/java/org/sopt/snappinserver/global/s3/S3Service.java
+++ b/src/main/java/org/sopt/snappinserver/global/s3/S3Service.java
@@ -17,7 +17,6 @@ public class S3Service {
 
     private final S3Presigner s3Presigner;
 
-    @NotBlank
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 

--- a/src/main/java/org/sopt/snappinserver/global/s3/S3Service.java
+++ b/src/main/java/org/sopt/snappinserver/global/s3/S3Service.java
@@ -3,7 +3,6 @@ package org.sopt.snappinserver.global.s3;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
-import java.net.URL;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,18 +18,20 @@ public class S3Service {
     private String bucketName;
 
     public String getPresignedUrl(String storedFileName) {
-        Date expiration = new Date();
-        long expTimeMillis = expiration.getTime();
-        expTimeMillis += 1000 * 60 * 10;
-        expiration.setTime(expTimeMillis);
+        try {
+            Date expiration = new Date();
+            long expTimeMillis = expiration.getTime();
+            expTimeMillis += 1000 * 60 * 10;
+            expiration.setTime(expTimeMillis);
 
-        GeneratePresignedUrlRequest generatePresignedUrlRequest =
-            new GeneratePresignedUrlRequest(bucketName, storedFileName)
-                .withMethod(HttpMethod.GET)
-                .withExpiration(expiration);
+            GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucketName, storedFileName)
+                    .withMethod(HttpMethod.GET)
+                    .withExpiration(expiration);
 
-        URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
-
-        return url.toString();
+            return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+        } catch (Exception e) {
+            throw new S3Exception(S3ErrorCode.S3_SERVICE_UNAVAILABLE);
+        }
     }
 }

--- a/src/main/java/org/sopt/snappinserver/global/s3/S3Service.java
+++ b/src/main/java/org/sopt/snappinserver/global/s3/S3Service.java
@@ -5,8 +5,8 @@ import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
 @Service
@@ -23,6 +23,7 @@ public class S3Service {
 
     public String getPresignedUrl(String storedFileName) {
         try {
+            validateStoredFileNameExsits(storedFileName);
             GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucketName)
                 .key(storedFileName)
@@ -37,6 +38,12 @@ public class S3Service {
             return presignedRequest.url().toString();
         } catch (Exception e) {
             throw new S3Exception(S3ErrorCode.S3_SERVICE_UNAVAILABLE);
+        }
+    }
+
+    private static void validateStoredFileNameExsits(String storedFileName) {
+        if(storedFileName == null || storedFileName.isBlank()) {
+            throw new S3Exception(S3ErrorCode.S3_KEY_REQUIRED);
         }
     }
 }

--- a/src/main/java/org/sopt/snappinserver/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/sopt/snappinserver/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package org.sopt.snappinserver.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.auth.domain.exception.AuthErrorCode;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.sopt.snappinserver.global.response.dto.ErrorMeta;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AuthenticationException authException
+    ) throws IOException {
+
+        ApiResponseBody<Void, ErrorMeta> body =
+            ApiResponseBody.onFailure(
+                AuthErrorCode.LOGIN_REQUIRED,
+                new ErrorMeta(request.getRequestURI(), Instant.now())
+            );
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}
+

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -35,3 +35,13 @@ jwt:
 auth:
   cookie:
     secure: false
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+    s3:
+      bucket: ${S3_BUCKET}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -35,3 +35,13 @@ jwt:
 auth:
   cookie:
     secure: false
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+    s3:
+      bucket: ${S3_BUCKET}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -26,3 +26,13 @@ auth:
 
 cors:
   allowed-origins: http://localhost:8080
+
+cloud:
+  aws:
+    credentials:
+      access-key: asdf
+      secret-key: asdf
+    region:
+      static: asfd
+    s3:
+      bucket: asdf

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -26,13 +26,3 @@ auth:
 
 cors:
   allowed-origins: http://localhost:8080
-
-cloud:
-  aws:
-    credentials:
-      access-key: asdf
-      secret-key: asdf
-    region:
-      static: asfd
-    s3:
-      bucket: asdf


### PR DESCRIPTION
## 👀 Summary

- close #60


## 🖇️ Tasks

- 질문-사진 중간 연결 테이블 리포지토리 추가
- 무드 큐레이션 조회를 위한 리포지토리단 코드 작성
- 사진 조회를 위해 AWS S3 접근 시 Presigned Url 방식 사용
- 무드 큐레이션 질문, 사진 조회를 위한 서비스 코드 작성
- 컨트롤러, 서비스 단 DTO 분리를 통해 책임 분리

## 🔍 To Reviewer

### ❶ 전체 흐름
1. user가 로그인했는지 검증
2. 단계가 null이 아닌지, 제대로 된 범위 내인지 검증
3. 무드 큐레이션과 단계로 질문 조회
4. 질문으로 질문-사진 연결 데이터 조회
5. 연결 데이터 목록을 서비스 단 DTO로 전환 및 이때 사진에 저장된 이미지 경로를 presignedUrl로 반환

### ❷ 고민한 지점
컨트롤러 단에서 파라미터 검증으로 입력값 예외를 던지는 것이 좋다고 생각했는데, postman으로 테스트한 결과 직접 만든 예외 클래스가 던져지지 않는 것을 확인했습니다. 따라서 서비스 내부에서 검증하는 부분으로 검증할 수 있도록 컨트롤러단 @NotNull 어노테이션을 삭제했습니다.

### ❸ PresignedUrl 동작 방식
만료 시간을 직접 지정한 후, 사진의 S3 키 값을 받아오면 미리 지정한 버킷의 키 값에 대해 만료 시간을 `amazonS3.generatePresignedUrl()`에서 만들어주는 방식입니다.