### PR TITLE
[FEAT] #69: 위시 상품 목록 조회

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/wish/code/WishSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/code/WishSuccessCode.java
@@ -12,7 +12,8 @@ public enum WishSuccessCode implements SuccessCode {
     POST_WISH_CANCEL_PORTFOLIO_OK(200, "WISH_200_002", "포트폴리오 좋아요 취소에 성공했습니다."),
     POST_WISH_LIKE_PRODUCT_OK(200, "WISH_200_003", "상품 좋아요 처리에 성공했습니다."),
     POST_WISH_CANCEL_PRODUCT_OK(200, "WISH_200_004", "상품 좋아요 취소에 성공했습니다."),
-    GET_WISHED_PORTFOLIOS_OK(200, "WISH_200_005", "좋아요한 포트폴리오 목록 조회에 성공했습니다.");
+    GET_WISHED_PORTFOLIOS_OK(200, "WISH_200_005", "좋아요한 포트폴리오 목록 조회에 성공했습니다."),
+    GET_WISHED_PRODUCTS_OK(200, "WISH_200_006", "좋아요한 상품 목록 조회에 성공했습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/org/sopt/snappinserver/api/wish/controller/WishApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/controller/WishApi.java
@@ -9,6 +9,7 @@ import org.sopt.snappinserver.api.wish.dto.request.WishProductRequest;
 import org.sopt.snappinserver.api.wish.dto.response.WishPortfolioResponse;
 import org.sopt.snappinserver.api.wish.dto.response.WishProductResponse;
 import org.sopt.snappinserver.api.wish.dto.response.WishedPortfoliosResponse;
+import org.sopt.snappinserver.api.wish.dto.response.WishedProductsResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.validation.annotation.Validated;
@@ -52,6 +53,17 @@ public interface WishApi {
     )
     @GetMapping("/portfolios")
     ApiResponseBody<WishedPortfoliosResponse, Void> getWishedPortfolios(
+
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo
+    );
+
+    @Operation(
+        summary = "위시 상품 목록 조회",
+        description = "사용자가 좋아요한 전체 상품 목록을 조회합니다."
+    )
+    @GetMapping("/products")
+    ApiResponseBody<WishedProductsResponse, Void> getWishedProducts(
 
         @Parameter(hidden = true)
         CustomUserInfo userInfo

--- a/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/controller/WishController.java
@@ -7,11 +7,14 @@ import org.sopt.snappinserver.api.wish.dto.request.WishProductRequest;
 import org.sopt.snappinserver.api.wish.dto.response.WishPortfolioResponse;
 import org.sopt.snappinserver.api.wish.dto.response.WishProductResponse;
 import org.sopt.snappinserver.api.wish.dto.response.WishedPortfoliosResponse;
+import org.sopt.snappinserver.api.wish.dto.response.WishedProductsResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishPortfolioResult;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishProductResult;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosResult;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsResult;
 import org.sopt.snappinserver.domain.wish.service.usecase.GetWishedPortfoliosUseCase;
+import org.sopt.snappinserver.domain.wish.service.usecase.GetWishedProductsUseCase;
 import org.sopt.snappinserver.domain.wish.service.usecase.PostWishPortfolioUseCase;
 import org.sopt.snappinserver.domain.wish.service.usecase.PostWishProductUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
@@ -27,6 +30,7 @@ public class WishController implements WishApi {
     private final PostWishPortfolioUseCase postWishPortfolioUseCase;
     private final PostWishProductUseCase postWishProductUseCase;
     private final GetWishedPortfoliosUseCase getWishedPortfoliosUseCase;
+    private final GetWishedProductsUseCase getWishedProductsUseCase;
 
     @Override
     public ApiResponseBody<WishPortfolioResponse, Void> updateWishPortfolio(
@@ -66,6 +70,18 @@ public class WishController implements WishApi {
         WishedPortfoliosResponse response = WishedPortfoliosResponse.from(result);
 
         return ApiResponseBody.ok(WishSuccessCode.GET_WISHED_PORTFOLIOS_OK, response);
+    }
+
+    @Override
+    public ApiResponseBody<WishedProductsResponse, Void> getWishedProducts(
+        @AuthenticationPrincipal CustomUserInfo userInfo
+    ) {
+        WishedProductsResult result = getWishedProductsUseCase.getWishedProducts(
+            userInfo.userId()
+        );
+        WishedProductsResponse response = WishedProductsResponse.from(result);
+
+        return ApiResponseBody.ok(WishSuccessCode.GET_WISHED_PRODUCTS_OK, response);
     }
 
     private WishSuccessCode decideSuccessCode(WishPortfolioResult result) {

--- a/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedProductResponse.java
@@ -1,0 +1,47 @@
+package org.sopt.snappinserver.api.wish.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductResult;
+
+@Schema(description = "위시 상품 단일 응답 DTO")
+public record WishedProductResponse(
+
+    @Schema(description = "상품 아이디", example = "1")
+    Long id,
+
+    @Schema(description = "상품 대표 이미지 URL", example = "https://example.com/product1.jpg")
+    String imageUrl,
+
+    @Schema(description = "상품명", example = "인물 스냅 촬영")
+    String title,
+
+    @Schema(description = "평균 별점", example = "4.8")
+    Double rate,
+
+    @Schema(description = "리뷰 개수", example = "23")
+    Integer reviewCount,
+
+    @Schema(description = "상품 등록 작가", example = "김사진")
+    String photographer,
+
+    @Schema(description = "상품 가격", example = "150000")
+    Integer price,
+
+    @Schema(description = "상품 무드 태그 목록", example = "[\"따뜻한\", \"자연스러운\", \"투명한\"]")
+    List<String> moods
+) {
+
+    public static WishedProductResponse from(WishedProductResult result) {
+        return new WishedProductResponse(
+            result.id(),
+            result.imageUrl(),
+            result.title(),
+            result.rate(),
+            result.reviewCount(),
+            result.photographer(),
+            result.price(),
+            result.moods()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedProductsResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/wish/dto/response/WishedProductsResponse.java
@@ -1,0 +1,19 @@
+package org.sopt.snappinserver.api.wish.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsResult;
+
+@Schema(description = "위시 상품 목록 조회 응답 DTO")
+public record WishedProductsResponse(
+
+    @Schema(description = "좋아요한 상품 목록")
+    List<WishedProductResponse> products
+) {
+
+    public static WishedProductsResponse from(WishedProductsResult result) {
+        return new WishedProductsResponse(
+            result.products().stream().map(WishedProductResponse::from).toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductMoodRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductMoodRepository.java
@@ -1,0 +1,11 @@
+package org.sopt.snappinserver.domain.product.repository;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.domain.product.domain.entity.ProductMood;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductMoodRepository extends JpaRepository<ProductMood, Long> {
+
+    List<ProductMood> findAllByProduct(Product product);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
@@ -1,0 +1,13 @@
+package org.sopt.snappinserver.domain.product.repository;
+
+import java.util.Optional;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.domain.product.domain.entity.ProductPhoto;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductPhotoRepository {
+
+    Optional<ProductPhoto> findFirstByProductOrderByDisplayOrderAsc(Product product);
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
@@ -3,10 +3,11 @@ package org.sopt.snappinserver.domain.product.repository;
 import java.util.Optional;
 import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.sopt.snappinserver.domain.product.domain.entity.ProductPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProductPhotoRepository {
+public interface ProductPhotoRepository extends JpaRepository<ProductPhoto, Long> {
 
     Optional<ProductPhoto> findFirstByProductOrderByDisplayOrderAsc(Product product);
 

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewStatsResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewStatsResult.java
@@ -1,5 +1,5 @@
 package org.sopt.snappinserver.domain.product.service.dto.response;
 
-public record ProductReviewStatsResult(long reviewCount, double averageRating) {
+public record ProductReviewStatsResult(long reviewCount, Double averageRating) {
 
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewStatsResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewStatsResult.java
@@ -1,0 +1,5 @@
+package org.sopt.snappinserver.domain.product.service.dto.response;
+
+public record ProductReviewStatsResult(long reviewCount, double averageRating) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.snappinserver.domain.review.repository;
 
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult;
 import org.springframework.data.domain.Pageable;
 import java.util.List;
 import org.sopt.snappinserver.domain.review.domain.entity.Review;
@@ -12,7 +13,7 @@ import org.springframework.stereotype.Repository;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
 
-    // 첫 페이지 조회 (cursor 없음)
+    // 리뷰 목록 첫 페이지 조회 (cursor 없음)
     @Query("""
         select review
         from Review review
@@ -26,7 +27,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         Pageable pageable
     );
 
-    // 커서 이후 페이지 조회
+    // 커서 이후 리뷰 목록 페이지 조회
     @Query("""
         select review
         from Review review
@@ -41,4 +42,20 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         @Param("cursor") Long cursor,
         Pageable pageable
     );
+
+    // 상품 기반 리뷰 수치(개수, 평균 별점) 조회
+    @Query("""
+            select new org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult(
+                count(review),
+                avg(review.rating)
+            )
+            from Review review
+            join review.reservation reservation
+            where reservation.product.id = :productId
+        """)
+    ProductReviewStatsResult findReviewStatsByProductId(
+        @Param("productId") Long productId
+    );
 }
+
+

--- a/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishProductRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishProductRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.snappinserver.domain.wish.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
@@ -9,5 +10,9 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WishProductRepository extends JpaRepository<WishProduct, Long> {
+
     Optional<WishProduct> findByUserAndProduct(User user, Product product);
+
+    List<WishProduct> findAllByUser(User user);
+
 }

--- a/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishProductRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishProductRepository.java
@@ -6,6 +6,8 @@ import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.sopt.snappinserver.domain.wish.domain.entity.WishProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,6 +15,12 @@ public interface WishProductRepository extends JpaRepository<WishProduct, Long> 
 
     Optional<WishProduct> findByUserAndProduct(User user, Product product);
 
-    List<WishProduct> findAllByUser(User user);
-
+    @Query("""
+        select wp
+        from WishProduct wp
+        join fetch wp.product p
+        join fetch p.photographer
+        where wp.user = :user
+    """)
+    List<WishProduct> findAllByUserWithProduct(@Param("user") User user);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsService.java
@@ -1,0 +1,93 @@
+package org.sopt.snappinserver.domain.wish.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.photo.domain.entity.Photo;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.domain.product.domain.entity.ProductPhoto;
+import org.sopt.snappinserver.domain.product.repository.ProductMoodRepository;
+import org.sopt.snappinserver.domain.product.repository.ProductPhotoRepository;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult;
+import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
+import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.sopt.snappinserver.domain.wish.domain.entity.WishProduct;
+import org.sopt.snappinserver.domain.wish.domain.exception.WishErrorCode;
+import org.sopt.snappinserver.domain.wish.domain.exception.WishException;
+import org.sopt.snappinserver.domain.wish.repository.WishProductRepository;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductResult;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsResult;
+import org.sopt.snappinserver.domain.wish.service.usecase.GetWishedProductsUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetWishedProductsService implements GetWishedProductsUseCase {
+
+    private final WishProductRepository wishProductRepository;
+    private final ProductPhotoRepository productPhotoRepository;
+    private final ProductMoodRepository productMoodRepository;
+    private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public WishedProductsResult getWishedProducts(Long userId) {
+        User user = getUser(userId);
+        List<WishedProductResult> results = getWishedProductResults(user);
+
+        return WishedProductsResult.from(results);
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new WishException(WishErrorCode.USER_NOT_FOUND));
+    }
+
+    private List<WishedProductResult> getWishedProductResults(User user) {
+        return wishProductRepository
+            .findAllByUser(user)
+            .stream()
+            .map(WishProduct::getProduct)
+            .map(this::mapToWishedProductResult)
+            .toList();
+    }
+
+    private WishedProductResult mapToWishedProductResult(Product product) {
+        String imageUrl = findThumbnailImageUrl(product);
+        ProductReviewStatsResult reviewStats = reviewRepository.findReviewStatsByProductId(
+            product.getId()
+        );
+
+        List<String> moods = findMoodNames(product);
+
+        return WishedProductResult.of(
+            product.getId(),
+            imageUrl,
+            product.getTitle(),
+            reviewStats.averageRating(),
+            (int) reviewStats.reviewCount(),
+            product.getPhotographer().getName(),
+            product.getPrice(),
+            moods
+        );
+    }
+
+    private String findThumbnailImageUrl(Product product) {
+        return productPhotoRepository
+            .findFirstByProductOrderByDisplayOrderAsc(product)
+            .map(ProductPhoto::getPhoto)
+            .map(Photo::getImageUrl)
+            .orElse(null);
+    }
+
+    private List<String> findMoodNames(Product product) {
+        return productMoodRepository
+            .findAllByProduct(product)
+            .stream()
+            .map(productMood -> productMood.getMood().getName())
+            .toList();
+    }
+}
+

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsService.java
@@ -47,7 +47,7 @@ public class GetWishedProductsService implements GetWishedProductsUseCase {
 
     private List<WishedProductResult> getWishedProductResults(User user) {
         return wishProductRepository
-            .findAllByUser(user)
+            .findAllByUserWithProduct(user)
             .stream()
             .map(WishProduct::getProduct)
             .map(this::mapToWishedProductResult)

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedProductResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedProductResult.java
@@ -1,0 +1,30 @@
+package org.sopt.snappinserver.domain.wish.service.dto.response;
+
+import java.util.List;
+
+public record WishedProductResult(
+    Long id,
+    String imageUrl,
+    String title,
+    Double rate,
+    Integer reviewCount,
+    String photographer,
+    Integer price,
+    List<String> moods
+) {
+
+    public static WishedProductResult of(
+        Long id,
+        String imageUrl,
+        String title,
+        Double rate,
+        Integer reviewCount,
+        String photographer,
+        Integer price,
+        List<String> moods
+    ) {
+        return new WishedProductResult(
+            id, imageUrl, title, rate, reviewCount, photographer, price, moods
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedProductsResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedProductsResult.java
@@ -1,0 +1,10 @@
+package org.sopt.snappinserver.domain.wish.service.dto.response;
+
+import java.util.List;
+
+public record WishedProductsResult(List<WishedProductResult> products) {
+
+    public static WishedProductsResult from(List<WishedProductResult> products) {
+        return new WishedProductsResult(products);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/usecase/GetWishedProductsUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/usecase/GetWishedProductsUseCase.java
@@ -1,0 +1,9 @@
+package org.sopt.snappinserver.domain.wish.service.usecase;
+
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsResult;
+
+public interface GetWishedProductsUseCase {
+
+    WishedProductsResult getWishedProducts(Long userId);
+
+}


### PR DESCRIPTION
## 👀 Summary

- close #69 

사용자가 좋아요한 상품 목록 조회 API를 구현했습니다.


## 🖇️ Tasks

- [x] 위시 상품 목록 조회 유스케이스 추가
- [x] 위시 상품 조회 결과 도메인 DTO 및 API 응답 DTO 분리
- [x] 상품 대표 이미지 조회를 위한 ProductPhotoRepository 추가
- [x] 상품 무드 태그 조회를 위한 ProductMoodRepository 추가
- [x] 상품 리뷰 개수 / 평균 별점 집계를 위한 조회 쿼리 추가
- [x] 위시 상품 목록 조회 API 엔드포인트 및 성공 코드 추가


## 🔍 To Reviewer

### ❶ 전체 흐름 및 구조

위시 상품 목록 조회 시 필요한 정보는 여러 도메인에 분산되어 있습니다. 현재 엔티티 구조는 아래와 같습니다!

```
User
  ↓
WishProduct
  ↓
Product
  ├─ ProductPhoto (대표 이미지, 순서)
  ├─ ProductMood (무드 태그)
  ├─ Reservation
        ↓
       Review (리뷰 개수, 평균 별점)
```

각 엔티티가 알고 있는 책임을 기준으로 조회 경로를 분리했습니다.
- WishProduct → 사용자가 좋아요한 상품 관계만 관리
- Product → 상품의 기본 정보(제목, 가격, 작가)만 보유
- ProductPhoto → 상품의 대표 이미지 결정 책임
- ProductMood → 상품의 무드 태그 관리
- Review → 상품과 연결된 예약 기반 리뷰 통계 제공

대표 이미지와 리뷰 통계는 각각 ProductPhotoRepository, ReviewRepository의 집계 쿼리를 통해 조회하도록 했고, Service 계층에서는 조회 결과를 조합하는 역할만 담당하도록 구성했습니다.

### ❷ 전용 Repository 분리 이유

대표 이미지, 무드 태그, 리뷰 통계는 각각 성격이 다른 조회라고 판단했습니다.

- 대표 이미지 → ProductPhoto의 displayOrder 규칙을 기반으로 결정
- 무드 태그 → ProductMood 연결 엔티티 기반 조회
- 리뷰 통계 → Review + Reservation 기반 집계 정보

이 조회 로직들을 하나의 레포지토리나 ProductRepository에서 처리하면 레포지토리 책임이 모호해지고 추후 확장이나 유지보수 시 복잡해질 가능성이 있다고 판단학, 아래와 같이 연결 엔티티 전용 Repository를 각각 두는 구조를 선택했습니다.

```
ProductPhotoRepository / ProductMoodRepository / ReviewRepository (집계 쿼리)
```

각 Repository는 자기 도메인의 규칙에 맞는 조회만 담당하고, Service 레이어에서 결과를 조합하도록 구성했습니다.

### ❸ 리뷰 수치 DTO 위치에 대한 고민

리뷰 개수와 평균 별점은 Review 도메인에서 계산되지만, 실제로 이 정보는 상품 카드/상품 상세를 설명하기 위해 상품에서 파생된 정보라는 점에서 Review 도메인 DTO로 두는 것이 어색하다고 판단했습니다. 그래서 집계 결과 DTO를 `ProductReviewStatsResult`라는 이름으로 Product 도메인 조회 DTO로 두고, Repository에서 생성자 표현식으로 바로 반환하도록 했습니다. 

> 생성자 표현식에서는 `new 패키지명.DTO(...)`로 생성 방법을 명시해야 하기 때문에, 코드 포맷팅에서 한 줄에 들어가는 글자 수 제한에 걸리는데요.... 이 부분은 개행을 추가하면 문법 상 오류가 날 가능성이 있다고 하여 예외적으로 그대로 두었습니다!

### ❹ 4. Service 계층 역할 
- 위시 상품 관계 조회
- 각 도메인 Repository에서 필요한 정보 조회
- 조회 결과를 WishedProductResult로 조합

Service는 정보들을 조합하는 역할만 수행하도록 했습니다!

### ❺ 성능 관련 (N+1)

위시 포트폴리오 목록 조회 API와 같이, 위시 상품 개수만큼 대표 이미지 조회가 발생하기 때문에 N+1 가능성은 인지하고 있습니다만, 기획 상 위시 상품 수가 많지 않을 것으로 논의되었기 때문에 이 부분은 추후에 필요하다면 리팩토링 진행하겠습니다!