### PR TITLE
[FEAT] #88: 예약 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
@@ -9,6 +9,11 @@ import org.sopt.snappinserver.global.response.code.common.SuccessCode;
 public enum ReservationSuccessCode implements SuccessCode {
 
     // 200 OK
+    GET_RESERVATION_LIST_OK(
+        200,
+        "RESERVATION_200_001",
+        "예약 목록 조회에 성공했습니다."
+    ),
 
     // 201 CREATED
     POST_RESERVATION_REVIEW_CREATED(201, "RESERVATION_201_001", "예약 리뷰 등록에 성공했습니다.");

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
@@ -48,7 +48,7 @@ public interface ReservationApi {
         CustomUserInfo userInfo,
 
         @Schema(description = "예약 조회 탭", example = "CLIENT_OVERVIEW")
-        @RequestParam ReservationStatusTab tab
+        @RequestParam @NotNull ReservationStatusTab tab
     );
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
@@ -33,7 +33,7 @@ public interface ReservationApi {
         @Schema(description = "예약 아이디", example = "1")
         @PathVariable @NotNull Long reservationId,
 
-        @Schema(description = "리뷰 정보", example = "1")
+        @Schema(description = "리뷰 정보")
         @Valid @RequestBody CreateReservationReviewRequest request
     );
 
@@ -47,7 +47,7 @@ public interface ReservationApi {
         @Parameter(hidden = true)
         CustomUserInfo userInfo,
 
-        @Schema(description = "예약 조회 탭", example = "예약 현황")
+        @Schema(description = "예약 조회 탭", example = "CLIENT_OVERVIEW")
         @RequestParam ReservationStatusTab tab
     );
 

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
@@ -2,16 +2,21 @@ package org.sopt.snappinserver.api.reservation.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import org.sopt.snappinserver.api.reservation.dto.request.CreateReservationReviewRequest;
 import org.sopt.snappinserver.api.reservation.dto.response.CreateReservationReviewResponse;
+import org.sopt.snappinserver.api.reservation.dto.response.ReservationListResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatusTab;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "010 - Reservation", description = "예약 관련 API")
 public interface ReservationApi {
@@ -25,9 +30,25 @@ public interface ReservationApi {
         @Parameter(hidden = true)
         CustomUserInfo userInfo,
 
+        @Schema(description = "예약 아이디", example = "1")
         @PathVariable @NotNull Long reservationId,
 
+        @Schema(description = "리뷰 정보", example = "1")
         @Valid @RequestBody CreateReservationReviewRequest request
+    );
+
+    @Operation(
+        summary = "예약 목록 조회",
+        description = "예약 탭에 해당하는 예약 목록을 조회합니다."
+    )
+    @GetMapping
+    ApiResponseBody<ReservationListResponse, Void> getReservations(
+
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo,
+
+        @Schema(description = "예약 조회 탭", example = "예약 현황")
+        @RequestParam ReservationStatusTab tab
     );
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
@@ -4,9 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.reservation.code.ReservationSuccessCode;
 import org.sopt.snappinserver.api.reservation.dto.request.CreateReservationReviewRequest;
 import org.sopt.snappinserver.api.reservation.dto.response.CreateReservationReviewResponse;
+import org.sopt.snappinserver.api.reservation.dto.response.ReservationListResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatusTab;
 import org.sopt.snappinserver.domain.reservation.service.dto.request.CreateReservationReviewCommand;
 import org.sopt.snappinserver.domain.reservation.service.dto.response.CreateReservationReviewResult;
+import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationListUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.PostReservationReviewUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReservationController implements ReservationApi {
 
     private final PostReservationReviewUseCase postReservationReviewUseCase;
+    private final GetReservationListUseCase getReservationListUseCase;
 
     @Override
     public ApiResponseBody<CreateReservationReviewResponse, Void> createReview(
@@ -42,5 +46,19 @@ public class ReservationController implements ReservationApi {
             CreateReservationReviewResponse.from(result)
         );
     }
+
+    @Override
+    public ApiResponseBody<ReservationListResponse, Void> getReservations(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        ReservationStatusTab tab
+    ) {
+        return ApiResponseBody.ok(
+            ReservationSuccessCode.GET_RESERVATION_LIST_OK,
+            ReservationListResponse.from(
+                getReservationListUseCase.getReservationList(userInfo.userId(), tab)
+            )
+        );
+    }
+
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationListItemResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationListItemResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.snappinserver.api.reservation.dto.response;
+
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationListItemResult;
+
+public record ReservationListItemResponse(
+    Long reservationId,
+    String status,
+    String client,
+    String createdAt,
+    ReservationListProductResponse product
+) {
+
+    public static ReservationListItemResponse from(GetReservationListItemResult result) {
+        return new ReservationListItemResponse(
+            result.reservationId(),
+            result.status(),
+            result.client(),
+            result.createdAt(),
+            ReservationListProductResponse.from(result.product())
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationListProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationListProductResponse.java
@@ -1,0 +1,33 @@
+package org.sopt.snappinserver.api.reservation.dto.response;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationListProductResult;
+
+public record ReservationListProductResponse(
+    Long id,
+    String imageUrl,
+    String title,
+    double rate,
+    int reviewCount,
+    String photographer,
+    int price,
+    List<String> moods,
+    boolean isReviewed
+) {
+
+    public static ReservationListProductResponse from(
+        GetReservationListProductResult result
+    ) {
+        return new ReservationListProductResponse(
+            result.id(),
+            result.imageUrl(),
+            result.title(),
+            result.rate(),
+            result.reviewCount(),
+            result.photographer(),
+            result.price(),
+            result.moods(),
+            result.isReviewed()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationListResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationListResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.snappinserver.api.reservation.dto.response;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationListResult;
+
+public record ReservationListResponse(
+    List<ReservationListItemResponse> reservations
+) {
+
+    public static ReservationListResponse from(GetReservationListResult result) {
+        return new ReservationListResponse(result
+            .reservations()
+            .stream()
+            .map(ReservationListItemResponse::from)
+            .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductMoodRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductMoodRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ProductMoodRepository extends JpaRepository<ProductMood, Long> {
 
     List<ProductMood> findAllByProduct(Product product);
+
+    List<ProductMood> findAllByProductIdIn(List<Long> productIds);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
@@ -1,14 +1,36 @@
 package org.sopt.snappinserver.domain.product.repository;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.sopt.snappinserver.domain.product.domain.entity.ProductPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductPhotoRepository extends JpaRepository<ProductPhoto, Long> {
 
     Optional<ProductPhoto> findFirstByProductOrderByDisplayOrderAsc(Product product);
+
+    @Query("""
+        select pp
+        from ProductPhoto pp
+        join fetch pp.photo ph
+        where pp.product.id in :productIds
+          and pp.displayOrder = 0
+    """)
+    List<ProductPhoto> findThumbnails(@Param("productIds") List<Long> productIds);
+
+    default Map<Long, String> findThumbnailByProductIds(List<Long> productIds) {
+        return findThumbnails(productIds).stream()
+            .collect(Collectors.toMap(
+                pp -> pp.getProduct().getId(),
+                pp -> pp.getPhoto().getImageUrl()
+            ));
+    }
 
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
@@ -17,19 +17,23 @@ public interface ProductPhotoRepository extends JpaRepository<ProductPhoto, Long
     Optional<ProductPhoto> findFirstByProductOrderByDisplayOrderAsc(Product product);
 
     @Query("""
-        select pp
-        from ProductPhoto pp
-        join fetch pp.photo ph
-        where pp.product.id in :productIds
-          and pp.displayOrder = 0
-    """)
+            select pp
+            from ProductPhoto pp
+            join fetch pp.photo ph
+            where pp.product.id in :productIds
+              and pp.displayOrder = 0
+        """)
     List<ProductPhoto> findThumbnails(@Param("productIds") List<Long> productIds);
 
     default Map<Long, String> findThumbnailByProductIds(List<Long> productIds) {
+        if (productIds.isEmpty()) {
+            return Map.of();
+        }
         return findThumbnails(productIds).stream()
             .collect(Collectors.toMap(
                 pp -> pp.getProduct().getId(),
-                pp -> pp.getPhoto().getImageUrl()
+                pp -> pp.getPhoto().getImageUrl(),
+                (existing, replacement) -> existing
             ));
     }
 

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/enums/ReservationStatusTab.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/enums/ReservationStatusTab.java
@@ -17,19 +17,27 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ReservationStatusTab {
 
-    CLIENT_OVERVIEW(
-        "예약 현황",
-        List.of(RESERVATION_REQUESTED, PHOTOGRAPHER_CHECKING, PAYMENT_REQUESTED, PAYMENT_COMPLETED,
-            RESERVATION_CANCELED, RESERVATION_REFUSED)
+    CLIENT_OVERVIEW("예약 현황",
+        List.of(
+            RESERVATION_REQUESTED,
+            PHOTOGRAPHER_CHECKING,
+            PAYMENT_REQUESTED,
+            PAYMENT_COMPLETED,
+            RESERVATION_CANCELED,
+            RESERVATION_REFUSED
+        )
     ),
 
     CLIENT_DONE("촬영 완료", List.of(SHOOT_COMPLETED)),
 
     PHOTOGRAPHER_REQUESTED("예약 요청", List.of(RESERVATION_REQUESTED)),
 
-    PHOTOGRAPHER_ADJUSTING(
-        "조율 중",
-        List.of(PHOTOGRAPHER_CHECKING, PAYMENT_REQUESTED, PAYMENT_COMPLETED)
+    PHOTOGRAPHER_ADJUSTING("조율 중",
+        List.of(
+            PHOTOGRAPHER_CHECKING,
+            PAYMENT_REQUESTED,
+            PAYMENT_COMPLETED
+        )
     ),
 
     PHOTOGRAPHER_CONFIRMED("예약 확정", List.of(RESERVATION_CONFIRMED)),

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/enums/ReservationStatusTab.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/enums/ReservationStatusTab.java
@@ -23,6 +23,7 @@ public enum ReservationStatusTab {
             PHOTOGRAPHER_CHECKING,
             PAYMENT_REQUESTED,
             PAYMENT_COMPLETED,
+            RESERVATION_CONFIRMED,
             RESERVATION_CANCELED,
             RESERVATION_REFUSED
         )
@@ -30,22 +31,33 @@ public enum ReservationStatusTab {
 
     CLIENT_DONE("촬영 완료", List.of(SHOOT_COMPLETED)),
 
-    PHOTOGRAPHER_REQUESTED("예약 요청", List.of(RESERVATION_REQUESTED)),
+    PHOTOGRAPHER_REQUESTED("예약 요청", List.of(RESERVATION_REQUESTED, RESERVATION_CANCELED)),
 
     PHOTOGRAPHER_ADJUSTING("조율 중",
         List.of(
             PHOTOGRAPHER_CHECKING,
             PAYMENT_REQUESTED,
-            PAYMENT_COMPLETED
+            PAYMENT_COMPLETED,
+            RESERVATION_CANCELED,
+            RESERVATION_REFUSED
         )
     ),
 
-    PHOTOGRAPHER_CONFIRMED("예약 확정", List.of(RESERVATION_CONFIRMED)),
+    PHOTOGRAPHER_CONFIRMED("예약 확정",
+        List.of(
+            RESERVATION_CONFIRMED,
+            RESERVATION_CANCELED,
+            RESERVATION_REFUSED)
+    ),
 
     PHOTOGRAPHER_DONE("촬영 완료", List.of(SHOOT_COMPLETED)),
     ;
 
     private final String tab;
     private final List<ReservationStatus> relatedStatus;
+
+    public boolean isClientTab() {
+        return this == CLIENT_OVERVIEW || this == CLIENT_DONE;
+    }
 
 }

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepository.java
@@ -6,6 +6,8 @@ import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
 import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -21,5 +23,38 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findAllByProductAndReservationStatusIn(
         Product product,
         List<ReservationStatus> statuses
+    );
+
+
+    // 고객 예약 목록
+    @Query("""
+        select r
+        from Reservation r
+        join fetch r.product p
+        join fetch p.photographer ph
+        join fetch r.user u
+        where u.id = :userId
+          and r.reservationStatus in :statuses
+        order by r.createdAt desc
+    """)
+    List<Reservation> findClientReservations(
+        @Param("userId") Long userId,
+        @Param("statuses") List<ReservationStatus> statuses
+    );
+
+    // 작가 예약 목록
+    @Query("""
+        select r
+        from Reservation r
+        join fetch r.product p
+        join fetch p.photographer ph
+        join fetch r.user u
+        where ph.user.id = :userId
+          and r.reservationStatus in :statuses
+        order by r.createdAt desc
+    """)
+    List<Reservation> findPhotographerReservations(
+        @Param("userId") Long userId,
+        @Param("statuses") List<ReservationStatus> statuses
     );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
@@ -57,7 +57,7 @@ public class GetReservationListService implements GetReservationListUseCase {
         Map<Long, List<String>> productMoodMap = getProductMoods(productIds);
         Map<Long, String> productThumbnailMap = getThumbnailImage(productIds);
 
-        List<GetReservationListItemResult> results = getGetReservationListItems(
+        List<GetReservationListItemResult> results = getReservationListItems(
             filtered,
             productThumbnailMap,
             productMoodMap,
@@ -149,7 +149,7 @@ public class GetReservationListService implements GetReservationListUseCase {
         return productPhotoRepository.findThumbnailByProductIds(productIds);
     }
 
-    private List<GetReservationListItemResult> getGetReservationListItems(
+    private List<GetReservationListItemResult> getReservationListItems(
         List<Reservation> filtered,
         Map<Long, String> productThumbnailMap,
         Map<Long, List<String>> productMoodMap,

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
@@ -1,0 +1,177 @@
+package org.sopt.snappinserver.domain.reservation.service;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.product.repository.ProductMoodRepository;
+import org.sopt.snappinserver.domain.product.repository.ProductPhotoRepository;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult;
+import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatusTab;
+import org.sopt.snappinserver.domain.reservation.repository.ReservationRepository;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationListItemResult;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationListProductResult;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationListResult;
+import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationListUseCase;
+import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetReservationListService implements GetReservationListUseCase {
+
+    private static final DateTimeFormatter FORMATTER =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final ReservationRepository reservationRepository;
+    private final ReviewRepository reviewRepository;
+    private final ProductMoodRepository productMoodRepository;
+    private final ProductPhotoRepository productPhotoRepository;
+
+    @Override
+    public GetReservationListResult getReservationList(
+        Long userId,
+        ReservationStatusTab tab
+    ) {
+        // 1. status 기준 조회
+        List<Reservation> reservations =
+            tab.isClientTab()
+                ? reservationRepository.findClientReservations(
+                userId, tab.getRelatedStatus()
+            )
+                : reservationRepository.findPhotographerReservations(
+                    userId, tab.getRelatedStatus()
+                );
+
+        // 2. 취소/거절 이전 상태 필터
+        List<Reservation> filtered = reservations.stream()
+            .filter(r -> isAllowedCanceledReservation(r, tab))
+            .toList();
+
+        if (filtered.isEmpty()) {
+            return new GetReservationListResult(List.of());
+        }
+
+        // 3. ID 수집
+        List<Long> reservationIds =
+            filtered.stream().map(Reservation::getId).toList();
+
+        List<Long> productIds =
+            filtered.stream()
+                .map(r -> r.getProduct().getId())
+                .distinct()
+                .toList();
+
+        // 4. 리뷰 작성 여부
+        Set<Long> reviewedReservationIds =
+            new HashSet<>(reviewRepository.findReviewedReservationIds(reservationIds));
+
+        // 5. 상품 리뷰 통계 (batch)
+        Map<Long, ProductReviewStatsResult> reviewStatsMap =
+            reviewRepository.findReviewStatsByProductIds(productIds).stream()
+                .collect(Collectors.toMap(
+                    row -> (Long) row[0],
+                    row -> (ProductReviewStatsResult) row[1]
+                ));
+
+        // 6. 상품 무드
+        Map<Long, List<String>> productMoodMap =
+            productMoodRepository.findAllByProductIdIn(productIds).stream()
+                .collect(Collectors.groupingBy(
+                    pm -> pm.getProduct().getId(),
+                    Collectors.mapping(
+                        pm -> pm.getMood().getName(),
+                        Collectors.toList()
+                    )
+                ));
+
+        // 7. 썸네일
+        Map<Long, String> productThumbnailMap =
+            productPhotoRepository.findThumbnailByProductIds(productIds);
+
+        // 8. DTO 변환
+        List<GetReservationListItemResult> results =
+            filtered.stream()
+                .map(r -> toItemResult(
+                    r,
+                    productThumbnailMap,
+                    productMoodMap,
+                    reviewedReservationIds,
+                    reviewStatsMap
+                ))
+                .toList();
+
+        return new GetReservationListResult(results);
+    }
+
+    private boolean isAllowedCanceledReservation(
+        Reservation reservation,
+        ReservationStatusTab tab
+    ) {
+        ReservationStatus status = reservation.getReservationStatus();
+
+        if (status != ReservationStatus.RESERVATION_CANCELED
+            && status != ReservationStatus.RESERVATION_REFUSED) {
+            return true;
+        }
+
+        ReservationStatus prev = reservation.getPreviousCancelStatus();
+
+        return switch (tab) {
+            case PHOTOGRAPHER_REQUESTED -> prev == ReservationStatus.RESERVATION_REQUESTED;
+
+            case PHOTOGRAPHER_ADJUSTING -> prev == ReservationStatus.PHOTOGRAPHER_CHECKING
+                || prev == ReservationStatus.PAYMENT_REQUESTED
+                || prev == ReservationStatus.PAYMENT_COMPLETED;
+
+            case PHOTOGRAPHER_CONFIRMED -> prev == ReservationStatus.RESERVATION_CONFIRMED;
+
+            case CLIENT_OVERVIEW -> true;
+
+            default -> false;
+        };
+    }
+
+    private GetReservationListItemResult toItemResult(
+        Reservation reservation,
+        Map<Long, String> productThumbnailMap,
+        Map<Long, List<String>> productMoodMap,
+        Set<Long> reviewedReservationIds,
+        Map<Long, ProductReviewStatsResult> reviewStatsMap
+    ) {
+        var product = reservation.getProduct();
+        Long productId = product.getId();
+
+        ProductReviewStatsResult stats =
+            reviewStatsMap.getOrDefault(
+                productId,
+                new ProductReviewStatsResult(0L, 0.0)
+            );
+
+        return new GetReservationListItemResult(
+            reservation.getId(),
+            reservation.getReservationStatus().name(),
+            reservation.getUser().getName(),
+            reservation.getCreatedAt()
+                .atZone(ZoneId.systemDefault())
+                .format(FORMATTER),
+            new GetReservationListProductResult(
+                productId,
+                productThumbnailMap.get(productId),
+                product.getTitle(),
+                stats.averageRating(),
+                (int) stats.reviewCount(),
+                product.getPhotographer().getUser().getName(),
+                product.getPrice(),
+                productMoodMap.getOrDefault(productId, List.of()),
+                reviewedReservationIds.contains(reservation.getId())
+            )
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.sopt.snappinserver.domain.product.repository.ProductMoodRepository;
 import org.sopt.snappinserver.domain.product.repository.ProductPhotoRepository;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult;
@@ -39,85 +40,53 @@ public class GetReservationListService implements GetReservationListUseCase {
         Long userId,
         ReservationStatusTab tab
     ) {
-        // 1. status 기준 조회
-        List<Reservation> reservations =
-            tab.isClientTab()
-                ? reservationRepository.findClientReservations(
-                userId, tab.getRelatedStatus()
-            )
-                : reservationRepository.findPhotographerReservations(
-                    userId, tab.getRelatedStatus()
-                );
 
-        // 2. 취소/거절 이전 상태 필터
-        List<Reservation> filtered = reservations.stream()
-            .filter(r -> isAllowedCanceledReservation(r, tab))
-            .toList();
+        List<Reservation> reservations = getReservationsByTab(userId, tab);
+        List<Reservation> filtered = filterReservationsByTab(tab, reservations);
 
         if (filtered.isEmpty()) {
             return new GetReservationListResult(List.of());
         }
 
-        // 3. ID 수집
-        List<Long> reservationIds =
-            filtered.stream().map(Reservation::getId).toList();
+        List<Long> reservationIds = getReservationIds(filtered);
+        List<Long> productIds = getProductIds(filtered);
 
-        List<Long> productIds =
-            filtered.stream()
-                .map(r -> r.getProduct().getId())
-                .distinct()
-                .toList();
+        Set<Long> reviewedReservationIds = getIsReviewed(reservationIds);
 
-        // 4. 리뷰 작성 여부
-        Set<Long> reviewedReservationIds =
-            new HashSet<>(reviewRepository.findReviewedReservationIds(reservationIds));
+        Map<Long, ProductReviewStatsResult> reviewStatsMap = getReviewStats(productIds);
+        Map<Long, List<String>> productMoodMap = getProductMoods(productIds);
+        Map<Long, String> productThumbnailMap = getThumbnailImage(productIds);
 
-        // 5. 상품 리뷰 통계 (batch)
-        Map<Long, ProductReviewStatsResult> reviewStatsMap =
-            reviewRepository.findReviewStatsByProductIds(productIds).stream()
-                .collect(Collectors.toMap(
-                    row -> (Long) row[0],
-                    row -> (ProductReviewStatsResult) row[1]
-                ));
-
-        // 6. 상품 무드
-        Map<Long, List<String>> productMoodMap =
-            productMoodRepository.findAllByProductIdIn(productIds).stream()
-                .collect(Collectors.groupingBy(
-                    pm -> pm.getProduct().getId(),
-                    Collectors.mapping(
-                        pm -> pm.getMood().getName(),
-                        Collectors.toList()
-                    )
-                ));
-
-        // 7. 썸네일
-        Map<Long, String> productThumbnailMap =
-            productPhotoRepository.findThumbnailByProductIds(productIds);
-
-        // 8. DTO 변환
-        List<GetReservationListItemResult> results =
-            filtered.stream()
-                .map(r -> toItemResult(
-                    r,
-                    productThumbnailMap,
-                    productMoodMap,
-                    reviewedReservationIds,
-                    reviewStatsMap
-                ))
-                .toList();
+        List<GetReservationListItemResult> results = getGetReservationListItems(
+            filtered,
+            productThumbnailMap,
+            productMoodMap,
+            reviewedReservationIds,
+            reviewStatsMap
+        );
 
         return new GetReservationListResult(results);
     }
 
-    private boolean isAllowedCanceledReservation(
-        Reservation reservation,
-        ReservationStatusTab tab
+    private List<Reservation> getReservationsByTab(Long userId, ReservationStatusTab tab) {
+        return tab.isClientTab()
+            ? reservationRepository.findClientReservations(userId, tab.getRelatedStatus())
+            : reservationRepository.findPhotographerReservations(userId, tab.getRelatedStatus());
+    }
+
+    private List<Reservation> filterReservationsByTab(
+        ReservationStatusTab tab,
+        List<Reservation> reservations
     ) {
+        return reservations.stream().filter(r -> isBelongingToTab(r, tab)).toList();
+    }
+
+    private boolean isBelongingToTab(Reservation reservation, ReservationStatusTab tab) {
         ReservationStatus status = reservation.getReservationStatus();
 
         if (status != ReservationStatus.RESERVATION_CANCELED
-            && status != ReservationStatus.RESERVATION_REFUSED) {
+            && status != ReservationStatus.RESERVATION_REFUSED
+        ) {
             return true;
         }
 
@@ -138,14 +107,74 @@ public class GetReservationListService implements GetReservationListUseCase {
         };
     }
 
-    private GetReservationListItemResult toItemResult(
+    private static List<Long> getReservationIds(List<Reservation> filtered) {
+        return filtered.stream().map(Reservation::getId).toList();
+    }
+
+    private static List<Long> getProductIds(List<Reservation> filtered) {
+        return filtered.stream()
+            .map(r -> r.getProduct().getId())
+            .distinct()
+            .toList();
+    }
+
+    private Set<Long> getIsReviewed(List<Long> reservationIds) {
+        return new HashSet<>(reviewRepository.findReviewedReservationIds(reservationIds));
+    }
+
+    private Map<Long, ProductReviewStatsResult> getReviewStats(
+        List<Long> productIds) {
+        return reviewRepository
+            .findReviewStatsByProductIds(productIds)
+            .stream()
+            .collect(Collectors.toMap(
+                row -> (Long) row[0],
+                row -> (ProductReviewStatsResult) row[1]
+            ));
+    }
+
+    private Map<Long, List<String>> getProductMoods(List<Long> productIds) {
+        return productMoodRepository
+            .findAllByProductIdIn(productIds)
+            .stream()
+            .collect(Collectors.groupingBy(productMood ->
+                productMood.getProduct().getId(),
+                Collectors.mapping(productMood ->
+                    productMood.getMood().getName(), Collectors.toList()
+                )
+            ));
+    }
+
+    private Map<Long, String> getThumbnailImage(List<Long> productIds) {
+        return productPhotoRepository.findThumbnailByProductIds(productIds);
+    }
+
+    private List<GetReservationListItemResult> getGetReservationListItems(
+        List<Reservation> filtered,
+        Map<Long, String> productThumbnailMap,
+        Map<Long, List<String>> productMoodMap,
+        Set<Long> reviewedReservationIds,
+        Map<Long, ProductReviewStatsResult> reviewStatsMap
+    ) {
+        return filtered.stream()
+            .map(reservation -> mapToReservationListItem(
+                reservation,
+                productThumbnailMap,
+                productMoodMap,
+                reviewedReservationIds,
+                reviewStatsMap
+            ))
+            .toList();
+    }
+
+    private GetReservationListItemResult mapToReservationListItem(
         Reservation reservation,
         Map<Long, String> productThumbnailMap,
         Map<Long, List<String>> productMoodMap,
         Set<Long> reviewedReservationIds,
         Map<Long, ProductReviewStatsResult> reviewStatsMap
     ) {
-        var product = reservation.getProduct();
+        Product product = reservation.getProduct();
         Long productId = product.getId();
 
         ProductReviewStatsResult stats =
@@ -158,9 +187,7 @@ public class GetReservationListService implements GetReservationListUseCase {
             reservation.getId(),
             reservation.getReservationStatus().name(),
             reservation.getUser().getName(),
-            reservation.getCreatedAt()
-                .atZone(ZoneId.systemDefault())
-                .format(FORMATTER),
+            reservation.getCreatedAt().atZone(ZoneId.systemDefault()).format(FORMATTER),
             new GetReservationListProductResult(
                 productId,
                 productThumbnailMap.get(productId),

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
@@ -54,7 +54,7 @@ public class GetReservationListService implements GetReservationListUseCase {
         List<Long> reservationIds = getReservationIds(filtered);
         List<Long> productIds = getProductIds(filtered);
 
-        Set<Long> reviewedReservationIds = getIsReviewed(reservationIds);
+        Set<Long> reviewedReservationIds = getReviewedReservationIds(reservationIds);
 
         Map<Long, ProductReviewStatsResult> reviewStatsMap = getReviewStats(productIds);
         Map<Long, List<String>> productMoodMap = getProductMoods(productIds);
@@ -121,18 +121,18 @@ public class GetReservationListService implements GetReservationListUseCase {
             .toList();
     }
 
-    private Set<Long> getIsReviewed(List<Long> reservationIds) {
+    private Set<Long> getReviewedReservationIds(List<Long> reservationIds) {
         return new HashSet<>(reviewRepository.findReviewedReservationIds(reservationIds));
     }
 
-    private Map<Long, ProductReviewStatsResult> getReviewStats(
-        List<Long> productIds) {
+    private Map<Long, ProductReviewStatsResult> getReviewStats(List<Long> productIds) {
         return reviewRepository
             .findReviewStatsByProductIds(productIds)
             .stream()
             .collect(Collectors.toMap(
                 row -> (Long) row[0],
-                row -> (ProductReviewStatsResult) row[1]
+                row -> (ProductReviewStatsResult) row[1],
+                (a, b) -> a // 중복 키 방어
             ));
     }
 

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
@@ -132,7 +132,7 @@ public class GetReservationListService implements GetReservationListUseCase {
             .collect(Collectors.toMap(
                 row -> (Long) row[0],
                 row -> (ProductReviewStatsResult) row[1],
-                (a, b) -> a // 중복 키 방어
+                (a, b) -> a
             ));
     }
 

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
@@ -22,11 +22,14 @@ import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReserva
 import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationListUseCase;
 import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class GetReservationListService implements GetReservationListUseCase {
 
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter FORMATTER =
         DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
@@ -187,7 +190,7 @@ public class GetReservationListService implements GetReservationListUseCase {
             reservation.getId(),
             reservation.getReservationStatus().name(),
             reservation.getUser().getName(),
-            reservation.getCreatedAt().atZone(ZoneId.systemDefault()).format(FORMATTER),
+            reservation.getCreatedAt().atZone(KOREA_ZONE).format(FORMATTER),
             new GetReservationListProductResult(
                 productId,
                 productThumbnailMap.get(productId),

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationListItemResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationListItemResult.java
@@ -1,0 +1,10 @@
+package org.sopt.snappinserver.domain.reservation.service.dto.response;
+
+public record GetReservationListItemResult(
+    Long reservationId,
+    String status,
+    String client,
+    String createdAt,
+    GetReservationListProductResult product
+) {
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationListProductResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationListProductResult.java
@@ -1,0 +1,16 @@
+package org.sopt.snappinserver.domain.reservation.service.dto.response;
+
+import java.util.List;
+
+public record GetReservationListProductResult(
+    Long id,
+    String imageUrl,
+    String title,
+    double rate,
+    int reviewCount,
+    String photographer,
+    int price,
+    List<String> moods,
+    boolean isReviewed
+) {
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationListResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationListResult.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.reservation.service.dto.response;
+
+import java.util.List;
+
+public record GetReservationListResult(
+    List<GetReservationListItemResult> reservations
+) {
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/GetReservationListUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/GetReservationListUseCase.java
@@ -1,0 +1,12 @@
+package org.sopt.snappinserver.domain.reservation.service.usecase;
+
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatusTab;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationListResult;
+
+public interface GetReservationListUseCase {
+
+    GetReservationListResult getReservationList(
+        Long userId,
+        ReservationStatusTab tab
+    );
+}

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
@@ -57,6 +57,35 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     ProductReviewStatsResult findReviewStatsByProductId(
         @Param("productId") Long productId
     );
+
+    // 상품 리뷰 통계 수치 여러 개 배치 조회
+    @Query("""
+        select
+            res.product.id,
+            new org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult(
+                count(r),
+                avg(r.rating)
+            )
+        from Review r
+        join r.reservation res
+        where res.product.id in :productIds
+        group by res.product.id
+    """)
+    List<Object[]> findReviewStatsByProductIds(
+        @Param("productIds") List<Long> productIds
+    );
+
+    // 예약 기준 리뷰 존재 여부
+    @Query("""
+        select r.reservation.id
+        from Review r
+        where r.reservation.id in :reservationIds
+    """)
+    List<Long> findReviewedReservationIds(
+        @Param("reservationIds") List<Long> reservationIds
+    );
+
+
 }
 
 

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
@@ -1,9 +1,9 @@
 package org.sopt.snappinserver.domain.review.repository;
 
-import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult;
-import org.springframework.data.domain.Pageable;
 import java.util.List;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult;
 import org.sopt.snappinserver.domain.review.domain.entity.Review;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,13 +16,13 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     // 리뷰 목록 첫 페이지 조회 (cursor 없음)
     @Query("""
-        select review
-        from Review review
-        join fetch review.reservation reservation
-        join fetch reservation.user user
-        where reservation.product.id = :productId
-        order by review.id desc
-    """)
+            select review
+            from Review review
+            join fetch review.reservation reservation
+            join fetch reservation.user user
+            where reservation.product.id = :productId
+            order by review.id desc
+        """)
     List<Review> findReviewsWithUserByProductId(
         @Param("productId") Long productId,
         Pageable pageable
@@ -30,14 +30,14 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     // 커서 이후 리뷰 목록 페이지 조회
     @Query("""
-        select review
-        from Review review
-        join fetch review.reservation reservation
-        join fetch reservation.user user
-        where reservation.product.id = :productId
-          and review.id < :cursor
-        order by review.id desc
-    """)
+            select review
+            from Review review
+            join fetch review.reservation reservation
+            join fetch reservation.user user
+            where reservation.product.id = :productId
+              and review.id < :cursor
+            order by review.id desc
+        """)
     List<Review> findReviewsWithUserByProductIdAndCursor(
         @Param("productId") Long productId,
         @Param("cursor") Long cursor,
@@ -60,32 +60,30 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     // 상품 리뷰 통계 수치 여러 개 배치 조회
     @Query("""
-        select
-            res.product.id,
-            new org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult(
-                count(r),
-                avg(r.rating)
-            )
-        from Review r
-        join r.reservation res
-        where res.product.id in :productIds
-        group by res.product.id
-    """)
+            select
+                res.product.id,
+                new org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult(
+                    count(r),
+                    avg(r.rating)
+                )
+            from Review r
+            join r.reservation res
+            where res.product.id in :productIds
+            group by res.product.id
+        """)
     List<Object[]> findReviewStatsByProductIds(
         @Param("productIds") List<Long> productIds
     );
 
     // 예약 기준 리뷰 존재 여부
     @Query("""
-        select r.reservation.id
-        from Review r
-        where r.reservation.id in :reservationIds
-    """)
+            select r.reservation.id
+            from Review r
+            where r.reservation.id in :reservationIds
+        """)
     List<Long> findReviewedReservationIds(
         @Param("reservationIds") List<Long> reservationIds
     );
-
-
 }
 
 


### PR DESCRIPTION
## 👀 Summary

- close #88 

예약 탭(고객/작가) 기준으로 예약 목록을 조회하는 API를 구현했습니다.

예약 상태값이 아닌 UI 상의 예약 탭에 맞는 예약 목록을 필터링하며, 예약 취소/예약 거절 상태는 previousCancelStatus(취소/거절 직전 상태)를 기반으로 어느 탭에 노출할지 결정됩니다.

## 🖇️ Tasks

- [x] 예약 목록 조회 API 추가
    - GET /api/v1/reservations?tab={tab} 엔드포인트 구현
    - 고객 탭 / 작가 탭 분기 처리
- [x] 예약 탭 정책(Enum 기반) 정리
    - ReservationStatusTab에 탭별 관련 상태 목록 정의
    - 고객/작가 탭 구분을 위한 메서드 추가
    - 취소/거절 상태를 탭별 상태 목록 포함
- [x] 도메인 결과 DTO / API 응답 DTO 구성
- [x] Repository 배치 조회 로직 추가/활용
    - 예약 목록 조회 쿼리(고객/작가) 구현
    - 상품 무드 배치 조회 사용
    - 상품 썸네일 배치 조회 사용
    - 리뷰 작성 여부(예약 기준) 배치 조회 사용
    - 상품 리뷰 통계(상품 기준) 배치 조회 사용
- [x] Service 로직 설계 및 책임 분리


## 🔍 To Reviewer
### ❶ DTO 관리

처음에는 '예약 목록' 응답/결과이므로 기존 다른 API에서 관리했던 네이밍과 같이 `Reservations + 접미사`와 같은 복수형 명사를 사용하고자 했으나, 목록 내부에 포함되는 예약 정보와 상품 정보가 아직 개발 전인 예약상세/촬영내역 조회 API의 DTO와 혼동될 우려가 있어 `ReservationList + 접미사`를 선택했습니다!


### ❷ Repository 로직 정리

<details>
<summary> 제가 보려고 적었습니다... 조회 관련해서 참고해주세요! </summary>

#### ReservationRepository

`findClientReservations(userId, statuses)`

> - 고객 예약 목록 조회 쿼리
> - 조건: `Reservation.user.id = :userId AND reservationStatus in :statuses`
> - 내가 만든 예약만 조회

`findPhotographerReservations(userId, statuses)`

> - 작가 예약 목록 조회 쿼리
> - 조건: Reservation.product.photographer.user.id = :userId AND reservationStatus in :statuses
> - 내 상품에 들어온 예약만 조회

#### ProductMoodRepository

`findAllByProductIdIn(productIds)`

> - 목록에 등장하는 상품들의 무드를 한 번에 조회
> - 서비스에서 groupingBy(productId)로 매핑

#### ProductPhotoRepository
`findThumbnails(productIds) + findThumbnailByProductIds(productIds)`

> - `displayOrder = 0`을 썸네일 기준으로 가정하고, 해당 사진들을 batch 조회
> - productId → imageUrl 형태로 변환해서 매핑합니다.

#### ReviewRepository

`findReviewedReservationIds(reservationIds)`

> - 예약 단위로 리뷰 존재 여부를 배치 조회
> - 서비스에서 Set<Long>으로 바꿔 contains(reservationId)로 판단

`findReviewStatsByProductIds(productIds)`

> - 상품 단위로 reviewCount / averageRating을 배치 조회
> - Map<Long, ProductReviewStatsResult> 형태로 변환 후 매핑

</details>

### ❸ StatusTab Enum에 예약 취소/거절 상태 및 고객/작가 확인 포함

처음에는 취소/거절은 이전 상태 기반으로 탭을 판별하기 때문에 relatedStatus에 넣지 않아도 되겠다고 생각하고 구현했었는데, 취소/거절 예약을 DB에서 아예 조회하지 못하면 서비스에서 previousCancelStatus를 확인할 수가 없었습니다.  즉 취소/거절 상태는 어떤 탭에도 단순 매핑되지 않는데, 기획 요구사항은 취소/거절도 이전 상태에 따라 특정 탭에 보여야 하기 때문에 1차 쿼리 단계에서 취소/거절을 가져와야 서비스에서 판단이 가능한 상황이었습니다.

그래서 ReservationStatusTab의 탭별 relatedStatus에 `RESERVATION_CANCELED`, `RESERVATION_REFUSED` 상태를 포함시켰고, 이후에 previousCancelStatus로 어느 탭에 보여줄지를 결정하도록 구현했습니다!


추가적으로 ReservationStatusTab Enum에 isClientTab() 메서드를 추가해놓았는데요, 고객/작가 탭 분기는 컨트롤러/서비스 여러 곳에서 반복될 수 있다고 판단했고, 이 조건은 탭이라는 도메인 값이 이미 알고 있는 정보라고 생각했습니다. 
서비스 내부에서 같은 조건문이 반복되는 것보다는 분기 기준을 한 군데(ENUM 내부)로 모아놓는게 더 낫다고 판단해서 ReservationStatusTab 안에 isClientTab()을 구현해놓았습니다.



### ❹ 전체 예약 목록 조회 흐름

1. 요청으로 전달된 예약 탭을 기준으로 고객/작가를 구분하고, 고객인 경우 내가 만든 예약만 / 작가인 경우 내 상품에 들어온 예약만 조회하도록 쿼리 분리

2. 조회된 예약 목록에 대해 어느 탭에 포함될지 판단하고, 취소/거절 상태의 예약은 취소·거절 이전 상태(previousCancelStatus)를 기준으로 어느 탭에 노출될지 결정

3. 위에서 필터링된 예약에 대해 예약 Id와 상품 Id를 이용해 배치 조회 방식으로 리뷰 작성 여부, 상품 리뷰 통계(평균 별점/리뷰 수), 상품 무드 태그, 썸네일 이미지를 조회하고,이를 조합해 예약 목록 화면에서 바로 사용할 수 있는 응답 형태로 변환하여 반환

기획 요구사항을 정리해보자면 다음과 같습니다.

> [고객 예약 목록]
> - 예약 현황 → 해당 유저의 예약 목록 중 예약요청, 작가확인중,결제요청,결제완료,예약확정,예약취소, 예약 거절 상태인 예약만 필터링해서 조회
> - 촬영 완료 → 해당 유저의 예약 목록 중 촬영 완료 상태인 예약만 필터링해서 조회 (단, 이 경우 리뷰 작성 여부도 함께 조회)
> 
> [작가 예약 목록]
> - 예약 요청 → 해당 작가의 예약 목록 중 예약 요청, 예약 취소 상태인 예약만 필터링해서 조회 (단, 예약 취소 상태인 경우 직전 상태가 예약 요청이었을 경우만)
> - 조율 중 → 해당 작가의 예약 목록 중 작가 확인중, 결제 요청, 결제 완료, 예약 취소, 예약 거절 상태인 예약만 필터링해서 조회  (단, 예약 취소와 예약 거절 상태인 경우 직전 상태가 작가 확인중, 결제 요청, 결제 완료 상태 중 하나였을 경우만)
> - 예약 확정 → 해당 작가의 예약 목록 중 예약 확정, 예약 취소, 예약 거절 상태인 예약만 필터링해서 조회  (단, 예약 취소와 예약 거절 상태인 경우 직전 상태가 예약 확정 상태였을 경우만)
> - 촬영 완료 → 해당 작가의 예약 목록 중 촬영 완료 상태인 예약만 필터링해서 조회 