### PR TITLE
[FEAT] #67: 상품 좋아요/취소 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/wish/code/WishSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/code/WishSuccessCode.java
@@ -9,7 +9,9 @@ import org.sopt.snappinserver.global.response.code.common.SuccessCode;
 public enum WishSuccessCode implements SuccessCode {
 
     POST_WISH_LIKE_PORTFOLIO_OK(200, "WISH_200_001", "포트폴리오 좋아요 처리에 성공했습니다."),
-    POST_WISH_CANCEL_PORTFOLIO_OK(200, "WISH_200_002", "포트폴리오 좋아요 취소에 성공했습니다.");
+    POST_WISH_CANCEL_PORTFOLIO_OK(200, "WISH_200_002", "포트폴리오 좋아요 취소에 성공했습니다."),
+    POST_WISH_LIKE_PRODUCT_OK(200, "WISH_200_003", "상품 좋아요 처리에 성공했습니다."),
+    POST_WISH_CANCEL_PRODUCT_OK(200, "WISH_200_004", "상품 좋아요 취소에 성공했습니다.");
 
 
     private final int status;

--- a/src/main/java/org/sopt/snappinserver/api/wish/controller/WishApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/controller/WishApi.java
@@ -5,25 +5,26 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.sopt.snappinserver.api.wish.dto.request.WishPortfolioRequest;
+import org.sopt.snappinserver.api.wish.dto.request.WishProductRequest;
 import org.sopt.snappinserver.api.wish.dto.response.WishPortfolioResponse;
+import org.sopt.snappinserver.api.wish.dto.response.WishProductResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "012 - Wish", description = "좋아요 관련 API")
 public interface WishApi {
 
-    @Operation(
-        summary = "포트폴리오 좋아요/취소",
-        description = "로그인한 사용자가 포트폴리오에 대해 좋아요를 추가하거나, 이미 좋아요를 누른 경우 취소합니다."
-    )
-    @PostMapping("/portfolios")
+    @Operation(summary = "포트폴리오 좋아요/취소", description = "로그인한 사용자가 포트폴리오에 대해 좋아요를 추가하거나, 이미 좋아요를 누른 경우 취소합니다.")
     ApiResponseBody<WishPortfolioResponse, Void> updateWishPortfolio(
         @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo userInfo,
+        @Valid @RequestBody WishPortfolioRequest request);
 
-        @Valid @RequestBody WishPortfolioRequest request
-    );
+    @Operation(summary = "상품 좋아요/취소", description = "로그인한 사용자가 상품에 대해 좋아요를 추가하거나, 이미 좋아요를 누른 경우 취소합니다.")
+    ApiResponseBody<WishProductResponse, Void> updateWishProduct(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        @Valid @RequestBody WishProductRequest request);
 }

