### PR TITLE
[FEAT] #77: 작가 상세 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/photographer/code/PhotographerSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/photographer/code/PhotographerSuccessCode.java
@@ -1,0 +1,21 @@
+package org.sopt.snappinserver.api.photographer.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.global.response.code.common.SuccessCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum PhotographerSuccessCode implements SuccessCode {
+
+    // 200 OK
+    GET_PHOTOGRAPHER_PROFILE_OK(200, "PHOTOGRAPHER_200_001", "성공적으로 작가 프로필을 조회했습니다."),
+
+    // 201 CREATED
+
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerApi.java
@@ -3,6 +3,8 @@ package org.sopt.snappinserver.api.photographer.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import org.sopt.snappinserver.api.photographer.dto.response.PhotographerProfileResponse;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.validation.annotation.Validated;
@@ -18,6 +20,8 @@ public interface PhotographerApi {
     )
     ApiResponseBody<PhotographerProfileResponse, Void> getPhotographerProfile(
         @Schema(description = "조회할 작가 ID")
+        @NotNull(message = "작가 ID는 필수입니다.")
+        @Positive(message = "작가 ID는 양수여야 합니다.")
         @PathVariable Long photographerId
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerApi.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-import org.sopt.snappinserver.api.photographer.dto.response.PhotographerProfileResponse;
+import org.sopt.snappinserver.api.photographer.dto.response.GetPhotographerProfileResponse;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,7 +18,7 @@ public interface PhotographerApi {
         summary = "작가 상세 조회 API",
         description = "입력받은 photographerId로 해당 작가의 프로필을 조회합니다."
     )
-    ApiResponseBody<PhotographerProfileResponse, Void> getPhotographerProfile(
+    ApiResponseBody<GetPhotographerProfileResponse, Void> getPhotographerProfile(
         @Schema(description = "조회할 작가 ID")
         @NotNull(message = "작가 ID는 필수입니다.")
         @Positive(message = "작가 ID는 양수여야 합니다.")

--- a/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerApi.java
@@ -1,8 +1,23 @@
 package org.sopt.snappinserver.api.photographer.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.snappinserver.api.photographer.dto.response.PhotographerProfileResponse;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "02 - Photographer", description = "스냅 작가 관련 API")
+@Validated
 public interface PhotographerApi {
 
+    @Operation(
+        summary = "작가 상세 조회 API",
+        description = "입력받은 photographerId로 해당 작가의 프로필을 조회합니다."
+    )
+    ApiResponseBody<PhotographerProfileResponse, Void> getPhotographerProfile(
+        @Schema(description = "조회할 작가 ID")
+        @PathVariable Long photographerId
+    );
 }

--- a/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerController.java
+++ b/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerController.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.photographer.code.PhotographerSuccessCode;
 import org.sopt.snappinserver.api.photographer.dto.response.GetPhotographerProfileResponse;
 import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerProfileResult;
-import org.sopt.snappinserver.domain.photographer.service.dto.usecase.GetPhotographerProfileUseCase;
+import org.sopt.snappinserver.domain.photographer.service.usecase.GetPhotographerProfileUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerController.java
+++ b/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerController.java
@@ -23,7 +23,7 @@ public class PhotographerController implements PhotographerApi {
         Long photographerId
     ) {
         GetPhotographerProfileResult result = getPhotographerProfileUseCase
-            .findPhotographerProfile(photographerId);
+            .getPhotographerProfile(photographerId);
         PhotographerProfileResponse response = PhotographerProfileResponse.from(result);
 
         return ApiResponseBody.ok(PhotographerSuccessCode.GET_PHOTOGRAPHER_PROFILE_OK, response);

--- a/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerController.java
+++ b/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerController.java
@@ -2,7 +2,7 @@ package org.sopt.snappinserver.api.photographer.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.photographer.code.PhotographerSuccessCode;
-import org.sopt.snappinserver.api.photographer.dto.response.PhotographerProfileResponse;
+import org.sopt.snappinserver.api.photographer.dto.response.GetPhotographerProfileResponse;
 import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerProfileResult;
 import org.sopt.snappinserver.domain.photographer.service.dto.usecase.GetPhotographerProfileUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
@@ -19,12 +19,12 @@ public class PhotographerController implements PhotographerApi {
 
     @Override
     @GetMapping("/{photographerId}")
-    public ApiResponseBody<PhotographerProfileResponse, Void> getPhotographerProfile(
+    public ApiResponseBody<GetPhotographerProfileResponse, Void> getPhotographerProfile(
         Long photographerId
     ) {
         GetPhotographerProfileResult result = getPhotographerProfileUseCase
             .getPhotographerProfile(photographerId);
-        PhotographerProfileResponse response = PhotographerProfileResponse.from(result);
+        GetPhotographerProfileResponse response = GetPhotographerProfileResponse.from(result);
 
         return ApiResponseBody.ok(PhotographerSuccessCode.GET_PHOTOGRAPHER_PROFILE_OK, response);
     }

--- a/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerController.java
+++ b/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerController.java
@@ -18,7 +18,7 @@ public class PhotographerController implements PhotographerApi {
     private final GetPhotographerProfileUseCase getPhotographerProfileUseCase;
 
     @Override
-    @GetMapping
+    @GetMapping("/{photographerId}")
     public ApiResponseBody<PhotographerProfileResponse, Void> getPhotographerProfile(
         Long photographerId
     ) {

--- a/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerController.java
+++ b/src/main/java/org/sopt/snappinserver/api/photographer/controller/PhotographerController.java
@@ -1,12 +1,31 @@
 package org.sopt.snappinserver.api.photographer.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.photographer.code.PhotographerSuccessCode;
+import org.sopt.snappinserver.api.photographer.dto.response.PhotographerProfileResponse;
+import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerProfileResult;
+import org.sopt.snappinserver.domain.photographer.service.dto.usecase.GetPhotographerProfileUseCase;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/photographers")
 @RequiredArgsConstructor
 @RestController
-public class PhotographerController implements PhotographerApi{
+public class PhotographerController implements PhotographerApi {
 
+    private final GetPhotographerProfileUseCase getPhotographerProfileUseCase;
+
+    @Override
+    @GetMapping
+    public ApiResponseBody<PhotographerProfileResponse, Void> getPhotographerProfile(
+        Long photographerId
+    ) {
+        GetPhotographerProfileResult result = getPhotographerProfileUseCase
+            .findPhotographerProfile(photographerId);
+        PhotographerProfileResponse response = PhotographerProfileResponse.from(result);
+
+        return ApiResponseBody.ok(PhotographerSuccessCode.GET_PHOTOGRAPHER_PROFILE_OK, response);
+    }
 }

--- a/src/main/java/org/sopt/snappinserver/api/photographer/dto/response/GetPhotographerProfileResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/photographer/dto/response/GetPhotographerProfileResponse.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerProfileResult;
 
 @Schema(description = "작가 상세 조회 응답 DTO")
-public record PhotographerProfileResponse(
+public record GetPhotographerProfileResponse(
 
     @Schema(description = "작가 ID", example = "1")
     Long id,
@@ -23,8 +23,8 @@ public record PhotographerProfileResponse(
     List<String> locations
 ) {
 
-    public static PhotographerProfileResponse from(GetPhotographerProfileResult result) {
-        return new PhotographerProfileResponse(
+    public static GetPhotographerProfileResponse from(GetPhotographerProfileResult result) {
+        return new GetPhotographerProfileResponse(
             result.id(),
             result.name(),
             result.bio(),

--- a/src/main/java/org/sopt/snappinserver/api/photographer/dto/response/PhotographerProfileResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/photographer/dto/response/PhotographerProfileResponse.java
@@ -1,0 +1,35 @@
+package org.sopt.snappinserver.api.photographer.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerProfileResult;
+
+@Schema(description = "작가 상세 조회 응답 DTO")
+public record PhotographerProfileResponse(
+
+    @Schema(description = "작가 ID", example = "1")
+    Long id,
+
+    @Schema(description = "작가가 설정한 작가명", example = "스윙스냅")
+    String name,
+
+    @Schema(description = "작가 한 줄 소개", example = "일상의 아름다움을 포착합니다")
+    String bio,
+
+    @Schema(description = "촬영 상품", example = "[ \"졸업스냅\", \"웨딩스냅\" ]")
+    List<String> specialties,
+
+    @Schema(description = "활동 지역", example = "[ \"서울\", \"인천\" ]")
+    List<String> locations
+) {
+
+    public static PhotographerProfileResponse from(GetPhotographerProfileResult result) {
+        return new PhotographerProfileResponse(
+            result.id(),
+            result.name(),
+            result.bio(),
+            result.specialties(),
+            result.locations()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/Photographer.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/Photographer.java
@@ -11,6 +11,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -54,10 +57,6 @@ public class Photographer extends BaseEntity {
     @Column(nullable = false)
     private Gender gender;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private SnapCategory specialty;
-
     @Column(length = MAX_BIO_LENGTH)
     private String bio;
 
@@ -67,14 +66,12 @@ public class Photographer extends BaseEntity {
         String name,
         String nickname,
         Gender gender,
-        SnapCategory specialty,
         String bio
     ) {
         this.user = user;
         this.name = name;
         this.nickname = nickname;
         this.gender = gender;
-        this.specialty = specialty;
         this.bio = bio;
     }
 
@@ -83,16 +80,14 @@ public class Photographer extends BaseEntity {
         String name,
         String nickname,
         Gender gender,
-        SnapCategory specialty,
         String bio
     ) {
-        validatePhotographer(user, name, nickname, gender, specialty, bio);
+        validatePhotographer(user, name, nickname, gender, bio);
         return Photographer.builder()
             .user(user)
             .name(name)
             .nickname(nickname)
             .gender(gender)
-            .specialty(specialty)
             .bio(bio)
             .build();
     }
@@ -102,14 +97,12 @@ public class Photographer extends BaseEntity {
         String name,
         String nickname,
         Gender gender,
-        SnapCategory specialty,
         String bio
     ) {
         validateUserExists(user);
         validateName(name);
         validateNickname(nickname);
         validateGenderExists(gender);
-        validateSpecialtyExists(specialty);
         validateBioLength(bio);
     }
 
@@ -156,12 +149,6 @@ public class Photographer extends BaseEntity {
     private static void validateGenderExists(Gender gender) {
         if (gender == null) {
             throw new PhotographerException(PhotographerErrorCode.GENDER_REQUIRED);
-        }
-    }
-
-    private static void validateSpecialtyExists(SnapCategory specialty) {
-        if (specialty == null) {
-            throw new PhotographerException(PhotographerErrorCode.SPECIALTY_REQUIRED);
         }
     }
 

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/Photographer.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/Photographer.java
@@ -11,19 +11,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.snappinserver.domain.photographer.domain.exception.PhotographerErrorCode;
 import org.sopt.snappinserver.domain.photographer.domain.exception.PhotographerException;
-import org.sopt.snappinserver.global.enums.Gender;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.sopt.snappinserver.global.entity.BaseEntity;
-import org.sopt.snappinserver.global.enums.SnapCategory;
+import org.sopt.snappinserver.global.enums.Gender;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/PhotographerAvailableLocation.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/PhotographerAvailableLocation.java
@@ -1,0 +1,94 @@
+package org.sopt.snappinserver.domain.photographer.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.snappinserver.domain.photographer.domain.exception.PhotographerErrorCode;
+import org.sopt.snappinserver.domain.photographer.domain.exception.PhotographerException;
+import org.sopt.snappinserver.domain.place.domain.entity.AvailableLocation;
+import org.sopt.snappinserver.global.entity.BaseEntity;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+    name = "photographer_available_location",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_photographer_available_location",
+            columnNames = {"photographer_id", "available_location_id"}
+        )
+    }
+)
+public class PhotographerAvailableLocation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "photographer_available_location_seq_gen")
+    @SequenceGenerator(
+        name = "photographer_available_location_seq_gen",
+        sequenceName = "photographer_available_location_specialty_seq",
+        allocationSize = 1
+    )
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "photographer_id", nullable = false)
+    private Photographer photographer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "available_location_id", nullable = false)
+    private AvailableLocation availableLocation;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private PhotographerAvailableLocation(
+        Photographer photographer,
+        AvailableLocation availableLocation
+    ) {
+        this.photographer = photographer;
+        this.availableLocation = availableLocation;
+    }
+
+    public static PhotographerAvailableLocation create(
+        Photographer photographer,
+        AvailableLocation availableLocation
+    ) {
+        validatePhotographerAvailableLocation(photographer, availableLocation);
+
+        return PhotographerAvailableLocation.builder()
+            .photographer(photographer)
+            .availableLocation(availableLocation)
+            .build();
+    }
+
+    private static void validatePhotographerAvailableLocation(
+        Photographer photographer,
+        AvailableLocation availableLocation
+    ) {
+        validatePhotographerExists(photographer);
+        validateAvailableLocationExists(availableLocation);
+    }
+
+    private static void validatePhotographerExists(Photographer photographer) {
+        if (photographer == null) {
+            throw new PhotographerException(PhotographerErrorCode.PHOTOGRAPHER_REQUIRED);
+        }
+    }
+
+    private static void validateAvailableLocationExists(AvailableLocation availableLocation) {
+        if (availableLocation == null) {
+            throw new PhotographerException(PhotographerErrorCode.AVAILABLE_LOCATION_REQUIRED);
+        }
+    }
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/PhotographerSpecialty.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/PhotographerSpecialty.java
@@ -19,6 +19,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.snappinserver.domain.photographer.domain.exception.PhotographerErrorCode;
 import org.sopt.snappinserver.domain.photographer.domain.exception.PhotographerException;
+import org.sopt.snappinserver.global.entity.BaseEntity;
 import org.sopt.snappinserver.global.enums.SnapCategory;
 
 @Getter
@@ -33,13 +34,13 @@ import org.sopt.snappinserver.global.enums.SnapCategory;
         )
     }
 )
-public class PhotographerSpecialty {
+public class PhotographerSpecialty extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "photographer_specialty_seq_gen")
     @SequenceGenerator(
-        name = "photographer_seq_gen",
-        sequenceName = "photographer_seq",
+        name = "photographer_specialty_seq_gen",
+        sequenceName = "photographer_specialty_seq",
         allocationSize = 1
     )
     private Long id;

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/PhotographerSpecialty.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/PhotographerSpecialty.java
@@ -1,0 +1,89 @@
+package org.sopt.snappinserver.domain.photographer.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.snappinserver.domain.photographer.domain.exception.PhotographerErrorCode;
+import org.sopt.snappinserver.domain.photographer.domain.exception.PhotographerException;
+import org.sopt.snappinserver.global.enums.SnapCategory;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+    name = "photographer_specialty",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_photographer_specialty",
+            columnNames = {"photographer_id", "specialty"}
+        )
+    }
+)
+public class PhotographerSpecialty {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @SequenceGenerator(
+        name = "photographer_seq_gen",
+        sequenceName = "photographer_seq",
+        allocationSize = 1
+    )
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "photographer_id", nullable = false)
+    private Photographer photographer;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "specialty", nullable = false)
+    private SnapCategory specialty;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private PhotographerSpecialty(Photographer photographer, SnapCategory specialty) {
+        this.photographer = photographer;
+        this.specialty = specialty;
+    }
+
+    public static PhotographerSpecialty create(Photographer photographer, SnapCategory specialty) {
+        validatePhotographerSpecialty(photographer, specialty);
+
+        return PhotographerSpecialty.builder()
+            .photographer(photographer)
+            .specialty(specialty)
+            .build();
+    }
+
+    private static void validatePhotographerSpecialty(
+        Photographer photographer,
+        SnapCategory specialty
+    ) {
+        validatePhotographerExists(photographer);
+        validateSpecialtyExists(specialty);
+    }
+
+    private static void validatePhotographerExists(Photographer photographer) {
+        if (photographer == null) {
+            throw new PhotographerException(PhotographerErrorCode.PHOTOGRAPHER_REQUIRED);
+        }
+    }
+
+    private static void validateSpecialtyExists(SnapCategory specialty) {
+        if (specialty == null) {
+            throw new PhotographerException(PhotographerErrorCode.SPECIALTY_REQUIRED);
+        }
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/domain/exception/PhotographerErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/domain/exception/PhotographerErrorCode.java
@@ -22,6 +22,7 @@ public enum PhotographerErrorCode implements ErrorCode {
     END_TIME_REQUIRED(400, "PHOTOGRAPHER_400_011", "종료 시각은 필수입니다."),
     START_TIME_AFTER_THAN_END_TIME(400, "PHOTOGRAPHER_400_012", "스케줄 시작 시간이 종료 시간보다 늦을 수 없습니다."),
     BIO_TOO_LONG(400, "PHOTOGRAPHER_400_013", "한 줄 소개 길이는 200자 이하입니다."),
+    AVAILABLE_LOCATION_REQUIRED(400, "PHOTOGRAPHER_400_014", "활동 지역은 필수입니다."),
 
     // 401 UNAUTHORIZED
 
@@ -29,6 +30,9 @@ public enum PhotographerErrorCode implements ErrorCode {
 
     // 404 NOT FOUND
     SCHEDULE_NOT_FOUND(404, "PHOTOGRAPHER_404_001", "해당 요일에 대한 작가 스케줄이 존재하지 않습니다."),
+    PHOTOGRAPHER_NOT_FOUND(404, "PHOTOGRAPHER_404_002", "해당 작가가 존재하지 않습니다."),
+    PHOTOGRAPHER_SPECIALTY_NOT_FOUND(404, "PHOTOGRAPHER_404_003", "해당 작가의 촬영 상품이 존재하지 않습니다."),
+    PHOTOGRAPHER_AVAILABLE_LOCATION_NOT_FOUND(404, "PHOTOGRAPHER_404_004", "해당 작가 활동 지역이 존재하지 않습니다."),
 
     ;
 

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/repository/PhotographerAvailableLocationRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/repository/PhotographerAvailableLocationRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.snappinserver.domain.photographer.repository;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+import org.sopt.snappinserver.domain.photographer.domain.entity.PhotographerAvailableLocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PhotographerAvailableLocationRepository
+    extends JpaRepository<PhotographerAvailableLocation, Long> {
+
+    List<PhotographerAvailableLocation> findAllByPhotographer(Photographer photographer);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/repository/PhotographerSpecialtyRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/repository/PhotographerSpecialtyRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.snappinserver.domain.photographer.repository;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+import org.sopt.snappinserver.domain.photographer.domain.entity.PhotographerSpecialty;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PhotographerSpecialtyRepository
+    extends JpaRepository<PhotographerSpecialty, Long> {
+
+    List<PhotographerSpecialty> findAllByPhotographer(Photographer photographer);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetPhotographerProfileService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetPhotographerProfileService.java
@@ -24,7 +24,7 @@ public class GetPhotographerProfileService implements GetPhotographerProfileUseC
     private final PhotographerSpecialtyRepository photographerSpecialtyRepository;
     private final PhotographerAvailableLocationRepository photographerAvailableLocationRepository;
 
-    public GetPhotographerProfileResult findPhotographerProfile(Long photographerId) {
+    public GetPhotographerProfileResult getPhotographerProfile(Long photographerId) {
         Photographer photographer = getExistingPhotographer(photographerId);
 
         List<PhotographerSpecialty> specialties = photographerSpecialtyRepository

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetPhotographerProfileService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetPhotographerProfileService.java
@@ -1,0 +1,64 @@
+package org.sopt.snappinserver.domain.photographer.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+import org.sopt.snappinserver.domain.photographer.domain.entity.PhotographerAvailableLocation;
+import org.sopt.snappinserver.domain.photographer.domain.entity.PhotographerSpecialty;
+import org.sopt.snappinserver.domain.photographer.domain.exception.PhotographerErrorCode;
+import org.sopt.snappinserver.domain.photographer.domain.exception.PhotographerException;
+import org.sopt.snappinserver.domain.photographer.repository.PhotographerAvailableLocationRepository;
+import org.sopt.snappinserver.domain.photographer.repository.PhotographerRepository;
+import org.sopt.snappinserver.domain.photographer.repository.PhotographerSpecialtyRepository;
+import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerProfileResult;
+import org.sopt.snappinserver.domain.photographer.service.dto.usecase.GetPhotographerProfileUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class GetPhotographerProfileService implements GetPhotographerProfileUseCase {
+
+    private final PhotographerRepository photographerRepository;
+    private final PhotographerSpecialtyRepository photographerSpecialtyRepository;
+    private final PhotographerAvailableLocationRepository photographerAvailableLocationRepository;
+
+    public GetPhotographerProfileResult findPhotographerProfile(Long photographerId) {
+        Photographer photographer = getExistingPhotographer(photographerId);
+
+        List<PhotographerSpecialty> specialties = photographerSpecialtyRepository
+            .findAllByPhotographer(photographer);
+        validateSpecialtyExists(specialties);
+
+        List<PhotographerAvailableLocation> availableLocations = photographerAvailableLocationRepository
+            .findAllByPhotographer(photographer);
+        validateAvailableLocationExists(availableLocations);
+
+        return null;
+    }
+
+    private Photographer getExistingPhotographer(Long photographerId) {
+        return photographerRepository.findById(photographerId)
+            .orElseThrow(
+                () -> new PhotographerException(PhotographerErrorCode.PHOTOGRAPHER_NOT_FOUND)
+            );
+    }
+
+    private void validateSpecialtyExists(List<PhotographerSpecialty> specialties) {
+        if (specialties.isEmpty()) {
+            throw new PhotographerException(PhotographerErrorCode.PHOTOGRAPHER_SPECIALTY_NOT_FOUND);
+        }
+    }
+
+    private void validateAvailableLocationExists(
+        List<PhotographerAvailableLocation> availableLocations
+    ) {
+        if (availableLocations.isEmpty()) {
+            throw new PhotographerException(
+                PhotographerErrorCode.PHOTOGRAPHER_AVAILABLE_LOCATION_NOT_FOUND
+            );
+        }
+    }
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetPhotographerProfileService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetPhotographerProfileService.java
@@ -11,7 +11,7 @@ import org.sopt.snappinserver.domain.photographer.repository.PhotographerAvailab
 import org.sopt.snappinserver.domain.photographer.repository.PhotographerRepository;
 import org.sopt.snappinserver.domain.photographer.repository.PhotographerSpecialtyRepository;
 import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerProfileResult;
-import org.sopt.snappinserver.domain.photographer.service.dto.usecase.GetPhotographerProfileUseCase;
+import org.sopt.snappinserver.domain.photographer.service.usecase.GetPhotographerProfileUseCase;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetPhotographerProfileService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetPhotographerProfileService.java
@@ -35,7 +35,7 @@ public class GetPhotographerProfileService implements GetPhotographerProfileUseC
             .findAllByPhotographer(photographer);
         validateAvailableLocationExists(availableLocations);
 
-        return null;
+        return GetPhotographerProfileResult.of(photographer, specialties, availableLocations);
     }
 
     private Photographer getExistingPhotographer(Long photographerId) {

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/dto/response/GetPhotographerProfileResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/dto/response/GetPhotographerProfileResult.java
@@ -1,0 +1,39 @@
+package org.sopt.snappinserver.domain.photographer.service.dto.response;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+import org.sopt.snappinserver.domain.photographer.domain.entity.PhotographerAvailableLocation;
+import org.sopt.snappinserver.domain.photographer.domain.entity.PhotographerSpecialty;
+import org.sopt.snappinserver.domain.place.domain.entity.AvailableLocation;
+import org.sopt.snappinserver.global.enums.SnapCategory;
+
+public record GetPhotographerProfileResult(
+    Long id,
+    String name,
+    String bio,
+    List<String> specialties,
+    List<String> locations
+) {
+
+    public static GetPhotographerProfileResult of(
+        Photographer photographer,
+        List<PhotographerSpecialty> specialties,
+        List<PhotographerAvailableLocation> locations
+    ) {
+        return new GetPhotographerProfileResult(
+            photographer.getId(),
+            photographer.getNickname(),
+            photographer.getBio(),
+
+            specialties.stream()
+                .map(PhotographerSpecialty::getSpecialty)
+                .map(SnapCategory::getCategory)
+                .toList(),
+
+            locations.stream()
+                .map(PhotographerAvailableLocation::getAvailableLocation)
+                .map(AvailableLocation::getFullLocation)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/dto/usecase/GetPhotographerProfileUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/dto/usecase/GetPhotographerProfileUseCase.java
@@ -4,5 +4,5 @@ import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotog
 
 public interface GetPhotographerProfileUseCase {
 
-    GetPhotographerProfileResult findPhotographerProfile(Long photographerId);
+    GetPhotographerProfileResult getPhotographerProfile(Long photographerId);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/dto/usecase/GetPhotographerProfileUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/dto/usecase/GetPhotographerProfileUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.photographer.service.dto.usecase;
+
+import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerProfileResult;
+
+public interface GetPhotographerProfileUseCase {
+
+    GetPhotographerProfileResult findPhotographerProfile(Long photographerId);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/usecase/GetPhotographerProfileUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/usecase/GetPhotographerProfileUseCase.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.domain.photographer.service.dto.usecase;
+package org.sopt.snappinserver.domain.photographer.service.usecase;
 
 import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerProfileResult;
 

--- a/src/main/java/org/sopt/snappinserver/domain/place/domain/entity/AvailableLocation.java
+++ b/src/main/java/org/sopt/snappinserver/domain/place/domain/entity/AvailableLocation.java
@@ -85,4 +85,11 @@ public class AvailableLocation extends BaseEntity {
             throw new PlaceException(PlaceErrorCode.SIGUNGU_TOO_LONG);
         }
     }
+
+    public String getFullLocation() {
+        if (sigungu == null || sigungu.isBlank()) {
+            return sido;
+        }
+        return sido + " " + sigungu;
+    }
 }


### PR DESCRIPTION
## 👀 Summary

- close #77


## 🖇️ Tasks

- 작가 촬영 상품 엔티티(PhotographerSnapCategory) 추가
- 작가 활동 지역 엔티티(PhotographerAvailableLocation) 추가
- 작가 상세 조회 스웨거 API 인터페이스 구현
- 작가 상세 조회 컨트롤러단 구현
- 작가 상세 조회 컨트롤러, 서비스단 DTO 분리
- 작가 상세 조회 서비스 코드 구현


## 🔍 To Reviewer

### ❶ 엔티티 변경
작가 촬영 상품이 여러 가지일 수 있어서 기존 작가 엔티티에서 specialty 컬럼을 삭제하고, 작가와 촬영 상품 카테고리를 가지는 중간 테이블을 생성했습니다. 또한, 작가 활동 지역을 기존에 고려하지 않았어서 작가 활동 지역 엔티티도 함께 추가했습니다. 작가 엔티티 컬럼에 따라 아래 SQL문을 로컬에서 꼭 실행해주세요!

```SQL
ALTER TABLE photographer
DROP COLUMN specialty;
````

### ❷ 전체 흐름
1. 작가 id를 받아서
2. 컨트롤러 DTO에서 null 여부, 양수 여부를 검증하고
3. 서비스 호출하여
4. 작가 객체 가져오고,
5. 작가 객체로 작가 촬영상품 목록 조회,
6. 작가 촬영상품 목록이 빈 경우 404 예외 발생 (반드시 있어야 함)
7.  작가 객체로 작가 활동지역 목록 조회
8. 작가 활동지역 목록이 빈 경우 404 예외 발생 (반드시 있어야 함) 
9. 서비스단 DTO에서 객체 목록을 문자열 배열로 반환
10. 컨트롤러 단에서 Response DTO로 변환 후 프론트에 전달

