### PR TITLE
[FEAT] #68: 위시 포트폴리오 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/wish/code/WishSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/code/WishSuccessCode.java
@@ -11,8 +11,8 @@ public enum WishSuccessCode implements SuccessCode {
     POST_WISH_LIKE_PORTFOLIO_OK(200, "WISH_200_001", "포트폴리오 좋아요 처리에 성공했습니다."),
     POST_WISH_CANCEL_PORTFOLIO_OK(200, "WISH_200_002", "포트폴리오 좋아요 취소에 성공했습니다."),
     POST_WISH_LIKE_PRODUCT_OK(200, "WISH_200_003", "상품 좋아요 처리에 성공했습니다."),
-    POST_WISH_CANCEL_PRODUCT_OK(200, "WISH_200_004", "상품 좋아요 취소에 성공했습니다.");
-
+    POST_WISH_CANCEL_PRODUCT_OK(200, "WISH_200_004", "상품 좋아요 취소에 성공했습니다."),
+    GET_WISHED_PORTFOLIOS_OK(200, "WISH_200_005", "좋아요한 포트폴리오 목록 조회에 성공했습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/org/sopt/snappinserver/api/wish/controller/WishApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/controller/WishApi.java
@@ -8,9 +8,11 @@ import org.sopt.snappinserver.api.wish.dto.request.WishPortfolioRequest;
 import org.sopt.snappinserver.api.wish.dto.request.WishProductRequest;
 import org.sopt.snappinserver.api.wish.dto.response.WishPortfolioResponse;
 import org.sopt.snappinserver.api.wish.dto.response.WishProductResponse;
+import org.sopt.snappinserver.api.wish.dto.response.WishedPortfoliosResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -28,7 +30,8 @@ public interface WishApi {
         @Parameter(hidden = true)
         CustomUserInfo userInfo,
 
-        @Valid @RequestBody WishPortfolioRequest request);
+        @Valid @RequestBody WishPortfolioRequest request
+    );
 
     @Operation(
         summary = "상품 좋아요/취소",
@@ -40,5 +43,18 @@ public interface WishApi {
         @Parameter(hidden = true)
         CustomUserInfo userInfo,
 
-        @Valid @RequestBody WishProductRequest request);
+        @Valid @RequestBody WishProductRequest request
+    );
+
+    @Operation(
+        summary = "위시 포트폴리오 목록 조회",
+        description = "사용자가 좋아요한 전체 포트폴리오 목록을 조회합니다."
+    )
+    @GetMapping("/portfolios")
+    ApiResponseBody<WishedPortfoliosResponse, Void> getWishedPortfolios(
+
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo
+    );
+
 }

--- a/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
@@ -8,7 +8,6 @@ import org.sopt.snappinserver.api.wish.dto.response.WishPortfolioResponse;
 import org.sopt.snappinserver.api.wish.dto.response.WishProductResponse;
 import org.sopt.snappinserver.api.wish.dto.response.WishedPortfoliosResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
-import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewPageResult;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishPortfolioResult;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishProductResult;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosResult;

--- a/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
@@ -1,14 +1,21 @@
 package org.sopt.snappinserver.api.wish.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.product.code.ProductSuccessCode;
+import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaResponse;
+import org.sopt.snappinserver.api.product.dto.response.ProductReviewsResponse;
 import org.sopt.snappinserver.api.wish.code.WishSuccessCode;
 import org.sopt.snappinserver.api.wish.dto.request.WishPortfolioRequest;
 import org.sopt.snappinserver.api.wish.dto.request.WishProductRequest;
 import org.sopt.snappinserver.api.wish.dto.response.WishPortfolioResponse;
 import org.sopt.snappinserver.api.wish.dto.response.WishProductResponse;
