### PR TITLE
[FIX] #103: 상품 대표 이미지 조회 문제 해결

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
@@ -21,7 +21,7 @@ public interface ProductPhotoRepository extends JpaRepository<ProductPhoto, Long
             from ProductPhoto pp
             join fetch pp.photo ph
             where pp.product.id in :productIds
-              and pp.displayOrder = 0
+              and pp.displayOrder = 1
         """)
     List<ProductPhoto> findThumbnails(@Param("productIds") List<Long> productIds);
 


### PR DESCRIPTION
## 👀 Summary

- close #103 

예약 목록에서 상품 대표 이미지 조회 시 null값이 조회되는 문제를 해결했습니다.

## 🖇️ Tasks

- [x] 대표 이미지 조회 시 displayOrder=1로 설정


## 🔍 To Reviewer

displayOrder 값은 1부터 시작하므로, 0으로 설정되어 있던 조회 조건을 1로 변경했습니다.

<img width="468" height="315" alt="image" src="https://github.com/user-attachments/assets/940182ee-a2a0-4d34-b539-44503dd02b37" />

