### PR TITLE
[FIX] #96: CORS 해결

### DIFF
--- a/src/main/java/org/sopt/snappinserver/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/sopt/snappinserver/global/security/CustomAuthenticationEntryPoint.java
@@ -28,10 +28,14 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     ) throws IOException {
         Object reason = request.getAttribute(TokenAuthenticationFilter.AUTH_ERROR_ATTR);
 
-        AuthErrorCode code =
-            "EXPIRED_ACCESS_TOKEN".equals(reason) ? AuthErrorCode.EXPIRED_ACCESS_TOKEN :
-                "INVALID_ACCESS_TOKEN".equals(reason) ? AuthErrorCode.INVALID_ACCESS_TOKEN :
-                    AuthErrorCode.LOGIN_REQUIRED;
+        AuthErrorCode code;
+        if ("EXPIRED_ACCESS_TOKEN".equals(reason)) {
+            code = AuthErrorCode.EXPIRED_ACCESS_TOKEN;
+        } else if ("INVALID_ACCESS_TOKEN".equals(reason)) {
+            code = AuthErrorCode.INVALID_ACCESS_TOKEN;
+        } else {
+            code = AuthErrorCode.LOGIN_REQUIRED;
+        }
 
         ApiResponseBody<Void, ErrorMeta> body =
             ApiResponseBody.onFailure(

--- a/src/main/java/org/sopt/snappinserver/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/sopt/snappinserver/global/security/CustomAuthenticationEntryPoint.java
@@ -26,10 +26,16 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         HttpServletResponse response,
         AuthenticationException authException
     ) throws IOException {
+        Object reason = request.getAttribute(TokenAuthenticationFilter.AUTH_ERROR_ATTR);
+
+        AuthErrorCode code =
+            "EXPIRED_ACCESS_TOKEN".equals(reason) ? AuthErrorCode.EXPIRED_ACCESS_TOKEN :
+                "INVALID_ACCESS_TOKEN".equals(reason) ? AuthErrorCode.INVALID_ACCESS_TOKEN :
+                    AuthErrorCode.LOGIN_REQUIRED;
 
         ApiResponseBody<Void, ErrorMeta> body =
             ApiResponseBody.onFailure(
-                AuthErrorCode.LOGIN_REQUIRED,
+                code,
                 new ErrorMeta(request.getRequestURI(), Instant.now())
             );
 
@@ -38,4 +44,3 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         response.getWriter().write(objectMapper.writeValueAsString(body));
     }
 }
-

--- a/src/main/java/org/sopt/snappinserver/global/security/TokenAuthenticationFilter.java
+++ b/src/main/java/org/sopt/snappinserver/global/security/TokenAuthenticationFilter.java
@@ -2,6 +2,7 @@ package org.sopt.snappinserver.global.security;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.servlet.FilterChain;
@@ -76,8 +77,10 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
                 .setAuthentication(authentication);
         } catch (ExpiredJwtException e) {
             request.setAttribute(AUTH_ERROR_ATTR, "EXPIRED_ACCESS_TOKEN");
-        } catch (MalformedJwtException | IllegalArgumentException | UnsupportedJwtException e) {
+            SecurityContextHolder.clearContext();
+        } catch (JwtException | IllegalArgumentException e) {
             request.setAttribute(AUTH_ERROR_ATTR, "INVALID_ACCESS_TOKEN");
+            SecurityContextHolder.clearContext();
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/org/sopt/snappinserver/global/security/TokenAuthenticationFilter.java
+++ b/src/main/java/org/sopt/snappinserver/global/security/TokenAuthenticationFilter.java
@@ -3,8 +3,6 @@ package org.sopt.snappinserver.global.security;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -34,7 +32,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getServletPath();
-        return path.startsWith("/api/v1/auth/")
+        return path.equals("/api/v1/auth/reissue") || path.equals("/api/v1/auth/login/kakao")
             || path.equals("/api/v1/photos/process");
     }
 

--- a/src/main/java/org/sopt/snappinserver/global/security/TokenAuthenticationFilter.java
+++ b/src/main/java/org/sopt/snappinserver/global/security/TokenAuthenticationFilter.java
@@ -1,8 +1,5 @@
 package org.sopt.snappinserver.global.security;
 