+import org.sopt.snappinserver.api.wish.dto.response.WishedPortfoliosResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewPageResult;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishPortfolioResult;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishProductResult;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosResult;
+import org.sopt.snappinserver.domain.wish.service.usecase.GetWishedPortfoliosUseCase;
 import org.sopt.snappinserver.domain.wish.service.usecase.PostWishPortfolioUseCase;
 import org.sopt.snappinserver.domain.wish.service.usecase.PostWishProductUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
@@ -23,6 +30,7 @@ public class WishController implements WishApi {
 
     private final PostWishPortfolioUseCase postWishPortfolioUseCase;
     private final PostWishProductUseCase postWishProductUseCase;
+    private final GetWishedPortfoliosUseCase getWishedPortfoliosUseCase;
 
     @Override
     public ApiResponseBody<WishPortfolioResponse, Void> updateWishPortfolio(
@@ -61,4 +69,18 @@ public class WishController implements WishApi {
         return result.liked() ? WishSuccessCode.POST_WISH_LIKE_PRODUCT_OK
             : WishSuccessCode.POST_WISH_CANCEL_PRODUCT_OK;
     }
+
+    @Override
+    public ApiResponseBody<WishedPortfoliosResponse, Void> getWishedPortfolios(
+        @AuthenticationPrincipal CustomUserInfo userInfo
+    ) {
+        WishedPortfoliosResult result =
+            getWishedPortfoliosUseCase.getWishedPortfolios(userInfo.userId());
+
+        WishedPortfoliosResponse response = WishedPortfoliosResponse.from(result);
+
+        return ApiResponseBody.ok(WishSuccessCode.GET_WISHED_PORTFOLIOS_OK, response);
+    }
 }
+
+

--- a/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
@@ -79,5 +79,3 @@ public class WishController implements WishApi {
             : WishSuccessCode.POST_WISH_CANCEL_PRODUCT_OK;
     }
 }
-
-

--- a/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
@@ -1,9 +1,6 @@
 package org.sopt.snappinserver.api.wish.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.api.product.code.ProductSuccessCode;
-import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaResponse;
-import org.sopt.snappinserver.api.product.dto.response.ProductReviewsResponse;
 import org.sopt.snappinserver.api.wish.code.WishSuccessCode;
 import org.sopt.snappinserver.api.wish.dto.request.WishPortfolioRequest;
 import org.sopt.snappinserver.api.wish.dto.request.WishProductRequest;

--- a/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
@@ -60,6 +60,18 @@ public class WishController implements WishApi {
         return ApiResponseBody.ok(decideSuccessCode(result), response);
     }
 
