### PR TITLE
[FEAT] #100: 예약상세/촬영내역 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
@@ -14,6 +14,11 @@ public enum ReservationSuccessCode implements SuccessCode {
         "RESERVATION_200_001",
         "예약 목록 조회에 성공했습니다."
     ),
+    GET_RESERVATION_DETAIL_OK(
+        200,
+        "RESERVATION_200_002",
+        "예약 상세 및 촬영 내역 조회에 성공했습니다."
+    ),
 
     // 201 CREATED
     POST_RESERVATION_REVIEW_CREATED(201, "RESERVATION_201_001", "예약 리뷰 등록에 성공했습니다.");

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import org.sopt.snappinserver.api.reservation.dto.request.CreateReservationReviewRequest;
 import org.sopt.snappinserver.api.reservation.dto.response.CreateReservationReviewResponse;
+import org.sopt.snappinserver.api.reservation.dto.response.ReservationDetailResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationListResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatusTab;
@@ -49,6 +50,20 @@ public interface ReservationApi {
 
         @Schema(description = "예약 조회 탭", example = "CLIENT_OVERVIEW")
         @RequestParam @NotNull ReservationStatusTab tab
+    );
+
+    @Operation(
+        summary = "예약상세/촬영내역 조회",
+        description = "예약된 상품에 대하여 예약 상세 정보와 결제 정보를 조회합니다."
+    )
+    @GetMapping("/{reservationId}")
+    ApiResponseBody<ReservationDetailResponse, Void> getReservationDetail(
+
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo,
+
+        @Schema(description = "예약 아이디", example = "1")
+        @PathVariable @NotNull Long reservationId
     );
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
@@ -4,15 +4,18 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.reservation.code.ReservationSuccessCode;
 import org.sopt.snappinserver.api.reservation.dto.request.CreateReservationReviewRequest;
 import org.sopt.snappinserver.api.reservation.dto.response.CreateReservationReviewResponse;
+import org.sopt.snappinserver.api.reservation.dto.response.ReservationDetailResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationListResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatusTab;
 import org.sopt.snappinserver.domain.reservation.service.dto.request.CreateReservationReviewCommand;
 import org.sopt.snappinserver.domain.reservation.service.dto.response.CreateReservationReviewResult;