-import static org.sopt.snappinserver.domain.auth.domain.exception.AuthErrorCode.EXPIRED_ACCESS_TOKEN;
-import static org.sopt.snappinserver.domain.auth.domain.exception.AuthErrorCode.INVALID_ACCESS_TOKEN;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -41,7 +38,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
 
-        return path.equals("/api/v1/auth/reissue") || path.equals("/api/v1/auth/login")
+        return path.startsWith("/api/v1/auth/")
             || path.equals("/api/v1/photos/process");
     }
 
@@ -81,11 +78,10 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
             SecurityContextHolder.getContext()
                 .setAuthentication(authentication);
-        } catch (ExpiredJwtException e) {
-            sendError(response, request, EXPIRED_ACCESS_TOKEN);
-            return;
-        } catch (MalformedJwtException | IllegalArgumentException | UnsupportedJwtException e) {
-            sendError(response, request, INVALID_ACCESS_TOKEN);
+        } catch (ExpiredJwtException | MalformedJwtException
+                 | IllegalArgumentException | UnsupportedJwtException e
+        ) {
+            filterChain.doFilter(request, response);
             return;
         }
 

--- a/src/main/java/org/sopt/snappinserver/global/security/TokenAuthenticationFilter.java
+++ b/src/main/java/org/sopt/snappinserver/global/security/TokenAuthenticationFilter.java
@@ -27,14 +27,13 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
-    public static final String AUTH_ERROR_ATTR = "AUTH_ERROR";
+    public static final String AUTH_ERROR_ATTR = "org.sopt.snappinserver.security.AUTH_ERROR";
 
     private final JwtProvider jwtProvider;
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getRequestURI();
-
+        String path = request.getServletPath();
         return path.startsWith("/api/v1/auth/")
             || path.equals("/api/v1/photos/process");
     }

--- a/src/main/java/org/sopt/snappinserver/global/security/TokenAuthenticationFilter.java
+++ b/src/main/java/org/sopt/snappinserver/global/security/TokenAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package org.sopt.snappinserver.global.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -10,15 +9,11 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.time.Instant;
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.domain.auth.domain.exception.AuthErrorCode;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.auth.infra.jwt.JwtProvider;
-import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
-import org.sopt.snappinserver.global.response.dto.ErrorMeta;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -31,8 +26,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
+    public static final String AUTH_ERROR_ATTR = "AUTH_ERROR";
+
     private final JwtProvider jwtProvider;
-    private final ObjectMapper objectMapper;
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
@@ -78,35 +74,12 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
             SecurityContextHolder.getContext()
                 .setAuthentication(authentication);
-        } catch (ExpiredJwtException | MalformedJwtException
-                 | IllegalArgumentException | UnsupportedJwtException e
-        ) {
-            filterChain.doFilter(request, response);
-            return;
+        } catch (ExpiredJwtException e) {
+            request.setAttribute(AUTH_ERROR_ATTR, "EXPIRED_ACCESS_TOKEN");
+        } catch (MalformedJwtException | IllegalArgumentException | UnsupportedJwtException e) {
+            request.setAttribute(AUTH_ERROR_ATTR, "INVALID_ACCESS_TOKEN");
         }
 
         filterChain.doFilter(request, response);
     }
-
-    private void sendError(
-        HttpServletResponse response,
-        HttpServletRequest request,
-        AuthErrorCode errorCode
-    ) throws IOException {
-
-        ErrorMeta meta = new ErrorMeta(
-            request.getRequestURI(),
-            Instant.now()
-        );
-
-        ApiResponseBody<Void, ErrorMeta> body =
-            ApiResponseBody.onFailure(errorCode, meta);
-
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write(
-            objectMapper.writeValueAsString(body)
-        );
-    }
-
 }


### PR DESCRIPTION
## 👀 Summary

- close #96


## 🖇️ Tasks

- TokenAuthenticationFilter 클래스 내부에서 shouldNotFilter의 로그인 엔드포인트 오류 수정
- 401 예외 발생한 경우 필터 단에서 예외 원인만 던지고 EntryPoint에서 원인 보고 분기처리 해서 응답하도록 수정


## 🔍 To Reviewer

-