--- a/src/main/java/org/sopt/snappinserver/api/wish/controller/WishApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/controller/WishApi.java
@@ -11,18 +11,27 @@ import org.sopt.snappinserver.api.wish.dto.response.WishProductResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "012 - Wish", description = "좋아요 관련 API")
 public interface WishApi {
 
-    @Operation(summary = "포트폴리오 좋아요/취소", description = "로그인한 사용자가 포트폴리오에 대해 좋아요를 추가하거나, 이미 좋아요를 누른 경우 취소합니다.")
+    @Operation(
+        summary = "포트폴리오 좋아요/취소",
+        description = "로그인한 사용자가 포트폴리오에 대해 좋아요를 추가하거나, 이미 좋아요를 누른 경우 취소합니다."
+    )
+    @PostMapping("/portfolios")
     ApiResponseBody<WishPortfolioResponse, Void> updateWishPortfolio(
         @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo userInfo,
         @Valid @RequestBody WishPortfolioRequest request);
 
-    @Operation(summary = "상품 좋아요/취소", description = "로그인한 사용자가 상품에 대해 좋아요를 추가하거나, 이미 좋아요를 누른 경우 취소합니다.")
+    @Operation(
+        summary = "상품 좋아요/취소",
+        description = "로그인한 사용자가 상품에 대해 좋아요를 추가하거나, 이미 좋아요를 누른 경우 취소합니다."
+    )
+    @PostMapping("/products")
     ApiResponseBody<WishProductResponse, Void> updateWishProduct(
         @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserInfo userInfo,

--- a/src/main/java/org/sopt/snappinserver/api/wish/controller/WishApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/controller/WishApi.java
@@ -10,11 +10,12 @@ import org.sopt.snappinserver.api.wish.dto.response.WishPortfolioResponse;
 import org.sopt.snappinserver.api.wish.dto.response.WishProductResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "012 - Wish", description = "좋아요 관련 API")
+@Validated
 public interface WishApi {
 
     @Operation(
@@ -23,8 +24,10 @@ public interface WishApi {
     )
     @PostMapping("/portfolios")
     ApiResponseBody<WishPortfolioResponse, Void> updateWishPortfolio(
+
         @Parameter(hidden = true)
-        @AuthenticationPrincipal CustomUserInfo userInfo,
+        CustomUserInfo userInfo,
+
         @Valid @RequestBody WishPortfolioRequest request);
 
     @Operation(
@@ -33,7 +36,9 @@ public interface WishApi {
     )
     @PostMapping("/products")
     ApiResponseBody<WishProductResponse, Void> updateWishProduct(
+
         @Parameter(hidden = true)
-        @AuthenticationPrincipal CustomUserInfo userInfo,
+        CustomUserInfo userInfo,
+
         @Valid @RequestBody WishProductRequest request);
 }

--- a/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
@@ -26,9 +26,8 @@ public class WishController implements WishApi {
     private final PostWishProductUseCase postWishProductUseCase;
 
     @Override
-    @PostMapping("/portfolios")
     public ApiResponseBody<WishPortfolioResponse, Void> updateWishPortfolio(
-        @AuthenticationPrincipal CustomUserInfo userInfo,
+        CustomUserInfo userInfo,
         WishPortfolioRequest request
     ) {
         WishPortfolioResult result = postWishPortfolioUseCase.togglePortfolioWish(
@@ -46,9 +45,8 @@ public class WishController implements WishApi {
     }
 
     @Override
-    @PostMapping("/products")
     public ApiResponseBody<WishProductResponse, Void> updateWishProduct(
-        @AuthenticationPrincipal CustomUserInfo userInfo,
+        CustomUserInfo userInfo,
         WishProductRequest request
     ) {
         WishProductResult result = postWishProductUseCase.toggleProductWish(

--- a/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
@@ -3,12 +3,17 @@ package org.sopt.snappinserver.api.wish.controller;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.wish.code.WishSuccessCode;
 import org.sopt.snappinserver.api.wish.dto.request.WishPortfolioRequest;
+import org.sopt.snappinserver.api.wish.dto.request.WishProductRequest;
 import org.sopt.snappinserver.api.wish.dto.response.WishPortfolioResponse;
+import org.sopt.snappinserver.api.wish.dto.response.WishProductResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishPortfolioResult;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishProductResult;
 import org.sopt.snappinserver.domain.wish.service.usecase.PostWishPortfolioUseCase;
+import org.sopt.snappinserver.domain.wish.service.usecase.PostWishProductUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,9 +23,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class WishController implements WishApi {
 
     private final PostWishPortfolioUseCase postWishPortfolioUseCase;
-
+    private final PostWishProductUseCase postWishProductUseCase;
 
     @Override
+    @PostMapping("/portfolios")
     public ApiResponseBody<WishPortfolioResponse, Void> updateWishPortfolio(
         @AuthenticationPrincipal CustomUserInfo userInfo,
         WishPortfolioRequest request
@@ -29,15 +35,33 @@ public class WishController implements WishApi {
             userInfo.userId(),
             request.portfolioId()
         );
-
         WishPortfolioResponse response = WishPortfolioResponse.from(result);
 
         return ApiResponseBody.ok(decideSuccessCode(result), response);
     }
 
     private WishSuccessCode decideSuccessCode(WishPortfolioResult result) {
-        return result.liked()
-            ? WishSuccessCode.POST_WISH_LIKE_PORTFOLIO_OK
+        return result.liked() ? WishSuccessCode.POST_WISH_LIKE_PORTFOLIO_OK
             : WishSuccessCode.POST_WISH_CANCEL_PORTFOLIO_OK;
+    }
+
+    @Override
+    @PostMapping("/products")
+    public ApiResponseBody<WishProductResponse, Void> updateWishProduct(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        WishProductRequest request
+    ) {
+        WishProductResult result = postWishProductUseCase.toggleProductWish(
+            userInfo.userId(),
+            request.productId()
+        );
+        WishProductResponse response = WishProductResponse.from(result);
+
+        return ApiResponseBody.ok(decideSuccessCode(result), response);
+    }
+
+    private WishSuccessCode decideSuccessCode(WishProductResult result) {
+        return result.liked() ? WishSuccessCode.POST_WISH_LIKE_PRODUCT_OK
+            : WishSuccessCode.POST_WISH_CANCEL_PRODUCT_OK;
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
@@ -12,6 +12,7 @@ import org.sopt.snappinserver.domain.wish.service.dto.response.WishProductResult
 import org.sopt.snappinserver.domain.wish.service.usecase.PostWishPortfolioUseCase;
 import org.sopt.snappinserver.domain.wish.service.usecase.PostWishProductUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,7 +26,7 @@ public class WishController implements WishApi {
 
     @Override
     public ApiResponseBody<WishPortfolioResponse, Void> updateWishPortfolio(
-        CustomUserInfo userInfo,
+        @AuthenticationPrincipal CustomUserInfo userInfo,
         WishPortfolioRequest request
     ) {
         WishPortfolioResult result = postWishPortfolioUseCase.togglePortfolioWish(
@@ -39,7 +40,7 @@ public class WishController implements WishApi {
 
     @Override
     public ApiResponseBody<WishProductResponse, Void> updateWishProduct(
-        CustomUserInfo userInfo,
+        @AuthenticationPrincipal CustomUserInfo userInfo,
         WishProductRequest request
     ) {
         WishProductResult result = postWishProductUseCase.toggleProductWish(

--- a/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
@@ -12,8 +12,6 @@ import org.sopt.snappinserver.domain.wish.service.dto.response.WishProductResult
 import org.sopt.snappinserver.domain.wish.service.usecase.PostWishPortfolioUseCase;
 import org.sopt.snappinserver.domain.wish.service.usecase.PostWishProductUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -39,11 +37,6 @@ public class WishController implements WishApi {
         return ApiResponseBody.ok(decideSuccessCode(result), response);
     }
 
-    private WishSuccessCode decideSuccessCode(WishPortfolioResult result) {
-        return result.liked() ? WishSuccessCode.POST_WISH_LIKE_PORTFOLIO_OK
-            : WishSuccessCode.POST_WISH_CANCEL_PORTFOLIO_OK;
-    }
-
     @Override
     public ApiResponseBody<WishProductResponse, Void> updateWishProduct(
         CustomUserInfo userInfo,
@@ -56,6 +49,11 @@ public class WishController implements WishApi {
         WishProductResponse response = WishProductResponse.from(result);
 
         return ApiResponseBody.ok(decideSuccessCode(result), response);
+    }
+
+    private WishSuccessCode decideSuccessCode(WishPortfolioResult result) {
+        return result.liked() ? WishSuccessCode.POST_WISH_LIKE_PORTFOLIO_OK
+            : WishSuccessCode.POST_WISH_CANCEL_PORTFOLIO_OK;
     }
 
     private WishSuccessCode decideSuccessCode(WishProductResult result) {

--- a/src/main/java/org/sopt/snappinserver/api/wish/dto/request/WishProductRequest.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/dto/request/WishProductRequest.java
@@ -1,0 +1,13 @@
+package org.sopt.snappinserver.api.wish.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "상품 좋아요/취소 요청 DTO")
+public record WishProductRequest(
+    @Schema(description = "좋아요/취소할 상품 아이디", example = "1")
+    @NotNull(message = "productId는 필수입니다.")
+    Long productId
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishPortfolioResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishPortfolioResponse.java
@@ -7,11 +7,12 @@ import org.sopt.snappinserver.domain.wish.service.dto.response.WishPortfolioResu
 public record WishPortfolioResponse(
     @Schema(description = "포트폴리오 아이디", example = "101")
     Long portfolioId,
+
     @Schema(description = "좋아요 상태 (요청 처리 후)", example = "true")
-    Boolean liked
+    boolean liked
 ) {
 
     public static WishPortfolioResponse from(WishPortfolioResult result) {
-        return new WishPortfolioResponse(result.portfolioId(), result.liked());
+        return new WishPortfolioResponse(result.portfolioId(), Boolean.TRUE.equals(result.liked()));
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishProductResponse.java
@@ -7,6 +7,7 @@ import org.sopt.snappinserver.domain.wish.service.dto.response.WishProductResult
 public record WishProductResponse(
     @Schema(description = "상품 아이디", example = "101")
     Long productId,
+
     @Schema(description = "좋아요 상태 (요청 처리 후)", example = "true")
     Boolean liked
 ) {

--- a/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishProductResponse.java
@@ -9,10 +9,10 @@ public record WishProductResponse(
     Long productId,
 
     @Schema(description = "좋아요 상태 (요청 처리 후)", example = "true")
-    Boolean liked
+    boolean liked
 ) {
 
     public static WishProductResponse from(WishProductResult result) {
-        return new WishProductResponse(result.productId(), result.liked());
+        return new WishProductResponse(result.productId(), Boolean.TRUE.equals(result.liked()));
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishProductResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.snappinserver.api.wish.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishProductResult;
+
+@Schema(description = "상품 좋아요/취소 응답 DTO")
+public record WishProductResponse(
+    @Schema(description = "상품 아이디", example = "101")
+    Long productId,
+    @Schema(description = "좋아요 상태 (요청 처리 후)", example = "true")
+    Boolean liked
+) {
+
+    public static WishProductResponse from(WishProductResult result) {
+        return new WishProductResponse(result.productId(), result.liked());
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishProductRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishProductRepository.java
@@ -1,10 +1,13 @@
 package org.sopt.snappinserver.domain.wish.repository;
 
+import java.util.Optional;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.sopt.snappinserver.domain.wish.domain.entity.WishProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WishProductRepository extends JpaRepository<WishProduct, Long> {
-
+    Optional<WishProduct> findByUserAndProduct(User user, Product product);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/PostWishProductService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/PostWishProductService.java
@@ -1,21 +1,15 @@
 package org.sopt.snappinserver.domain.wish.service;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
-import org.sopt.snappinserver.domain.portfolio.repository.PortfolioRepository;
 import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.sopt.snappinserver.domain.product.repository.ProductRepository;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.sopt.snappinserver.domain.user.repository.UserRepository;
-import org.sopt.snappinserver.domain.wish.domain.entity.WishPortfolio;
 import org.sopt.snappinserver.domain.wish.domain.entity.WishProduct;
 import org.sopt.snappinserver.domain.wish.domain.exception.WishErrorCode;
 import org.sopt.snappinserver.domain.wish.domain.exception.WishException;
-import org.sopt.snappinserver.domain.wish.repository.WishPortfolioRepository;
 import org.sopt.snappinserver.domain.wish.repository.WishProductRepository;
-import org.sopt.snappinserver.domain.wish.service.dto.response.WishPortfolioResult;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishProductResult;
-import org.sopt.snappinserver.domain.wish.service.usecase.PostWishPortfolioUseCase;
 import org.sopt.snappinserver.domain.wish.service.usecase.PostWishProductUseCase;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/PostWishProductService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/PostWishProductService.java
@@ -1,0 +1,63 @@
+package org.sopt.snappinserver.domain.wish.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
+import org.sopt.snappinserver.domain.portfolio.repository.PortfolioRepository;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.domain.product.repository.ProductRepository;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
+import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.sopt.snappinserver.domain.wish.domain.entity.WishPortfolio;
+import org.sopt.snappinserver.domain.wish.domain.entity.WishProduct;
+import org.sopt.snappinserver.domain.wish.domain.exception.WishErrorCode;
+import org.sopt.snappinserver.domain.wish.domain.exception.WishException;
+import org.sopt.snappinserver.domain.wish.repository.WishPortfolioRepository;
+import org.sopt.snappinserver.domain.wish.repository.WishProductRepository;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishPortfolioResult;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishProductResult;
+import org.sopt.snappinserver.domain.wish.service.usecase.PostWishPortfolioUseCase;
+import org.sopt.snappinserver.domain.wish.service.usecase.PostWishProductUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostWishProductService implements PostWishProductUseCase {
+
+    private final WishProductRepository wishProductRepository;
+    private final UserRepository userRepository;
+    private final ProductRepository productRepository;
+
+    @Override
+    @Transactional
+    public WishProductResult toggleProductWish(Long userId, Long productId) {
+        User user = getUser(userId);
+        Product product = getProduct(productId);
+
+        return wishProductRepository.findByUserAndProduct(user, product)
+            .map(existingWish -> cancelWish(existingWish, productId))
+            .orElseGet(() -> likeWish(user, product, productId));
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new WishException(WishErrorCode.USER_NOT_FOUND));
+    }
+
+    private Product getProduct(Long productId) {
+        return productRepository.findById(productId)
+            .orElseThrow(() -> new WishException(WishErrorCode.PORTFOLIO_NOT_FOUND));
+    }
+
+    private WishProductResult cancelWish(WishProduct existingWish, Long productId) {
+        wishProductRepository.delete(existingWish);
+        return WishProductResult.of(productId, false);
+    }
+
+    private WishProductResult likeWish(User user, Product product, Long productId) {
+        WishProduct newWish = WishProduct.create(user, product);
+        wishProductRepository.save(newWish);
+        return WishProductResult.of(productId, true);
+    }
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/PostWishProductService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/PostWishProductService.java
@@ -40,7 +40,7 @@ public class PostWishProductService implements PostWishProductUseCase {
 
     private Product getProduct(Long productId) {
         return productRepository.findById(productId)
-            .orElseThrow(() -> new WishException(WishErrorCode.PORTFOLIO_NOT_FOUND));
+            .orElseThrow(() -> new WishException(WishErrorCode.PRODUCT_NOT_FOUND));
     }
 
     private WishProductResult cancelWish(WishProduct existingWish, Long productId) {

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishProductResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishProductResult.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.wish.service.dto.response;
+
+public record WishProductResult(Long productId, Boolean liked) {
+
+    public static WishProductResult of(Long productId, Boolean liked) {
+        return new WishProductResult(productId, liked);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/usecase/PostWishProductUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/usecase/PostWishProductUseCase.java
@@ -1,0 +1,7 @@
+package org.sopt.snappinserver.domain.wish.service.usecase;
+
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishProductResult;
+
+public interface PostWishProductUseCase {
+    WishProductResult toggleProductWish(Long userId, Long productId);
+}


### PR DESCRIPTION
## 👀 Summary

- close #67 

상품 좋아요/취소(토글) API를 구현했습니다.
인증된 사용자가 특정 상품 에 대해 좋아요를 추가하거나, 이미 좋아요한 경우 취소할 수 있습니다.


## 🖇️ Tasks
- [x] 상품 좋아요 토글 유즈케이스 인터페이스 정의
- [x] 좋아요/취소 토글 비즈니스 로직 서비스 구현
- [x] 좋아요 요청/응답 DTO 및 도메인 결과 객체(WishProduct)Result) 추가
- [x] 좋아요 API 인터페이스 및 컨트롤러 구현
- [x] 좋아요/취소 결과에 따라 SuccessCode를 분기 처리하도록 응답 구성
- [x] Swagger 문서화를 위한 요청/응답 스키마 정의


## 🔍 To Reviewer

### ❶ 토글 형태 설계
클라이언트에서 현재 좋아요 상태를 알지 못 하더라도 요청할 수 있도록 하기 위해, 좋아요 추가/취소를 하나의 POST API로 처리했습니다.
서버에서는 (user, product) 기준으로 기존 위시 존재 여부를 확인해 존재 시 취소, 미존재 시 생성하는 방식으로 동작합니다.

### ❷ 좋아요/취소 성공 코드 분기 처리 계층
Service에서는 도메인 사실(liked 여부)만 판단하고 반환하도록 했습니다.
좋아요 성공 / 취소 성공에 따른 API 의미(SuccessCode) 결정은 Controller에서 처리하여 HTTP/API 계층 책임을 분리했습니다.

### ❸ 토글 로직 가독성에 대한 고민
서비스 계층에서 단순 `if/else + null` 체크 대신 `Optional.map / orElseGet + cancelWish / likeWish` 메서드로 분리하여 있으면 취소, 없으면 좋아요 처리하는 흐름이 한 눈에 보이도록 구성했고, 로직 자체를 쪼개기보다는 의미 단위가 코드 구조에 드러나도록 하는 데 집중했습니다.

> 이전에 구현한 포트폴리오 좋아요/취소 API(#52)와 로직이 완전히 동일하니, 이 점 참고해주세요!