### PR TITLE
[FEAT] #74: 상품 운영 시작, 종료일 컬럼 삭제 및 프로젝트 사소한 설정 추가

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,6 +51,8 @@ services:
     image: redis:7
     container_name: redis
     restart: always
+    ports:
+      - "6379:6379"
     networks: [backend]
 
 networks:

--- a/src/main/java/org/sopt/snappinserver/domain/product/domain/entity/Product.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/domain/entity/Product.java
@@ -11,7 +11,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -70,12 +69,6 @@ public class Product extends BaseEntity {
     @Column(length = MAX_CAUTION_LENGTH)
     private String caution;
 
-    @Column(columnDefinition = "TIMESTAMP WITHOUT TIME ZONE", nullable = false)
-    private LocalDateTime startsAt;
-
-    @Column(columnDefinition = "TIMESTAMP WITHOUT TIME ZONE", nullable = false)
-    private LocalDateTime endsAt;
-
     @Builder(access = AccessLevel.PRIVATE)
     private Product(
         Photographer photographer,
@@ -85,9 +78,7 @@ public class Product extends BaseEntity {
         String description,
         String equipment,
         String processDescription,
-        String caution,
-        LocalDateTime startsAt,
-        LocalDateTime endsAt
+        String caution
     ) {
         this.photographer = photographer;
         this.title = title;
@@ -97,8 +88,6 @@ public class Product extends BaseEntity {
         this.equipment = equipment;
         this.processDescription = processDescription;
         this.caution = caution;
-        this.startsAt = startsAt;
-        this.endsAt = endsAt;
     }
 
     public static Product create(
@@ -109,9 +98,7 @@ public class Product extends BaseEntity {
         String description,
         String equipment,
         String processDescription,
-        String caution,
-        LocalDateTime startsAt,
-        LocalDateTime endsAt
+        String caution
     ) {
         validateProduct(
             photographer,
@@ -121,9 +108,7 @@ public class Product extends BaseEntity {
             description,
             equipment,
             processDescription,
-            caution,
-            startsAt,
-            endsAt
+            caution
         );
         return Product.builder()
             .photographer(photographer)
@@ -134,8 +119,6 @@ public class Product extends BaseEntity {
             .equipment(equipment)
             .processDescription(processDescription)
             .caution(caution)
-            .startsAt(startsAt)
-            .endsAt(endsAt)
             .build();
     }
 
@@ -147,9 +130,7 @@ public class Product extends BaseEntity {
         String description,
         String equipment,
         String processDescription,
-        String caution,
-        LocalDateTime startsAt,
-        LocalDateTime endsAt
+        String caution
     ) {
         validatePhotographerExists(photographer);
         validateTitle(title);
@@ -159,7 +140,6 @@ public class Product extends BaseEntity {
         validateEquipmentLength(equipment);
         validateProcessDescriptionLength(processDescription);
         validateCautionLength(caution);
-        validateTime(startsAt, endsAt);
     }
 
     private static void validatePhotographerExists(Photographer photographer) {
@@ -237,30 +217,6 @@ public class Product extends BaseEntity {
     private static void validateCautionLength(String caution) {
         if (caution != null && caution.length() > MAX_CAUTION_LENGTH) {
             throw new ProductException(ProductErrorCode.CAUTION_TOO_LONG);
-        }
-    }
-
-    private static void validateTime(LocalDateTime startsAt, LocalDateTime endsAt) {
-        validateStartsAtExists(startsAt);
-        validateEndsAtExists(endsAt);
-        validateTimeOrder(startsAt, endsAt);
-    }
-
-    private static void validateStartsAtExists(LocalDateTime startsAt) {
-        if (startsAt == null) {
-            throw new ProductException(ProductErrorCode.STARTS_AT_REQUIRED);
-        }
-    }
-
-    private static void validateEndsAtExists(LocalDateTime endsAt) {
-        if (endsAt == null) {
-            throw new ProductException(ProductErrorCode.ENDS_AT_REQUIRED);
-        }
-    }
-
-    private static void validateTimeOrder(LocalDateTime startsAt, LocalDateTime endsAt) {
-        if (startsAt.isAfter(endsAt) || startsAt.isEqual(endsAt)) {
-            throw new ProductException(ProductErrorCode.STARTS_AT_AFTER_ENDS_AT);
         }
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/domain/exception/ProductErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/domain/exception/ProductErrorCode.java
@@ -20,16 +20,15 @@ public enum ProductErrorCode implements ErrorCode {
     EQUIPMENT_TOO_LONG(400, "PRODUCT_400_009", "사용 장비 설명 길이는 512자 이하입니다."),
     PROCESS_DESCRIPTION_TOO_LONG(400, "PRODUCT_400_010", "촬영 진행 순서 길이는 1024자 이하입니다."),
     CAUTION_TOO_LONG(400, "PRODUCT_400_011", "기타 주의 사항 길이는 1024자 이하입니다."),
-    STARTS_AT_REQUIRED(400, "PRODUCT_400_012", "예약 운영 시작일은 필수입니다."),
-    ENDS_AT_REQUIRED(400, "PRODUCT_400_013", "예약 운영 종료일은 필수입니다."),
-    STARTS_AT_AFTER_ENDS_AT(400, "PRODUCT_400_014", "예약 운영 시작일이 예약 운영 종료일보다 앞서야 합니다."),
-    PRODUCT_REQUIRED(400, "PRODUCT_400_015", ""),
-    PRODUCT_OPTION_CATEGORY_REQUIRED(400, "PRODUCT_400_016", ""),
-    ANSWER_REQUIRED(400, "PRODUCT_400_017", ""),
-    ANSWER_TOO_LONG(400, "PRODUCT_400_018", ""),
-    INVALID_CURSOR(400, "PRODUCT_400_019", "유효하지 않은 커서 값입니다."),
-    DURATION_TIME_REQUIRED(400, "PRODUCT_400_020", "촬영 시간 옵션은 필수입니다."),
-    PRODUCT_UNAVAILABLE_DATE(400, "PRODUCT_400_021", "예약이 불가능한 날짜입니다."),
+    STARTS_AT_AFTER_ENDS_AT(400, "PRODUCT_400_012", "예약 운영 시작일이 예약 운영 종료일보다 앞서야 합니다."),
+    PRODUCT_REQUIRED(400, "PRODUCT_400_013", "상품은 필수입니다."),
+    PRODUCT_OPTION_CATEGORY_REQUIRED(400, "PRODUCT_400_014", "상품 옵션 종류는 필수입니다."),
+    ANSWER_REQUIRED(400, "PRODUCT_400_015", "상품 옵션 내용은 필수입니다."),
+    ANSWER_TOO_LONG(400, "PRODUCT_400_016", "상품 옵션 내용 길이는 1024자 이하입니다."),
+    INVALID_CURSOR(400, "PRODUCT_400_017", "유효하지 않은 커서 값입니다."),
+    DURATION_TIME_REQUIRED(400, "PRODUCT_400_018", "촬영 시간 옵션은 필수입니다."),
+    PRODUCT_UNAVAILABLE_DATE(400, "PRODUCT_400_019", "예약이 불가능한 날짜입니다."),
+
     // 401 UNAUTHORIZED
 
     // 403 FORBIDDEN

--- a/src/main/java/org/sopt/snappinserver/domain/product/domain/exception/ProductErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/domain/exception/ProductErrorCode.java
@@ -20,14 +20,13 @@ public enum ProductErrorCode implements ErrorCode {
     EQUIPMENT_TOO_LONG(400, "PRODUCT_400_009", "사용 장비 설명 길이는 512자 이하입니다."),
     PROCESS_DESCRIPTION_TOO_LONG(400, "PRODUCT_400_010", "촬영 진행 순서 길이는 1024자 이하입니다."),
     CAUTION_TOO_LONG(400, "PRODUCT_400_011", "기타 주의 사항 길이는 1024자 이하입니다."),
-    STARTS_AT_AFTER_ENDS_AT(400, "PRODUCT_400_012", "예약 운영 시작일이 예약 운영 종료일보다 앞서야 합니다."),
-    PRODUCT_REQUIRED(400, "PRODUCT_400_013", "상품은 필수입니다."),
-    PRODUCT_OPTION_CATEGORY_REQUIRED(400, "PRODUCT_400_014", "상품 옵션 종류는 필수입니다."),
-    ANSWER_REQUIRED(400, "PRODUCT_400_015", "상품 옵션 내용은 필수입니다."),
-    ANSWER_TOO_LONG(400, "PRODUCT_400_016", "상품 옵션 내용 길이는 1024자 이하입니다."),
-    INVALID_CURSOR(400, "PRODUCT_400_017", "유효하지 않은 커서 값입니다."),
-    DURATION_TIME_REQUIRED(400, "PRODUCT_400_018", "촬영 시간 옵션은 필수입니다."),
-    PRODUCT_UNAVAILABLE_DATE(400, "PRODUCT_400_019", "예약이 불가능한 날짜입니다."),
+    PRODUCT_REQUIRED(400, "PRODUCT_400_012", "상품은 필수입니다."),
+    PRODUCT_OPTION_CATEGORY_REQUIRED(400, "PRODUCT_400_013", "상품 옵션 종류는 필수입니다."),
+    ANSWER_REQUIRED(400, "PRODUCT_400_014", "상품 옵션 내용은 필수입니다."),
+    ANSWER_TOO_LONG(400, "PRODUCT_400_015", "상품 옵션 내용 길이는 1024자 이하입니다."),
+    INVALID_CURSOR(400, "PRODUCT_400_016", "유효하지 않은 커서 값입니다."),
+    DURATION_TIME_REQUIRED(400, "PRODUCT_400_017", "촬영 시간 옵션은 필수입니다."),
+    PRODUCT_UNAVAILABLE_DATE(400, "PRODUCT_400_018", "예약이 불가능한 날짜입니다."),
 
     // 401 UNAUTHORIZED
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,11 @@ spring:
     jdbc:
       initialize-schema: never
 
+  security:
+    user:
+      name: disabled
+      password: disabled
+
 springdoc:
   swagger-ui:
     tags-sorter: alpha


### PR DESCRIPTION
## 👀 Summary

- close #74


## 🖇️ Tasks

- 기획 요구사항에 따라 상품 운영 시작, 종료일 컬럼을 상품 테이블에서 삭제합니다.
- 프로젝트 실행 시 스프링 시큐리티 기본 사용자를 비활성화합니다.
- Datagrip에 dev 에서 실행되는 redis를 관리할 수 있도록 docker-compose.dev.yml에서 컨테이너 포트와 호스트 포트를 바인딩했습니다.


## 🔍 To Reviewer

### 로컬 DB 반영 관련
ddl-auto: update에서는 컬럼 추가, 수정만 반영되고 삭제는 위험 이슈가 있어 반영되지 않습니다. dev db에는 제가 직접 반영했고, 성하님 로컬 DB에 콘솔 켜서 다음 SQL문 실행해주세요.

```SQL
ALTER TABLE product DROP COLUMN starts_at;
ALTER TABLE product DROP COLUMN ends_at;
```