+    @Override
+    public ApiResponseBody<WishedPortfoliosResponse, Void> getWishedPortfolios(
+        @AuthenticationPrincipal CustomUserInfo userInfo
+    ) {
+        WishedPortfoliosResult result = getWishedPortfoliosUseCase.getWishedPortfolios(
+            userInfo.userId()
+        );
+        WishedPortfoliosResponse response = WishedPortfoliosResponse.from(result);
+
+        return ApiResponseBody.ok(WishSuccessCode.GET_WISHED_PORTFOLIOS_OK, response);
+    }
+
     private WishSuccessCode decideSuccessCode(WishPortfolioResult result) {
         return result.liked() ? WishSuccessCode.POST_WISH_LIKE_PORTFOLIO_OK
             : WishSuccessCode.POST_WISH_CANCEL_PORTFOLIO_OK;
@@ -68,18 +80,6 @@ public class WishController implements WishApi {
     private WishSuccessCode decideSuccessCode(WishProductResult result) {
         return result.liked() ? WishSuccessCode.POST_WISH_LIKE_PRODUCT_OK
             : WishSuccessCode.POST_WISH_CANCEL_PRODUCT_OK;
-    }
-
-    @Override
-    public ApiResponseBody<WishedPortfoliosResponse, Void> getWishedPortfolios(
-        @AuthenticationPrincipal CustomUserInfo userInfo
-    ) {
-        WishedPortfoliosResult result =
-            getWishedPortfoliosUseCase.getWishedPortfolios(userInfo.userId());
-
-        WishedPortfoliosResponse response = WishedPortfoliosResponse.from(result);
-
-        return ApiResponseBody.ok(WishSuccessCode.GET_WISHED_PORTFOLIOS_OK, response);
     }
 }
 

--- a/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedPortfolioResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedPortfolioResponse.java
@@ -1,0 +1,15 @@
+package org.sopt.snappinserver.api.wish.dto.response;
+
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfolioResult;
+
+public record WishedPortfolioResponse(
+    Long id,
+    String imageUrl
+) {
+    public static WishedPortfolioResponse from(WishedPortfolioResult result) {
+        return new WishedPortfolioResponse(
+            result.id(),
+            result.imageUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedPortfolioResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedPortfolioResponse.java
@@ -6,6 +6,7 @@ public record WishedPortfolioResponse(
     Long id,
     String imageUrl
 ) {
+
     public static WishedPortfolioResponse from(WishedPortfolioResult result) {
         return new WishedPortfolioResponse(
             result.id(),

--- a/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedPortfolioResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedPortfolioResponse.java
@@ -1,9 +1,18 @@
 package org.sopt.snappinserver.api.wish.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfolioResult;
 
+@Schema(description = "위시 포트폴리오 단일 응답 DTO")
 public record WishedPortfolioResponse(
+
+    @Schema(description = "포트폴리오 아이디", example = "1")
     Long id,
+
+    @Schema(
+        description = "포트폴리오 대표 이미지 URL",
+        example = "https://example.com/portfolio1.jpg"
+    )
     String imageUrl
 ) {
 

--- a/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedPortfoliosResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedPortfoliosResponse.java
@@ -1,9 +1,15 @@
 package org.sopt.snappinserver.api.wish.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosResult;
 
-public record WishedPortfoliosResponse(List<WishedPortfolioResponse> portfolios) {
+@Schema(description = "위시 포트폴리오 목록 조회 응답 DTO")
+public record WishedPortfoliosResponse(
+
+    @Schema(description = "좋아요한 포트폴리오 목록")
+    List<WishedPortfolioResponse> portfolios
+) {
 
     public static WishedPortfoliosResponse from(WishedPortfoliosResult result) {
         return new WishedPortfoliosResponse(

--- a/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedPortfoliosResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedPortfoliosResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.snappinserver.api.wish.dto.response;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosResult;
+
+public record WishedPortfoliosResponse(
+    List<WishedPortfolioResponse> portfolios
+) {
+
+    public static WishedPortfoliosResponse from(WishedPortfoliosResult result) {
+        return new WishedPortfoliosResponse(
+            result.portfolios().stream()
+                .map(WishedPortfolioResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedPortfoliosResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedPortfoliosResponse.java
@@ -3,15 +3,11 @@ package org.sopt.snappinserver.api.wish.dto.response;
 import java.util.List;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosResult;
 
-public record WishedPortfoliosResponse(
-    List<WishedPortfolioResponse> portfolios
-) {
+public record WishedPortfoliosResponse(List<WishedPortfolioResponse> portfolios) {
 
     public static WishedPortfoliosResponse from(WishedPortfoliosResult result) {
         return new WishedPortfoliosResponse(
-            result.portfolios().stream()
-                .map(WishedPortfolioResponse::from)
-                .toList()
+            result.portfolios().stream().map(WishedPortfolioResponse::from).toList()
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioPhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioPhotoRepository.java
@@ -1,0 +1,13 @@
+package org.sopt.snappinserver.domain.portfolio.repository;
+
+import java.util.Optional;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PortfolioPhotoRepository extends JpaRepository<PortfolioPhoto, Long> {
+
+    Optional<PortfolioPhoto> findFirstByPortfolioOrderByDisplayOrderAsc(Portfolio portfolio);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/domain/exception/UserErrorCode.java
@@ -20,6 +20,7 @@ public enum UserErrorCode implements ErrorCode {
     // 403 FORBIDDEN
 
     // 404 NOT FOUND
+    USER_NOT_FOUND(404, "USER_404_001","존재하지 않는 사용자입니다.")
 
     ;
 

--- a/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishPortfolioRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishPortfolioRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WishPortfolioRepository extends JpaRepository<WishPortfolio, Long> {
+
     Optional<WishPortfolio> findByUserAndPortfolio(User user, Portfolio portfolio);
 
     List<WishPortfolio> findAllByUser(User user);

--- a/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishPortfolioRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishPortfolioRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.snappinserver.domain.wish.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
@@ -10,4 +11,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface WishPortfolioRepository extends JpaRepository<WishPortfolio, Long> {
     Optional<WishPortfolio> findByUserAndPortfolio(User user, Portfolio portfolio);
+
+    List<WishPortfolio> findAllByUser(User user);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
@@ -45,7 +45,8 @@ public class GetWishedPortfoliosService implements GetWishedPortfoliosUseCase {
             .findAllByUser(user)
             .stream()
             .map(WishPortfolio::getPortfolio)
-            .map(this::mapToWishedPortfolioResult).toList();
+            .map(this::mapToWishedPortfolioResult)
+            .toList();
     }
 
     private WishedPortfolioResult mapToWishedPortfolioResult(Portfolio portfolio) {

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
@@ -1,0 +1,36 @@
+package org.sopt.snappinserver.domain.wish.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
+import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.sopt.snappinserver.domain.wish.domain.entity.WishPortfolio;
+import org.sopt.snappinserver.domain.wish.repository.WishPortfolioRepository;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfolioResult;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosResult;
+import org.sopt.snappinserver.domain.wish.service.usecase.GetWishedPortfoliosUseCase;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetWishedPortfoliosService implements GetWishedPortfoliosUseCase {
+
+    private final WishPortfolioRepository wishPortfolioRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public WishedPortfoliosResult getWishedPortfolios(Long userId) {
+        User user = userRepository.getById(userId);
+
+        List<WishedPortfolioResult> results =
+            wishPortfolioRepository.findAllByUser(user)
+                .stream()
+                .map(WishPortfolio::getPortfolio)
+                .map(WishedPortfolioResult::from)
+                .toList();
+
+        return WishedPortfoliosResult.from(results);
+    }
+}
+

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
@@ -7,10 +7,10 @@ import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioPhoto;
 import org.sopt.snappinserver.domain.portfolio.repository.PortfolioPhotoRepository;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
-import org.sopt.snappinserver.domain.user.domain.exception.UserErrorCode;
-import org.sopt.snappinserver.domain.user.domain.exception.UserException;
 import org.sopt.snappinserver.domain.user.repository.UserRepository;
 import org.sopt.snappinserver.domain.wish.domain.entity.WishPortfolio;
+import org.sopt.snappinserver.domain.wish.domain.exception.WishErrorCode;
+import org.sopt.snappinserver.domain.wish.domain.exception.WishException;
 import org.sopt.snappinserver.domain.wish.repository.WishPortfolioRepository;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfolioResult;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosResult;
@@ -37,7 +37,7 @@ public class GetWishedPortfoliosService implements GetWishedPortfoliosUseCase {
 
     private User getUser(Long userId) {
         return userRepository.findById(userId)
-            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+            .orElseThrow(() -> new WishException(WishErrorCode.USER_NOT_FOUND));
     }
 
     private List<WishedPortfolioResult> getWishedPortfolioResults(User user) {

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
@@ -2,8 +2,13 @@ package org.sopt.snappinserver.domain.wish.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.photo.domain.entity.Photo;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioPhoto;
+import org.sopt.snappinserver.domain.portfolio.repository.PortfolioPhotoRepository;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
+import org.sopt.snappinserver.domain.user.domain.exception.UserErrorCode;
+import org.sopt.snappinserver.domain.user.domain.exception.UserException;
 import org.sopt.snappinserver.domain.user.repository.UserRepository;
 import org.sopt.snappinserver.domain.wish.domain.entity.WishPortfolio;
 import org.sopt.snappinserver.domain.wish.repository.WishPortfolioRepository;
@@ -17,20 +22,37 @@ import org.springframework.stereotype.Service;
 public class GetWishedPortfoliosService implements GetWishedPortfoliosUseCase {
 
     private final WishPortfolioRepository wishPortfolioRepository;
+    private final PortfolioPhotoRepository portfolioPhotoRepository;
     private final UserRepository userRepository;
 
     @Override
     public WishedPortfoliosResult getWishedPortfolios(Long userId) {
-        User user = userRepository.getById(userId);
-
-        List<WishedPortfolioResult> results =
-            wishPortfolioRepository.findAllByUser(user)
-                .stream()
-                .map(WishPortfolio::getPortfolio)
-                .map(WishedPortfolioResult::from)
-                .toList();
+        User user = getUser(userId);
+        List<WishedPortfolioResult> results = getWishedPortfolioResults(user);
 
         return WishedPortfoliosResult.from(results);
     }
-}
 
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    private List<WishedPortfolioResult> getWishedPortfolioResults(User user) {
+        return wishPortfolioRepository
+            .findAllByUser(user)
+            .stream()
+            .map(WishPortfolio::getPortfolio)
+            .map(this::toWishedPortfolioResult).toList();
+    }
+
+    private WishedPortfolioResult toWishedPortfolioResult(Portfolio portfolio) {
+        String imageUrl = portfolioPhotoRepository
+            .findFirstByPortfolioOrderByDisplayOrderAsc(portfolio)
+            .map(PortfolioPhoto::getPhoto)
+            .map(Photo::getImageUrl)
+            .orElse(null);
+
+        return WishedPortfolioResult.of(portfolio.getId(), imageUrl);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
@@ -16,9 +16,11 @@ import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfolioRe
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosResult;
 import org.sopt.snappinserver.domain.wish.service.usecase.GetWishedPortfoliosUseCase;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class GetWishedPortfoliosService implements GetWishedPortfoliosUseCase {
 
     private final WishPortfolioRepository wishPortfolioRepository;
@@ -43,10 +45,10 @@ public class GetWishedPortfoliosService implements GetWishedPortfoliosUseCase {
             .findAllByUser(user)
             .stream()
             .map(WishPortfolio::getPortfolio)
-            .map(this::toWishedPortfolioResult).toList();
+            .map(this::mapToWishedPortfolioResult).toList();
     }
 
-    private WishedPortfolioResult toWishedPortfolioResult(Portfolio portfolio) {
+    private WishedPortfolioResult mapToWishedPortfolioResult(Portfolio portfolio) {
         String imageUrl = portfolioPhotoRepository
             .findFirstByPortfolioOrderByDisplayOrderAsc(portfolio)
             .map(PortfolioPhoto::getPhoto)

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedPortfolioResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedPortfolioResult.java
@@ -1,15 +1,8 @@
 package org.sopt.snappinserver.domain.wish.service.dto.response;
 
-import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
+public record WishedPortfolioResult(Long id, String imageUrl) {
 
-public record WishedPortfolioResult(
-    Long id,
-    String imageUrl
-) {
-    public static WishedPortfolioResult from(Portfolio portfolio) {
-        return new WishedPortfolioResult(
-            portfolio.getId(),
-            portfolio.getThumbnailImageUrl()
-        );
+    public static WishedPortfolioResult of(Long id, String imageUrl) {
+        return new WishedPortfolioResult(id, imageUrl);
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedPortfolioResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedPortfolioResult.java
@@ -1,0 +1,15 @@
+package org.sopt.snappinserver.domain.wish.service.dto.response;
+
+import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
+
+public record WishedPortfolioResult(
+    Long id,
+    String imageUrl
+) {
+    public static WishedPortfolioResult from(Portfolio portfolio) {
+        return new WishedPortfolioResult(
+            portfolio.getId(),
+            portfolio.getThumbnailImageUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedPortfoliosResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedPortfoliosResult.java
@@ -1,0 +1,12 @@
+package org.sopt.snappinserver.domain.wish.service.dto.response;
+
+import java.util.List;
+
+public record WishedPortfoliosResult(
+    List<WishedPortfolioResult> portfolios
+) {
+
+    public static WishedPortfoliosResult from(List<WishedPortfolioResult> portfolios) {
+        return new WishedPortfoliosResult(portfolios);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedPortfoliosResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedPortfoliosResult.java
@@ -2,9 +2,7 @@ package org.sopt.snappinserver.domain.wish.service.dto.response;
 
 import java.util.List;
 
-public record WishedPortfoliosResult(
-    List<WishedPortfolioResult> portfolios
-) {
+public record WishedPortfoliosResult(List<WishedPortfolioResult> portfolios) {
 
     public static WishedPortfoliosResult from(List<WishedPortfolioResult> portfolios) {
         return new WishedPortfoliosResult(portfolios);

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/usecase/GetWishedPortfoliosUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/usecase/GetWishedPortfoliosUseCase.java
@@ -1,0 +1,7 @@
+package org.sopt.snappinserver.domain.wish.service.usecase;
+
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosResult;
+
+public interface GetWishedPortfoliosUseCase {
+    WishedPortfoliosResult getWishedPortfolios(Long userId);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/usecase/GetWishedPortfoliosUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/usecase/GetWishedPortfoliosUseCase.java
@@ -3,5 +3,6 @@ package org.sopt.snappinserver.domain.wish.service.usecase;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosResult;
 
 public interface GetWishedPortfoliosUseCase {
+
     WishedPortfoliosResult getWishedPortfolios(Long userId);
 }


### PR DESCRIPTION
## 👀 Summary

- close #68 

위시 포트폴리오 목록 조회 API를 구현했습니다.

## 🖇️ Tasks

- [x] 위시 포트폴리오 목록 조회 API 엔드포인트 추가
- [x] 조회 응답 DTO 정의 및 Swagger 스키마 적용
- [x] 위시 포트폴리오 목록 조회 유스케이스(GetWishedPortfoliosUseCase) 구현
- [x] PortfolioPhoto 연결 엔티티 전용 PortfolioPhotoRepository 추가
- [x] 포트폴리오 대표 이미지 조회 로직 구현 (displayOrder 기준)
- [x] 위시 포트폴리오 조회 도메인 DTO 단순화
- [x] Service 내부 로직을 메서드 단위로 분리


## 🔍 To Reviewer
### ❶ PortfolioPhotoRepository 추가
현재 엔티티 연결 구조는 아래와 같은 흐름을 가집니다.

```
User → WishPortfolio → Portfolio → PortfolioPhoto → Photo
```

각 엔티티가 아는 정보는 명확히 분리되어 있으며, 포트폴리오 대표 이미지(썸네일)는 포트폴리오–사진 연결 정보와 사진 순서(displayOrder)를 기준으로 결정됩니다. 따라서 WishPortfolioRepository, PortfolioRepository, PhotoRepository 중 어느 곳에서도 대표 이미지를 판단하는 책임을 가지게 하면 안된다고 판단했습니다!

따라서 포트폴리오–사진 연결 엔티티 전용 레포지토리 PortfolioPhotoRepository를 추가하고, 대표 이미지 선택 로직을 Service 레이어에서 처리하도록 구현했습니다.

### ❷ 성능 관련 (N+1)

위시 포트폴리오 개수만큼 대표 이미지 조회가 발생하기 때문에 N+1 가능성은 인지하고 있습니다만, 기획 상 위시 포트폴리오 전체 조회 시 개수가 많지 않을 것으로 논의되었고 구조적으로 최적화 포인트가 명확하여 이 부분은 추후에 필요하다면 리팩토링 진행하겠습니다!