+import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationDetailUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationListUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.PostReservationReviewUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,6 +26,7 @@ public class ReservationController implements ReservationApi {
 
     private final PostReservationReviewUseCase postReservationReviewUseCase;
     private final GetReservationListUseCase getReservationListUseCase;
+    private final GetReservationDetailUseCase getReservationDetailUseCase;
 
     @Override
     public ApiResponseBody<CreateReservationReviewResponse, Void> createReview(
@@ -60,5 +64,19 @@ public class ReservationController implements ReservationApi {
         );
     }
 
-
+    @Override
+    public ApiResponseBody<ReservationDetailResponse, Void> getReservationDetail(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        Long reservationId
+    ) {
+        return ApiResponseBody.ok(
+            ReservationSuccessCode.GET_RESERVATION_DETAIL_OK,
+            ReservationDetailResponse.from(
+                getReservationDetailUseCase.getReservationDetail(
+                    userInfo.userId(),
+                    reservationId
+                )
+            )
+        );
+    }
 }

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailInfoResponse.java
@@ -1,6 +1,7 @@
 package org.sopt.snappinserver.api.reservation.dto.response;
 
 import java.time.format.DateTimeFormatter;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailInfoResult;
 
 public record ReservationDetailInfoResponse(
     String client,
@@ -12,9 +13,8 @@ public record ReservationDetailInfoResponse(
     int peopleCount,
     String requestNote
 ) {
-    public static ReservationDetailInfoResponse from(
-        org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailInfoResult result
-    ) {
+
+    public static ReservationDetailInfoResponse from(GetReservationDetailInfoResult result) {
         return new ReservationDetailInfoResponse(
             result.client(),
             result.createdAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailInfoResponse.java
@@ -1,0 +1,29 @@
+package org.sopt.snappinserver.api.reservation.dto.response;
+
+import java.time.format.DateTimeFormatter;
+
+public record ReservationDetailInfoResponse(
+    String client,
+    String createdAt,
+    String date,
+    String startTime,
+    double durationTime,
+    String place,
+    int peopleCount,
+    String requestNote
+) {
+    public static ReservationDetailInfoResponse from(
+        org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailInfoResult result
+    ) {
+        return new ReservationDetailInfoResponse(
+            result.client(),
+            result.createdAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+            result.date().toString(),
+            result.startTime().toString(),
+            result.durationMinutes() / 60.0,
+            result.place(),
+            result.peopleCount(),
+            result.requestNote()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailInfoResponse.java
@@ -13,11 +13,13 @@ public record ReservationDetailInfoResponse(
     int peopleCount,
     String requestNote
 ) {
+    private static final DateTimeFormatter CREATED_AT_FORMATTER =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     public static ReservationDetailInfoResponse from(GetReservationDetailInfoResult result) {
         return new ReservationDetailInfoResponse(
             result.client(),
-            result.createdAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+            result.createdAt().format(CREATED_AT_FORMATTER),
             result.date().toString(),
             result.startTime().toString(),
             result.durationMinutes() / 60.0,

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailPaymentResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailPaymentResponse.java
@@ -1,14 +1,17 @@
 package org.sopt.snappinserver.api.reservation.dto.response;
 
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailPaymentResult;
+
 public record ReservationDetailPaymentResponse(
     int basePrice,
     int extraPrice,
     int totalPrice
 ) {
-    public static ReservationDetailPaymentResponse from(
-        org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailPaymentResult result
-    ) {
-        if (result == null) return null;
+
+    public static ReservationDetailPaymentResponse from(GetReservationDetailPaymentResult result) {
+        if (result == null) {
+            return null;
+        }
 
         return new ReservationDetailPaymentResponse(
             result.basePrice(),

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailPaymentResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailPaymentResponse.java
@@ -1,0 +1,19 @@
+package org.sopt.snappinserver.api.reservation.dto.response;
+
+public record ReservationDetailPaymentResponse(
+    int basePrice,
+    int extraPrice,
+    int totalPrice
+) {
+    public static ReservationDetailPaymentResponse from(
+        org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailPaymentResult result
+    ) {
+        if (result == null) return null;
+
+        return new ReservationDetailPaymentResponse(
+            result.basePrice(),
+            result.extraPrice(),
+            result.totalPrice()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailProductResponse.java
@@ -1,0 +1,29 @@
+package org.sopt.snappinserver.api.reservation.dto.response;
+
+import java.util.List;
+
+public record ReservationDetailProductResponse(
+    Long id,
+    String imageUrl,
+    String title,
+    double rate,
+    int reviewCount,
+    String photographer,
+    int price,
+    List<String> moods
+) {
+    public static ReservationDetailProductResponse from(
+        org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailProductResult result
+    ) {
+        return new ReservationDetailProductResponse(
+            result.id(),
+            result.imageUrl(),
+            result.title(),
+            result.rate(),
+            result.reviewCount(),
+            result.photographer(),
+            result.price(),
+            result.moods()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailProductResponse.java
@@ -1,6 +1,7 @@
 package org.sopt.snappinserver.api.reservation.dto.response;
 
 import java.util.List;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailProductResult;
 
 public record ReservationDetailProductResponse(
     Long id,
@@ -12,9 +13,8 @@ public record ReservationDetailProductResponse(
     int price,
     List<String> moods
 ) {
-    public static ReservationDetailProductResponse from(
-        org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailProductResult result
-    ) {
+
+    public static ReservationDetailProductResponse from(GetReservationDetailProductResult result) {
         return new ReservationDetailProductResponse(
             result.id(),
             result.imageUrl(),

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailResponse.java
@@ -1,0 +1,21 @@
+package org.sopt.snappinserver.api.reservation.dto.response;
+
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailResult;
+
+public record ReservationDetailResponse(
+    String status,
+    ReservationDetailProductResponse productInfo,
+    ReservationDetailInfoResponse reservationInfo,
+    ReservationDetailPaymentResponse paymentInfo,
+    ReservationDetailReviewResponse reviewInfo
+) {
+    public static ReservationDetailResponse from(GetReservationDetailResult result) {
+        return new ReservationDetailResponse(
+            result.status().name(),
+            ReservationDetailProductResponse.from(result.product()),
+            ReservationDetailInfoResponse.from(result.reservationInfo()),
+            ReservationDetailPaymentResponse.from(result.payment()),
+            ReservationDetailReviewResponse.from(result.review())
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailReviewResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailReviewResponse.java
@@ -1,0 +1,27 @@
+package org.sopt.snappinserver.api.reservation.dto.response;
+
+import java.util.List;
+
+public record ReservationDetailReviewResponse(
+    Long id,
+    String reviewer,
+    int rating,
+    String createdAt,
+    List<String> images,
+    String content
+) {
+    public static ReservationDetailReviewResponse from(
+        org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailReviewResult result
+    ) {
+        if (result == null) return null;
+
+        return new ReservationDetailReviewResponse(
+            result.id(),
+            result.reviewer(),
+            result.rating(),
+            result.createdAt().toString(),
+            result.imageUrls(),
+            result.content()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailReviewResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ReservationDetailReviewResponse.java
@@ -1,6 +1,7 @@
 package org.sopt.snappinserver.api.reservation.dto.response;
 
 import java.util.List;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailReviewResult;
 
 public record ReservationDetailReviewResponse(
     Long id,
@@ -11,7 +12,7 @@ public record ReservationDetailReviewResponse(
     String content
 ) {
     public static ReservationDetailReviewResponse from(
-        org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailReviewResult result
+        GetReservationDetailReviewResult result
     ) {
         if (result == null) return null;
 

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
@@ -25,7 +25,7 @@ public enum ReservationErrorCode implements ErrorCode {
     // 401 UNAUTHORIZED
 
     // 403 FORBIDDEN
-    RESERVATION_USER_NOT_MATCH(404, "RESERVATION_403_001", "사용자가 예약의 소유자가 아닙니다."),
+    RESERVATION_USER_NOT_MATCH(403, "RESERVATION_403_001", "사용자가 예약의 소유자가 아닙니다."),
 
     // 404 NOT FOUND
     RESERVATION_NOT_FOUND(404, "RESERVATION_404_001", "존재하지 않는 예약입니다."),

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
@@ -22,17 +22,18 @@ public enum ReservationErrorCode implements ErrorCode {
     ADDITIONAL_PAYMENT_NAME_TOO_LONG(400, "RESERVATION_400_011", "추가 요청 금액명 길이는 100자 이하입니다."),
     ADDITIONAL_PAYMENT_AMOUNT_REQUIRED(400, "RESERVATION_400_012", "추가 요청 금액은 필수입니다."),
     ADDITIONAL_PAYMENT_AMOUNT_TOO_SMALL(400, "RESERVATION_400_013", "추가 요청 금액은 10원 이상이어야 합니다."),
-    RESERVATION_USER_NOT_MATCH(400, "RESERVATION_400_014", "사용자가 예약의 소유자가 아닙니다."),
     // 401 UNAUTHORIZED
 
     // 403 FORBIDDEN
+    RESERVATION_USER_NOT_MATCH(404, "RESERVATION_403_001", "사용자가 예약의 소유자가 아닙니다."),
 
     // 404 NOT FOUND
     RESERVATION_NOT_FOUND(404, "RESERVATION_404_001", "존재하지 않는 예약입니다."),
-    RESERVATION_NOT_COMPLETED(404, "RESERVATION_404_002", "촬영이 완료된 예약만 리뷰를 작성할 수 있습니다."),
 
     // 409 CONFLICT
-    RESERVATION_TIME_CONFLICT(409, "RESERVATION_409_001", "해당 시간에 이미 예약이 존재합니다.");
+    RESERVATION_TIME_CONFLICT(409, "RESERVATION_409_001", "해당 시간에 이미 예약이 존재합니다."),
+    RESERVATION_NOT_COMPLETED(409, "RESERVATION_409_002", "촬영이 완료된 예약만 리뷰를 작성할 수 있습니다.");
+
 
     private final int status;
     private final String code;

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationAdditionalPaymentRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationAdditionalPaymentRepository.java
@@ -1,0 +1,14 @@
+package org.sopt.snappinserver.domain.reservation.repository;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
+import org.sopt.snappinserver.domain.reservation.domain.entity.ReservationAdditionalPayment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReservationAdditionalPaymentRepository
+    extends JpaRepository<ReservationAdditionalPayment, Long> {
+
+    List<ReservationAdditionalPayment> findAllByReservation(Reservation reservation);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
@@ -1,0 +1,155 @@
+package org.sopt.snappinserver.domain.reservation.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.domain.product.repository.ProductMoodRepository;
+import org.sopt.snappinserver.domain.product.repository.ProductPhotoRepository;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult;
+import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
+import org.sopt.snappinserver.domain.reservation.domain.entity.ReservationAdditionalPayment;
+import org.sopt.snappinserver.domain.reservation.domain.exception.ReservationErrorCode;
+import org.sopt.snappinserver.domain.reservation.domain.exception.ReservationException;
+import org.sopt.snappinserver.domain.reservation.repository.ReservationAdditionalPaymentRepository;
+import org.sopt.snappinserver.domain.reservation.repository.ReservationRepository;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailInfoResult;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailPaymentResult;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailProductResult;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailResult;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailReviewResult;
+import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationDetailUseCase;
+import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
+import org.sopt.snappinserver.domain.review.repository.ReviewPhotoRepository;
+import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetReservationDetailService implements GetReservationDetailUseCase {
+
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+    private final ReservationRepository reservationRepository;
+    private final ProductPhotoRepository productPhotoRepository;
+    private final ProductMoodRepository productMoodRepository;
+    private final ReviewRepository reviewRepository;
+    private final ReviewPhotoRepository reviewPhotoRepository;
+    private final ReservationAdditionalPaymentRepository reservationAdditionalPaymentRepository;
+
+    @Override
+    public GetReservationDetailResult getReservationDetail(Long userId, Long reservationId) {
+
+        Reservation reservation = getReservation(reservationId, userId);
+        Product product = reservation.getProduct();
+
+        GetReservationDetailProductResult productResult = mapToProductResult(product);
+        GetReservationDetailInfoResult infoResult = mapToReservationInfoResult(reservation);
+        GetReservationDetailPaymentResult paymentResult = mapToPaymentResult(reservation, product);
+        GetReservationDetailReviewResult reviewResult = mapToReviewResult(reservation);
+
+        return new GetReservationDetailResult(
+            reservation.getReservationStatus(),
+            productResult,
+            infoResult,
+            paymentResult,
+            reviewResult
+        );
+    }
+
+    private Reservation getReservation(Long reservationId, Long userId) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+            .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+        if (!reservation.validateReservationClient(userId)) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_USER_NOT_MATCH);
+        }
+
+        return reservation;
+    }
+
+    private String getThumbnail(Product product) {
+        return productPhotoRepository.findFirstByProductOrderByDisplayOrderAsc(product)
+            .map(pp -> pp.getPhoto().getImageUrl())
+            .orElse(null);
+    }
+
+    private ProductReviewStatsResult getReviewStats(Product product) {
+        return reviewRepository.findReviewStatsByProductId(product.getId());
+    }
+
+    private GetReservationDetailProductResult mapToProductResult(Product product) {
+        ProductReviewStatsResult stats = getReviewStats(product);
+
+        return new GetReservationDetailProductResult(
+            product.getId(),
+            getThumbnail(product),
+            product.getTitle(),
+            stats != null ? stats.averageRating() : 0.0,
+            stats == null ? 0 : Math.toIntExact(stats.reviewCount()),
+            product.getPhotographer().getName(),
+            product.getPrice(),
+            getMoodNames(product)
+        );
+    }
+
+    private List<String> getMoodNames(Product product) {
+        return productMoodRepository.findAllByProduct(product).stream()
+            .map(pm -> pm.getMood().getName())
+            .toList();
+    }
+
+    private GetReservationDetailInfoResult mapToReservationInfoResult(Reservation reservation) {
+        return new GetReservationDetailInfoResult(
+            reservation.getUser().getName(),
+            LocalDateTime.ofInstant(reservation.getCreatedAt(), KOREA_ZONE),
+            reservation.getReservedAt().toLocalDate(),
+            reservation.getReservedAt().toLocalTime(),
+            reservation.getDurationTime(),
+            reservation.getPlace().getName(),
+            reservation.getPeopleCount(),
+            reservation.getRequestNote()
+        );
+    }
+
+    private GetReservationDetailPaymentResult mapToPaymentResult(
+        Reservation reservation,
+        Product product
+    ) {
+        List<ReservationAdditionalPayment> additionalPayments =
+            reservationAdditionalPaymentRepository.findAllByReservation(reservation);
+
+        int extraPrice = additionalPayments.stream()
+            .mapToInt(ReservationAdditionalPayment::getAmount)
+            .sum();
+
+        int basePrice = product.getPrice();
+
+        return new GetReservationDetailPaymentResult(
+            basePrice,
+            extraPrice,
+            basePrice + extraPrice
+        );
+    }
+
+    private GetReservationDetailReviewResult mapToReviewResult(Reservation reservation) {
+        return reviewRepository.findByReservation(reservation)
+            .map(review -> {
+                List<ReviewPhoto> photos =
+                    reviewPhotoRepository.findAllByReviewIds(List.of(review.getId()));
+
+                return new GetReservationDetailReviewResult(
+                    review.getId(),
+                    reservation.getUser().getName(),
+                    review.getRating(),
+                    LocalDate.ofInstant(review.getCreatedAt(), KOREA_ZONE),
+                    photos.stream().map(rp -> rp.getPhoto().getImageUrl()).toList(),
+                    review.getContent()
+                );
+            })
+            .orElse(null);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
@@ -89,7 +89,7 @@ public class GetReservationDetailService implements GetReservationDetailUseCase 
             getThumbnail(product),
             product.getTitle(),
             stats != null ? stats.averageRating() : 0.0,
-            stats == null ? 0 : Math.toIntExact(stats.reviewCount()),
+            stats != null ? Math.toIntExact(stats.reviewCount()) : 0,
             product.getPhotographer().getName(),
             product.getPrice(),
             getMoodNames(product)

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
@@ -42,7 +42,6 @@ public class GetReservationDetailService implements GetReservationDetailUseCase 
 
     @Override
     public GetReservationDetailResult getReservationDetail(Long userId, Long reservationId) {
-
         Reservation reservation = getReservation(reservationId, userId);
         Product product = reservation.getProduct();
 

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationDetailInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationDetailInfoResult.java
@@ -1,0 +1,18 @@
+package org.sopt.snappinserver.domain.reservation.service.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record GetReservationDetailInfoResult(
+    String client,
+    LocalDateTime createdAt,
+    LocalDate date,
+    LocalTime startTime,
+    int durationMinutes,
+    String place,
+    int peopleCount,
+    String requestNote
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationDetailPaymentResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationDetailPaymentResult.java
@@ -1,0 +1,9 @@
+package org.sopt.snappinserver.domain.reservation.service.dto.response;
+
+public record GetReservationDetailPaymentResult(
+    int basePrice,
+    int extraPrice,
+    int totalPrice
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationDetailProductResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationDetailProductResult.java
@@ -1,0 +1,16 @@
+package org.sopt.snappinserver.domain.reservation.service.dto.response;
+
+import java.util.List;
+
+public record GetReservationDetailProductResult(
+    Long id,
+    String imageUrl,
+    String title,
+    double rate,
+    int reviewCount,
+    String photographer,
+    int price,
+    List<String> moods
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationDetailResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationDetailResult.java
@@ -1,0 +1,13 @@
+package org.sopt.snappinserver.domain.reservation.service.dto.response;
+
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
+
+public record GetReservationDetailResult(
+    ReservationStatus status,
+    GetReservationDetailProductResult product,
+    GetReservationDetailInfoResult reservationInfo,
+    GetReservationDetailPaymentResult payment,
+    GetReservationDetailReviewResult review
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationDetailReviewResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationDetailReviewResult.java
@@ -1,0 +1,15 @@
+package org.sopt.snappinserver.domain.reservation.service.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record GetReservationDetailReviewResult(
+    Long id,
+    String reviewer,
+    int rating,
+    LocalDate createdAt,
+    List<String> imageUrls,
+    String content
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/GetReservationDetailUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/GetReservationDetailUseCase.java
@@ -1,0 +1,11 @@
+package org.sopt.snappinserver.domain.reservation.service.usecase;
+
+import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailResult;
+
+public interface GetReservationDetailUseCase {
+
+    GetReservationDetailResult getReservationDetail(
+        Long userId,
+        Long reservationId
+    );
+}

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
@@ -1,7 +1,9 @@
 package org.sopt.snappinserver.domain.review.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult;
+import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
 import org.sopt.snappinserver.domain.review.domain.entity.Review;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -84,6 +86,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Long> findReviewedReservationIds(
         @Param("reservationIds") List<Long> reservationIds
     );
+
+    // 예약 기준 리뷰 단일 조회
+    Optional<Review> findByReservation(Reservation reservation);
+
 }
 
 


### PR DESCRIPTION
## 👀 Summary

- close #89 

특정 예약에 대한 상품 정보, 예약 상세, 결제 정보, 리뷰 정보를 조회하는 예약 상세/촬영내역 조회 API를 구현했습니다.

## 🖇️ Tasks

- [x] 예약 상세 조회 UseCase 및 Service 구현
- [x] 예약 단일 조회 시 예약 소유자 검증 로직 추가
- [x] 예약 정보 관련 Domain 결과 DTO 설계
    - 상품 정보 (썸네일, 평균 별점, 리뷰 수, 무드 태그)
    - 예약 정보 (예약자, 예약일시, 촬영 정보)
    - 결제 정보 (기본 금액, 추가 금액, 최종 금액)
    - 리뷰 정보 (리뷰, 리뷰 이미지)
- [x] 상품 대표 이미지 조회 로직 추가
- [x] 상품 리뷰 통계(평균 별점, 리뷰 수) 조회 로직 기존 메서드 재사용
- [x] 예약 추가 결제 금액 합산 및 최종 결제 금액 계산
- [x] 리뷰 및 리뷰 이미지 조회 처리
- [x] API Response DTO 매핑 및 컨트롤러 구현 
- [x] 시간 타입 처리 정리
    - DB/Entity: `Instant`
    - Service: `LocalDate` / `LocalDateTime` (Asia/Seoul 기준 변환)

## 🔍 To Reviewer

### ❶ 전체 흐름

1. Reservation 단일 조회 / 사용자 소유 검증
2. Product 기반 상품 정보 조립
    - 썸네일 (ProductPhoto)
    - 평균 별점 / 리뷰 수 (Review)
    - 무드 태그 (ProductMood)
3. Reservation 기반 예약 상세 정보 조립
4. 결제 정보 계산
    - 기본 금액 (Product)
    - 추가 금액 합산 (ReservationAdditionalPayment)
5. 리뷰 정보 조립 (Review / ReviewPhoto, nullable)

### ❷ 설계 관련
예약 상세 단일 조회 API이기 때문에 현재 단계에서는 쿼리 수로 인한 성능 이슈는 크지 않다고 판단했습니다!
다만 조회 대상 엔티티가 많아, 각 도메인 Repository에서 필요한 데이터를 조회한 뒤 Service 계층에서 DTO로 조립하는 방식으로 구현했습니다.