### PR TITLE
[FEAT] #64: 사용자 정보 조회 

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/user/code/UserSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/user/code/UserSuccessCode.java
@@ -1,0 +1,21 @@
+package org.sopt.snappinserver.api.user.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.global.response.code.common.SuccessCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserSuccessCode implements SuccessCode {
+
+    // 200 OK
+    GET_USER_INFO_OK(200, "USER_200_001", "성공적으로 유저 정보를 조회했습니다."),
+
+    // 201 CREATED
+
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/sopt/snappinserver/api/user/controller/UserApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/user/controller/UserApi.java
@@ -1,8 +1,21 @@
 package org.sopt.snappinserver.api.user.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.snappinserver.api.user.dto.response.GetUserInfoResponse;
+import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 
 @Tag(name = "01 - User", description = "사용자 관련 API")
 public interface UserApi {
 
+    @Operation(
+        summary = "유저 정보 조회 API",
+        description = "현재 로그인한 사용자의 역할을 기반으로 사용자 정보를 조회합니다."
+    )
+    ApiResponseBody<GetUserInfoResponse, Void> getUserInfo(
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo
+    );
 }

--- a/src/main/java/org/sopt/snappinserver/api/user/controller/UserController.java
+++ b/src/main/java/org/sopt/snappinserver/api/user/controller/UserController.java
@@ -1,6 +1,15 @@
 package org.sopt.snappinserver.api.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.user.code.UserSuccessCode;
+import org.sopt.snappinserver.api.user.dto.response.GetUserInfoResponse;
+import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.domain.user.service.GetUserInfoService;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetUserInfoResult;
+import org.sopt.snappinserver.domain.user.service.usecase.GetUserInfoUseCase;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,4 +18,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class UserController implements UserApi {
 
+    private final GetUserInfoUseCase getUserInfoUseCase;
+    private final GetUserInfoService getUserInfoService;
+
+    @Override
+    @GetMapping("/me")
+    public ApiResponseBody<GetUserInfoResponse, Void> getUserInfo(
+        @AuthenticationPrincipal CustomUserInfo userInfo
+    ) {
+        GetUserInfoResult result = getUserInfoService.getUserInfo(userInfo.userId());
+        GetUserInfoResponse response = GetUserInfoResponse.from(result);
+
+        return ApiResponseBody.ok(UserSuccessCode.GET_USER_INFO_OK, response);
+    }
 }

--- a/src/main/java/org/sopt/snappinserver/api/user/controller/UserController.java
+++ b/src/main/java/org/sopt/snappinserver/api/user/controller/UserController.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.user.code.UserSuccessCode;
 import org.sopt.snappinserver.api.user.dto.response.GetUserInfoResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
-import org.sopt.snappinserver.domain.user.service.GetUserInfoService;
 import org.sopt.snappinserver.domain.user.service.dto.response.GetUserInfoResult;
 import org.sopt.snappinserver.domain.user.service.usecase.GetUserInfoUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
@@ -19,14 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController implements UserApi {
 
     private final GetUserInfoUseCase getUserInfoUseCase;
-    private final GetUserInfoService getUserInfoService;
-
     @Override
     @GetMapping("/me")
     public ApiResponseBody<GetUserInfoResponse, Void> getUserInfo(
         @AuthenticationPrincipal CustomUserInfo userInfo
     ) {
-        GetUserInfoResult result = getUserInfoService.getUserInfo(userInfo.userId());
+        GetUserInfoResult result = getUserInfoUseCase.getUserInfo(userInfo.userId());
         GetUserInfoResponse response = GetUserInfoResponse.from(result);
 
         return ApiResponseBody.ok(UserSuccessCode.GET_USER_INFO_OK, response);

--- a/src/main/java/org/sopt/snappinserver/api/user/dto/response/GetClientInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/user/dto/response/GetClientInfoResponse.java
@@ -1,0 +1,23 @@
+package org.sopt.snappinserver.api.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetClientInfoResult;
+
+@Schema(description = "고객 정보 응답 DTO")
+public record GetClientInfoResponse(
+
+    @Schema(description = "고객명")
+    String name,
+
+    @Schema(description = "고객 큐레이션 무드 결과 목록")
+    List<String> curatedMoods
+) {
+
+    public static GetClientInfoResponse from(GetClientInfoResult result) {
+        return new GetClientInfoResponse(
+            result.name(),
+            result.curatedMoods()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/user/dto/response/GetPhotographerInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/user/dto/response/GetPhotographerInfoResponse.java
@@ -1,0 +1,31 @@
+package org.sopt.snappinserver.api.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetPhotographerInfoResult;
+
+@Schema(description = "작가 정보 응답 DTO")
+public record GetPhotographerInfoResponse(
+
+    @Schema(description = "작가명")
+    String name,
+
+    @Schema(description = "한줄 소개")
+    String bio,
+
+    @Schema(description = "작가 촬영 상품")
+    List<String> specialties,
+
+    @Schema(description = "작가 활동 지역")
+    List<String> locations
+) {
+
+    public static GetPhotographerInfoResponse from(GetPhotographerInfoResult result) {
+        return new GetPhotographerInfoResponse(
+            result.name(),
+            result.bio(),
+            result.specialties(),
+            result.locations()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/user/dto/response/GetUserInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/user/dto/response/GetUserInfoResponse.java
@@ -1,0 +1,42 @@
+package org.sopt.snappinserver.api.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetUserInfoResult;
+
+@Schema(description = "유저 정보 조회 응답 DTO")
+public record GetUserInfoResponse(
+
+    @Schema(description = "유저 ID")
+    Long id,
+
+    @Schema(description = "현재 로그인된 유저 역할")
+    String role,
+
+    @Schema(description = "유저 프로필 이미지")
+    String profileImageUrl,
+
+    @Schema(description = "작가 프로필 보유 여부")
+    boolean hasPhotographerProfile,
+
+    @Schema(description = "고객 관련 정보 DTO")
+    GetClientInfoResponse clientInfo,
+
+    @Schema(description = "작가 프로필 관련 정보 DTO")
+    GetPhotographerInfoResponse photographerInfo
+) {
+
+    public static GetUserInfoResponse from(GetUserInfoResult result) {
+        return new GetUserInfoResponse(
+            result.id(),
+            result.role(),
+            result.profileImageUrl(),
+            result.hasPhotographerProfile(),
+            result.clientInfo() != null
+                ? GetClientInfoResponse.from(result.clientInfo())
+                : null,
+            result.photographerInfo() != null
+                ? GetPhotographerInfoResponse.from(result.photographerInfo())
+                : null
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/curation/repository/CurationRepositoryCustom.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/repository/CurationRepositoryCustom.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.curation.repository;
+
+import java.util.List;
+
+public interface CurationRepositoryCustom {
+
+    List<Long> findTop3MoodIdsByUserId(Long userId);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/curation/repository/CurationRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/repository/CurationRepositoryImpl.java
@@ -1,0 +1,25 @@
+package org.sopt.snappinserver.domain.curation.repository;
+
+import static org.sopt.snappinserver.domain.curation.domain.entity.QCuration.curation;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class CurationRepositoryImpl implements CurationRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<Long> findTop3MoodIdsByUserId(Long userId) {
+        return jpaQueryFactory
+            .select(curation.mood.id)
+            .from(curation)
+            .where(curation.user.id.eq(userId))
+            .orderBy(curation.createdAt.desc())
+            .limit(3)
+            .fetch();
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/repository/PhotographerRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/repository/PhotographerRepository.java
@@ -1,8 +1,12 @@
 package org.sopt.snappinserver.domain.photographer.repository;
 
+import java.util.Optional;
 import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PhotographerRepository extends JpaRepository<Photographer, Long> {
+
+    Optional<Photographer> findByUser(User user);
 
 }

--- a/src/main/java/org/sopt/snappinserver/domain/user/domain/entity/User.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/domain/entity/User.java
@@ -26,6 +26,8 @@ public class User extends BaseEntity {
 
     private static final int MAX_NAME_LENGTH = 50;
     private static final int MAX_PROFILE_IMAGE_URL_LENGTH = 1024;
+    private static final String CLIENT_ROLE = "CLIENT";
+    private static final String PHOTOGRAPHER_ROLE = "PHOTOGRAPHER";
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "users_seq_gen")
@@ -66,6 +68,7 @@ public class User extends BaseEntity {
         validateUserRoleExists(role);
         validateNameExists(name);
         validateNameLength(name);
+        validateProfileImageUrl(profileImageUrl);
     }
 
     private static void validateUserRoleExists(UserRole role) {
@@ -87,11 +90,27 @@ public class User extends BaseEntity {
     }
 
     private static void validateProfileImageUrl(String profileImageUrl) {
-        if(profileImageUrl == null || profileImageUrl.isBlank()) {
+        validateProfileImageExists(profileImageUrl);
+        validateProfileImageLength(profileImageUrl);
+    }
 
+    private static void validateProfileImageExists(String profileImageUrl) {
+        if (profileImageUrl == null || profileImageUrl.isBlank()) {
+            throw new UserException(UserErrorCode.PROFILE_IMAGE_URL_REQUIRED);
         }
-        if(profileImageUrl.length() > MAX_PROFILE_IMAGE_URL_LENGTH) {
+    }
 
+    private static void validateProfileImageLength(String profileImageUrl) {
+        if (profileImageUrl.length() > MAX_PROFILE_IMAGE_URL_LENGTH) {
+            throw new UserException(UserErrorCode.PROFILE_IMAGE_URL_TOO_LONG);
         }
+    }
+
+    public boolean isLoginByClient() {
+        return this.role.name().equals(CLIENT_ROLE);
+    }
+
+    public boolean isLoginByPhotographer() {
+        return this.role.name().equals(PHOTOGRAPHER_ROLE);
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/user/domain/entity/User.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/domain/entity/User.java
@@ -26,8 +26,6 @@ public class User extends BaseEntity {
 
     private static final int MAX_NAME_LENGTH = 50;
     private static final int MAX_PROFILE_IMAGE_URL_LENGTH = 1024;
-    private static final String CLIENT_ROLE = "CLIENT";
-    private static final String PHOTOGRAPHER_ROLE = "PHOTOGRAPHER";
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "users_seq_gen")
@@ -107,10 +105,6 @@ public class User extends BaseEntity {
     }
 
     public boolean isLoginByClient() {
-        return this.role.name().equals(CLIENT_ROLE);
-    }
-
-    public boolean isLoginByPhotographer() {
-        return this.role.name().equals(PHOTOGRAPHER_ROLE);
+        return this.role == UserRole.CLIENT;
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/domain/exception/UserErrorCode.java
@@ -20,7 +20,8 @@ public enum UserErrorCode implements ErrorCode {
     // 403 FORBIDDEN
 
     // 404 NOT FOUND
-    USER_NOT_FOUND(404, "USER_404_001","존재하지 않는 사용자입니다.")
+    USER_NOT_FOUND(404, "USER_404_001","존재하지 않는 사용자입니다."),
+    PHOTOGRAPHER_NOT_FOUND(404, "USER_404_002", "해당 사용자의 작가 프로필이 존재하지 않습니다."),
 
     ;
 

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
@@ -1,0 +1,111 @@
+package org.sopt.snappinserver.domain.user.service;
+
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.curation.repository.CurationRepositoryCustom;
+import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
+import org.sopt.snappinserver.domain.mood.repository.MoodRepository;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+import org.sopt.snappinserver.domain.photographer.repository.PhotographerAvailableLocationRepository;
+import org.sopt.snappinserver.domain.photographer.repository.PhotographerRepository;
+import org.sopt.snappinserver.domain.photographer.repository.PhotographerSpecialtyRepository;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
+import org.sopt.snappinserver.domain.user.domain.exception.UserErrorCode;
+import org.sopt.snappinserver.domain.user.domain.exception.UserException;
+import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetClientInfoResult;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetPhotographerInfoResult;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetUserInfoResult;
+import org.sopt.snappinserver.domain.user.service.usecase.GetUserInfoUseCase;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class GetUserInfoService implements GetUserInfoUseCase {
+
+    private final UserRepository userRepository;
+    private final PhotographerRepository photographerRepository;
+    private final MoodRepository moodRepository;
+    private final CurationRepositoryCustom curationRepository;
+    private final PhotographerSpecialtyRepository specialtyRepository;
+    private final PhotographerAvailableLocationRepository locationRepository;
+
+    @Override
+    public GetUserInfoResult getUserInfo(Long userId) {
+        User user = getUser(userId);
+        Optional<Photographer> photographerOpt = photographerRepository.findByUser(user);
+
+        if (user.isLoginByClient()) {
+            return getClientInfo(user, photographerOpt);
+        }
+        return getPhotographerInfo(user, photographerOpt);
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    private GetUserInfoResult getClientInfo(
+        User user,
+        Optional<Photographer> photographerOptional
+    ) {
+        List<Long> moodIds = curationRepository.findTop3MoodIdsByUserId(user.getId());
+        List<String> moodNames = getMoodNames(moodIds);
+        GetClientInfoResult clientInfo = new GetClientInfoResult(user.getName(), moodNames);
+
+        return GetUserInfoResult.of(user, photographerOptional, clientInfo, null);
+    }
+
+    private List<String> getMoodNames(List<Long> moodIds) {
+        return moodRepository.findAllById(moodIds)
+            .stream()
+            .map(Mood::getName)
+            .toList();
+    }
+
+
+    private GetUserInfoResult getPhotographerInfo(
+        User user,
+        Optional<Photographer> photographerOptional
+    ) {
+        Photographer photographer = getPhotographer(photographerOptional);
+        List<String> specialties = getSpecialties(photographer);
+        List<String> locations = getAvailableLocations(photographer);
+        GetPhotographerInfoResult photographerInfo = new GetPhotographerInfoResult(
+            photographer.getName(),
+            photographer.getBio(),
+            specialties,
+            locations
+        );
+
+        return GetUserInfoResult.of(user, photographerOptional, null, photographerInfo);
+    }
+
+    private static Photographer getPhotographer(Optional<Photographer> photographerOptional) {
+        return photographerOptional
+            .orElseThrow(() -> new UserException(UserErrorCode.PHOTOGRAPHER_NOT_FOUND));
+    }
+
+    private List<String> getSpecialties(Photographer photographer) {
+        return specialtyRepository
+            .findAllByPhotographer(photographer)
+            .stream()
+            .map(photographerSpecialty
+                -> photographerSpecialty.getSpecialty().getCategory()
+            )
+            .toList();
+    }
+
+    private List<String> getAvailableLocations(Photographer photographer) {
+        return locationRepository
+            .findAllByPhotographer(photographer)
+            .stream()
+            .map(
+                photographerAvailableLocation
+                    -> photographerAvailableLocation.getAvailableLocation().getFullLocation()
+            )
+            .toList();
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
@@ -1,7 +1,6 @@
 package org.sopt.snappinserver.domain.user.service;
 
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.domain.curation.repository.CurationRepositoryCustom;
 import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
@@ -36,12 +35,12 @@ public class GetUserInfoService implements GetUserInfoUseCase {
     @Override
     public GetUserInfoResult getUserInfo(Long userId) {
         User user = getUser(userId);
-        Optional<Photographer> photographerOpt = photographerRepository.findByUser(user);
+        Photographer photographer = photographerRepository.findByUser(user)
+            .orElse(null);
 
-        if (user.isLoginByClient()) {
-            return getClientInfo(user, photographerOpt);
-        }
-        return getPhotographerInfo(user, photographerOpt);
+        return user.isLoginByClient()
+            ? getClientInfo(user)
+            : getPhotographerInfo(user, photographer);
     }
 
     private User getUser(Long userId) {
@@ -50,14 +49,13 @@ public class GetUserInfoService implements GetUserInfoUseCase {
     }
 
     private GetUserInfoResult getClientInfo(
-        User user,
-        Optional<Photographer> photographerOptional
+        User user
     ) {
         List<Long> moodIds = curationRepository.findTop3MoodIdsByUserId(user.getId());
         List<String> moodNames = getMoodNames(moodIds);
         GetClientInfoResult clientInfo = new GetClientInfoResult(user.getName(), moodNames);
 
-        return GetUserInfoResult.of(user, photographerOptional, clientInfo, null);
+        return GetUserInfoResult.of(user, null, clientInfo, null);
     }
 
     private List<String> getMoodNames(List<Long> moodIds) {
@@ -67,12 +65,10 @@ public class GetUserInfoService implements GetUserInfoUseCase {
             .toList();
     }
 
-
     private GetUserInfoResult getPhotographerInfo(
         User user,
-        Optional<Photographer> photographerOptional
+        Photographer photographer
     ) {
-        Photographer photographer = getPhotographer(photographerOptional);
         List<String> specialties = getSpecialties(photographer);
         List<String> locations = getAvailableLocations(photographer);
         GetPhotographerInfoResult photographerInfo = new GetPhotographerInfoResult(
@@ -82,12 +78,7 @@ public class GetUserInfoService implements GetUserInfoUseCase {
             locations
         );
 
-        return GetUserInfoResult.of(user, photographerOptional, null, photographerInfo);
-    }
-
-    private static Photographer getPhotographer(Optional<Photographer> photographerOptional) {
-        return photographerOptional
-            .orElseThrow(() -> new UserException(UserErrorCode.PHOTOGRAPHER_NOT_FOUND));
+        return GetUserInfoResult.of(user, photographer, null, photographerInfo);
     }
 
     private List<String> getSpecialties(Photographer photographer) {

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
@@ -19,7 +19,9 @@ import org.sopt.snappinserver.domain.user.service.dto.response.GetPhotographerIn
 import org.sopt.snappinserver.domain.user.service.dto.response.GetUserInfoResult;
 import org.sopt.snappinserver.domain.user.service.usecase.GetUserInfoUseCase;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class GetUserInfoService implements GetUserInfoUseCase {

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetClientInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetClientInfoResult.java
@@ -1,0 +1,10 @@
+package org.sopt.snappinserver.domain.user.service.dto.response;
+
+import java.util.List;
+
+public record GetClientInfoResult(
+    String name,
+    List<String> curatedMoods
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetPhotographerInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetPhotographerInfoResult.java
@@ -1,0 +1,12 @@
+package org.sopt.snappinserver.domain.user.service.dto.response;
+
+import java.util.List;
+
+public record GetPhotographerInfoResult(
+    String name,
+    String bio,
+    List<String> specialties,
+    List<String> locations
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetUserInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetUserInfoResult.java
@@ -1,0 +1,31 @@
+package org.sopt.snappinserver.domain.user.service.dto.response;
+
+import java.util.Optional;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
+
+public record GetUserInfoResult(
+    Long id,
+    String role,
+    String profileImageUrl,
+    boolean hasPhotographerProfile,
+    GetClientInfoResult clientInfo,
+    GetPhotographerInfoResult photographerInfo
+) {
+    public static GetUserInfoResult of(
+        User user,
+        Optional<Photographer> photographer,
+        GetClientInfoResult clientInfo,
+        GetPhotographerInfoResult photographerInfo
+    ) {
+        return new GetUserInfoResult(
+            user.getId(),
+            user.getRole().name(),
+            user.getProfileImageUrl(),
+            photographer.isPresent(),
+            clientInfo,
+            photographerInfo
+        );
+    }
+}
+

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetUserInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetUserInfoResult.java
@@ -1,6 +1,5 @@
 package org.sopt.snappinserver.domain.user.service.dto.response;
 
-import java.util.Optional;
 import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
 
@@ -14,7 +13,7 @@ public record GetUserInfoResult(
 ) {
     public static GetUserInfoResult of(
         User user,
-        Optional<Photographer> photographer,
+        Photographer photographer,
         GetClientInfoResult clientInfo,
         GetPhotographerInfoResult photographerInfo
     ) {
@@ -22,7 +21,7 @@ public record GetUserInfoResult(
             user.getId(),
             user.getRole().name(),
             user.getProfileImageUrl(),
-            photographer.isPresent(),
+            photographer != null,
             clientInfo,
             photographerInfo
         );

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/usecase/GetUserInfoUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/usecase/GetUserInfoUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.user.service.usecase;
+
+import org.sopt.snappinserver.domain.user.service.dto.response.GetUserInfoResult;
+
+public interface GetUserInfoUseCase {
+
+    GetUserInfoResult getUserInfo(Long userId);
+}


### PR DESCRIPTION
## 👀 Summary

- close #64


## 🖇️ Tasks

- 사용자 기본 정보 조회 로직 구현
- 로그인 역할 기준 분기 처리
    - Client 로그인 시 큐레이션 테이블 기반 최근 무드 태그 이름 목록 조회
   - Photographer 로그인 시 작가 전문 분야, 활동 지역 목록 조회
- 여러 Repository 결과를 Service 계층에서 조합하여 GetUserInfoResult 생성


## 🔍 To Reviewer

### ❶ 하나의 API 에서 사용자의 역할에 따른 분기 처리 책임에 대한 고민
이전 "전체 무드 필터 값 조회" API와 비슷하게, 하나의 API에서 사용자의 로그인 여부나 사용자의 역할에 따라 다른 로직이 사용되고, 그에 따라 필요한 리포지토리가 달라지는 경우 해당 조회의 책임을 특정 분기에서만 사용되는 응답 DTO의 정적 팩토리 메서드에 두어야 할지, 서비스 메서드에 두어야 할지 고민했습니다.

이 고민에 대해 각 클래스의 책임을 다시 생각해보았습니다. DTO의 책임은 데이터 변환이고, 서비스 계층은 실제 비즈니스 로직을 실행하고, DB 관련 조회 로직을 조합하는 역할을 가집니다. 따라서, 서비스에서 유저 정보 후, 조회한 유저의 역할을 바탕으로 어떤 응답을 내려줄지에 대한 분기처리를 진행했습니다. 그래서 각 분기 처리 시에만 필요한 데이터들을 해당 분기에서만 가져올 수 있도록 불필요한 DB 조회를 최소화했습니다.

피곤해서 말이 안 나오네요....
