### PR TITLE
[FEAT] #102: 포트폴리오 상세 조회

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/portfolio/code/PortfolioSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/code/PortfolioSuccessCode.java
@@ -10,6 +10,7 @@ public enum PortfolioSuccessCode implements SuccessCode {
 
     // 200 OK
     GET_POPULAR_PORTFOLIOS_OK(200, "PORTFOLIO_200_001", "성공적으로 인기 무드 기반 포트폴리오 목록을 조회했습니다."),
+    GET_PORTFOLIO_DETAIL_OK(200, "PORTFOLIO_200_002", "성공적으로 포트폴리오 상세를 조회했습니다."),
 
     // 201 CREATED
 

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioApi.java
@@ -1,9 +1,13 @@
 package org.sopt.snappinserver.api.portfolio.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetPopularPortfolioListResponse;
+import org.sopt.snappinserver.api.portfolio.dto.response.GetPortfolioDetailResponse;
+import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "08 - Portfolio", description = "포트폴리오 관련 API")
 public interface PortfolioApi {
@@ -14,4 +18,14 @@ public interface PortfolioApi {
     )
     ApiResponseBody<GetPopularPortfolioListResponse, Void> getPopularPortfolios();
 
+    @Operation(
+        summary = "포트폴리오 상세 조회 API",
+        description = "포트폴리오 ID를 받아서 포트폴리오 상세 정보를 조회합니다."
+    )
+    ApiResponseBody<GetPortfolioDetailResponse, Void> getPortfolioDetail(
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo,
+
+        @PathVariable Long portfolioId
+    );
 }

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioController.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioController.java
@@ -3,11 +3,18 @@ package org.sopt.snappinserver.api.portfolio.controller;
 import static org.sopt.snappinserver.api.portfolio.code.PortfolioSuccessCode.GET_POPULAR_PORTFOLIOS_OK;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.portfolio.code.PortfolioSuccessCode;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetPopularPortfolioListResponse;
+import org.sopt.snappinserver.api.portfolio.dto.response.GetPortfolioDetailResponse;
+import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPopularPortfolioListResult;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioDetailResult;
 import org.sopt.snappinserver.domain.portfolio.service.usecase.GetPopularPortfolioListUseCase;
+import org.sopt.snappinserver.domain.portfolio.service.usecase.GetPortfolioDetailUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PortfolioController implements PortfolioApi {
 
     private final GetPopularPortfolioListUseCase getPopularPortfolioListUseCase;
+    private final GetPortfolioDetailUseCase getPortfolioDetailUseCase;
 
     @Override
     @GetMapping("/popular")
@@ -26,5 +34,21 @@ public class PortfolioController implements PortfolioApi {
         GetPopularPortfolioListResponse response = GetPopularPortfolioListResponse.from(result);
 
         return ApiResponseBody.ok(GET_POPULAR_PORTFOLIOS_OK, response);
+    }
+
+    @Override
+    @GetMapping("/{portfolioId}")
+    public ApiResponseBody<GetPortfolioDetailResponse, Void> getPortfolioDetail(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        @PathVariable Long portfolioId
+    ) {
+        Long userId = (userInfo != null) ? userInfo.userId() : null;
+        GetPortfolioDetailResult result = getPortfolioDetailUseCase.findPortfolioDetail(
+            userId,
+            portfolioId
+        );
+        GetPortfolioDetailResponse response = GetPortfolioDetailResponse.from(result);
+
+        return ApiResponseBody.ok(PortfolioSuccessCode.GET_PORTFOLIO_DETAIL_OK, response);
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetPhotographerInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetPhotographerInfoResponse.java
@@ -1,0 +1,37 @@
+package org.sopt.snappinserver.api.portfolio.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPhotographerInfoResult;
+
+@Schema(description = "포트폴리오 작가 응답 DTO")
+public record GetPhotographerInfoResponse(
+
+    @Schema(description = "작가 ID")
+    Long id,
+
+    @Schema(description = "작가명")
+    String name,
+
+    @Schema(description = "작가 한줄 소개")
+    String bio,
+
+    @Schema(description = "작가 촬영 상품 종류")
+    List<String> specialties,
+
+    @Schema(description = "작가 활동 지역")
+    List<String> locations
+) {
+
+    public static GetPhotographerInfoResponse from(
+        GetPhotographerInfoResult result
+    ) {
+        return new GetPhotographerInfoResponse(
+            result.id(),
+            result.name(),
+            result.bio(),
+            result.specialties(),
+            result.locations()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetPortfolioDetailResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetPortfolioDetailResponse.java
@@ -1,0 +1,59 @@
+package org.sopt.snappinserver.api.portfolio.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioDetailResult;
+
+@Schema(description = "포트폴리오 상세 조회 응답 DTO")
+public record GetPortfolioDetailResponse(
+
+    @Schema(description = "포트폴리오 ID")
+    Long id,
+
+    @Schema(description = "포트폴리오 한줄 소개")
+    String description,
+
+    @Schema(description = "이미지 URL 목록")
+    List<String> images,
+
+    @Schema(description = "좋아요 여부")
+    boolean isLiked,
+
+    @Schema(description = "좋아요 수")
+    int likeCount,
+
+    @Schema(description = "촬영 종류")
+    String snapCategory,
+
+    @Schema(description = "촬영 장소")
+    String place,
+
+    @Schema(description = "촬영 시각")
+    String startsAt,
+
+    @Schema(description = "스냅 무드")
+    List<String> moods,
+
+    @Schema(description = "작가 프로필")
+    GetPhotographerInfoResponse photographerInfo,
+
+    @Schema(description = "관련 상품 정보")
+    GetProductInfoResponse productInfo
+) {
+
+    public static GetPortfolioDetailResponse from(GetPortfolioDetailResult result) {
+        return new GetPortfolioDetailResponse(
+            result.id(),
+            result.description(),
+            result.images(),
+            result.isLiked(),
+            result.likeCount(),
+            result.snapCategory(),
+            result.place(),
+            result.startsAt(),
+            result.moods(),
+            GetPhotographerInfoResponse.from(result.photographerInfo()),
+            GetProductInfoResponse.from(result.productInfo())
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetProductInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetProductInfoResponse.java
@@ -1,0 +1,47 @@
+package org.sopt.snappinserver.api.portfolio.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetProductInfoResult;
+
+@Schema(description = "상품 응답 DTO")
+public record GetProductInfoResponse(
+
+    @Schema(description = "상품 ID")
+    Long id,
+
+    @Schema(description = "상품 썸네일")
+    String imageUrl,
+
+    @Schema(description = "상품명")
+    String title,
+
+    @Schema(description = "리뷰 별점 평균")
+    Double rate,
+
+    @Schema(description = "리뷰 수")
+    long reviewCount,
+
+    @Schema(description = "작가명")
+    String photographer,
+
+    @Schema(description = "상품 기본 가격")
+    int price,
+
+    @Schema(description = "관련 상품 무드")
+    List<String> moods
+) {
+
+    public static GetProductInfoResponse from(GetProductInfoResult result) {
+        return new GetProductInfoResponse(
+            result.id(),
+            result.imageUrl(),
+            result.title(),
+            result.rate(),
+            result.reviewCount(),
+            result.photographer(),
+            result.price(),
+            result.moods()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/domain/exception/PortfolioErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/domain/exception/PortfolioErrorCode.java
@@ -20,6 +20,10 @@ public enum PortfolioErrorCode implements ErrorCode {
     // 403 FORBIDDEN
 
     // 404 NOT FOUND
+    PORTFOLIO_NOT_FOUND(404, "PORTFOLIO_404_001", "해당 포트폴리오를 찾을 수 없습니다."),
+    PLACE_NOT_FOUND(404, "PORTFOLIO_404_002", "해당 장소를 찾을 수 없습니다."),
+    PRODUCT_PHOTO_NOT_FOUND(404, "PORTFOLIO_404_003", "해당 상품 이미지를 찾을 수 없습니다."),
+    PRODUCT_NOT_FOUND(404, "PRODUCT_404_004", "해당 상품을 찾을 수 없습니다."),
 
     ;
 

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioMoodRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioMoodRepository.java
@@ -16,7 +16,6 @@ public interface PortfolioMoodRepository extends JpaRepository<PortfolioMood, Lo
             JOIN FETCH pm.mood
             WHERE pm.portfolio.id IN :portfolioIds
         """)
-
     List<PortfolioMood> findByPortfolioIds(
         @Param("portfolioIds") List<Long> portfolioIds
     );

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioPhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioPhotoRepository.java
@@ -22,5 +22,4 @@ public interface PortfolioPhotoRepository extends JpaRepository<PortfolioPhoto, 
             ORDER BY pp.portfolio.id, pp.displayOrder
         """)
     List<PortfolioPhoto> findByPortfolioIds(@Param("portfolioIds") List<Long> portfolioIds);
-
 }

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryCustom.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryCustom.java
@@ -1,0 +1,24 @@
+package org.sopt.snappinserver.domain.portfolio.repository;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.PortfolioDetailProjection;
+
+public interface PortfolioRepositoryCustom {
+
+    PortfolioDetailProjection findDetail(Long portfolioId);
+
+    LikeStatusProjection findLikeStatus(Long portfolioId, Long userId);
+
+    List<String> findPortfolioImageUrls(Long portfolioId);
+
+    List<String> findPortfolioMoods(Long portfolioId);
+
+    List<String> findProductMoods(Long productId);
+
+    String findProductThumbnailUrl(Long productId);
+
+    List<String> findPhotographerSpecialties(Long photographerId);
+
+    List<String> findPhotographerAvailableLocations(Long photographerId);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -1,0 +1,182 @@
+package org.sopt.snappinserver.domain.portfolio.repository;
+
+import static org.sopt.snappinserver.domain.mood.domain.entity.QMood.mood;
+import static org.sopt.snappinserver.domain.photographer.domain.entity.QPhotographer.photographer;
+import static org.sopt.snappinserver.domain.photographer.domain.entity.QPhotographerAvailableLocation.photographerAvailableLocation;
+import static org.sopt.snappinserver.domain.photographer.domain.entity.QPhotographerSpecialty.photographerSpecialty;
+import static org.sopt.snappinserver.domain.place.domain.entity.QAvailableLocation.availableLocation;
+import static org.sopt.snappinserver.domain.place.domain.entity.QPlace.place;
+import static org.sopt.snappinserver.domain.portfolio.domain.entity.QPortfolio.portfolio;
+import static org.sopt.snappinserver.domain.portfolio.domain.entity.QPortfolioMood.portfolioMood;
+import static org.sopt.snappinserver.domain.portfolio.domain.entity.QPortfolioPhoto.portfolioPhoto;
+import static org.sopt.snappinserver.domain.portfolio.domain.entity.QPortfolioPlace.portfolioPlace;
+import static org.sopt.snappinserver.domain.product.domain.entity.QProduct.product;
+import static org.sopt.snappinserver.domain.product.domain.entity.QProductMood.productMood;
+import static org.sopt.snappinserver.domain.product.domain.entity.QProductPhoto.productPhoto;
+import static org.sopt.snappinserver.domain.wish.domain.entity.QWishPortfolio.wishPortfolio;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.PortfolioDetailProjection;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public PortfolioDetailProjection findDetail(Long portfolioId) {
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    PortfolioDetailProjection.class,
+                    portfolio.id,
+                    portfolio.description,
+                    portfolio.snapCategory,
+                    portfolio.startsAt.stringValue(),
+                    place.name,
+                    photographer.id,
+                    photographer.name,
+                    product.id,
+                    product.title,
+                    product.price
+                )
+            )
+            .from(portfolio)
+            .join(portfolio.product, product)
+            .join(product.photographer, photographer)
+            .join(portfolioPlace).on(portfolioPlace.portfolio.eq(portfolio))
+            .join(portfolioPlace.place, place)
+            .where(portfolio.id.eq(portfolioId))
+            .fetchOne();
+    }
+
+
+    @Override
+    public LikeStatusProjection findLikeStatus(Long portfolioId, Long userId) {
+        NumberExpression<Integer> likeCount = wishPortfolio.count().intValue();
+
+        if (userId == null) {
+            return queryFactory
+                .select(
+                    Projections.constructor(
+                        LikeStatusProjection.class,
+                        likeCount,
+                        Expressions.FALSE
+                    )
+                )
+                .from(wishPortfolio)
+                .where(wishPortfolio.portfolio.id.eq(portfolioId))
+                .fetchOne();
+        }
+
+        BooleanExpression liked =
+            JPAExpressions
+                .selectOne()
+                .from(wishPortfolio)
+                .where(
+                    wishPortfolio.portfolio.id.eq(portfolioId),
+                    wishPortfolio.user.id.eq(userId)
+                )
+                .exists();
+
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    LikeStatusProjection.class,
+                    likeCount,
+                    liked
+                )
+            )
+            .from(wishPortfolio)
+            .where(wishPortfolio.portfolio.id.eq(portfolioId))
+            .fetchOne();
+    }
+
+    @Override
+    public List<String> findPortfolioImageUrls(Long portfolioId) {
+        return queryFactory
+            .select(portfolioPhoto.photo.imageUrl)
+            .from(portfolioPhoto)
+            .join(portfolioPhoto.photo)
+            .where(portfolioPhoto.portfolio.id.eq(portfolioId))
+            .orderBy(portfolioPhoto.displayOrder.asc())
+            .fetch();
+    }
+
+    @Override
+    public List<String> findPortfolioMoods(Long portfolioId) {
+        return queryFactory
+            .select(mood.name)
+            .from(portfolioMood)
+            .join(portfolioMood.mood, mood)
+            .where(portfolioMood.portfolio.id.eq(portfolioId))
+            .fetch();
+    }
+
+    @Override
+    public List<String> findProductMoods(Long productId) {
+        return queryFactory
+            .select(mood.name)
+            .from(productMood)
+            .join(productMood.mood, mood)
+            .where(productMood.product.id.eq(productId))
+            .fetch();
+    }
+
+    @Override
+    public String findProductThumbnailUrl(Long productId) {
+        return queryFactory
+            .select(productPhoto.photo.imageUrl)
+            .from(productPhoto)
+            .join(productPhoto.photo)
+            .where(
+                productPhoto.product.id.eq(productId),
+                productPhoto.displayOrder.eq(1)
+            )
+            .fetchOne();
+    }
+
+    @Override
+    public List<String> findPhotographerSpecialties(Long photographerId) {
+        return queryFactory
+            .select(photographerSpecialty.specialty.stringValue())
+            .from(photographerSpecialty)
+            .where(photographerSpecialty.photographer.id.eq(photographerId))
+            .fetch();
+    }
+
+    @Override
+    public List<String> findPhotographerAvailableLocations(Long photographerId) {
+        return queryFactory
+            .select(
+                Expressions.stringTemplate(
+                    "case " +
+                        "when {1} is null or {1} = '' " +
+                        "then {0} " +
+                        "else concat({0}, ' ', {1}) end",
+                    availableLocation.sido,
+                    availableLocation.sigungu
+                )
+            )
+            .from(photographerAvailableLocation)
+            .join(
+                photographerAvailableLocation.availableLocation,
+                availableLocation
+            )
+            .where(
+                photographerAvailableLocation.photographer.id.eq(photographerId)
+            )
+            .fetch();
+    }
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -54,12 +54,11 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
             .from(portfolio)
             .join(portfolio.product, product)
             .join(product.photographer, photographer)
-            .join(portfolioPlace).on(portfolioPlace.portfolio.eq(portfolio))
-            .join(portfolioPlace.place, place)
+            .leftJoin(portfolioPlace).on(portfolioPlace.portfolio.eq(portfolio))
+            .leftJoin(portfolioPlace.place, place)
             .where(portfolio.id.eq(portfolioId))
             .fetchOne();
     }
-
 
     @Override
     public LikeStatusProjection findLikeStatus(Long portfolioId, Long userId) {

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetPortfolioDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetPortfolioDetailService.java
@@ -1,0 +1,72 @@
+package org.sopt.snappinserver.domain.portfolio.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+import org.sopt.snappinserver.domain.portfolio.domain.exception.PortfolioErrorCode;
+import org.sopt.snappinserver.domain.portfolio.domain.exception.PortfolioException;
+import org.sopt.snappinserver.domain.portfolio.repository.PortfolioRepositoryCustom;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioDetailResult;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.PortfolioDetailProjection;
+import org.sopt.snappinserver.domain.portfolio.service.mapper.PortfolioDetailMapper;
+import org.sopt.snappinserver.domain.portfolio.service.usecase.GetPortfolioDetailUseCase;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.domain.product.repository.ProductRepository;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult;
+import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class GetPortfolioDetailService implements GetPortfolioDetailUseCase {
+
+    private final PortfolioRepositoryCustom queryRepository;
+    private final ProductRepository productRepository;
+    private final ReviewRepository reviewRepository;
+    private final PortfolioDetailMapper mapper;
+
+    @Override
+    public GetPortfolioDetailResult findPortfolioDetail(Long userId, Long portfolioId) {
+        PortfolioDetailProjection portfolioProjection = queryRepository.findDetail(portfolioId);
+        LikeStatusProjection likeStatus = queryRepository.findLikeStatus(portfolioId, userId);
+
+        List<String> portfolioImages = queryRepository.findPortfolioImageUrls(portfolioId);
+        List<String> portfolioMoods = queryRepository.findPortfolioMoods(portfolioId);
+        List<String> photographerSpecialties = queryRepository.findPhotographerSpecialties(
+            portfolioProjection.photographerId()
+        );
+        List<String> photographerLocations = queryRepository.findPhotographerAvailableLocations(
+            portfolioProjection.photographerId()
+        );
+
+        Product product = getProduct(portfolioProjection);
+        Photographer photographer = product.getPhotographer();
+        ProductReviewStatsResult reviewStats = reviewRepository.findReviewStatsByProductId(
+            product.getId()
+        );
+        String productThumbnail = queryRepository.findProductThumbnailUrl(product.getId());
+        List<String> productMoods = queryRepository.findProductMoods(product.getId());
+
+        return mapper.toResult(
+            portfolioProjection,
+            likeStatus,
+            portfolioImages,
+            portfolioMoods,
+            photographer,
+            photographerSpecialties,
+            photographerLocations,
+            product,
+            productThumbnail,
+            reviewStats,
+            productMoods
+        );
+    }
+
+    private Product getProduct(PortfolioDetailProjection detail) {
+        return productRepository.findById(detail.productId())
+            .orElseThrow(() -> new PortfolioException(PortfolioErrorCode.PRODUCT_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetPortfolioDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetPortfolioDetailService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
 import org.sopt.snappinserver.domain.portfolio.domain.exception.PortfolioErrorCode;
 import org.sopt.snappinserver.domain.portfolio.domain.exception.PortfolioException;
+import org.sopt.snappinserver.domain.portfolio.repository.PortfolioRepository;
 import org.sopt.snappinserver.domain.portfolio.repository.PortfolioRepositoryCustom;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioDetailResult;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
@@ -27,9 +28,11 @@ public class GetPortfolioDetailService implements GetPortfolioDetailUseCase {
     private final ProductRepository productRepository;
     private final ReviewRepository reviewRepository;
     private final PortfolioDetailMapper mapper;
+    private final PortfolioRepository portfolioRepository;
 
     @Override
     public GetPortfolioDetailResult findPortfolioDetail(Long userId, Long portfolioId) {
+        validateExistsPortfolio(portfolioId);
         PortfolioDetailProjection portfolioProjection = queryRepository.findDetail(portfolioId);
         LikeStatusProjection likeStatus = queryRepository.findLikeStatus(portfolioId, userId);
 
@@ -63,6 +66,12 @@ public class GetPortfolioDetailService implements GetPortfolioDetailUseCase {
             reviewStats,
             productMoods
         );
+    }
+
+    private void validateExistsPortfolio(Long portfolioId) {
+        if (!portfolioRepository.existsById(portfolioId)) {
+            throw new PortfolioException(PortfolioErrorCode.PORTFOLIO_NOT_FOUND);
+        }
     }
 
     private Product getProduct(PortfolioDetailProjection detail) {

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPhotographerInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPhotographerInfoResult.java
@@ -1,0 +1,27 @@
+package org.sopt.snappinserver.domain.portfolio.service.dto.response;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+
+public record GetPhotographerInfoResult(
+    Long id,
+    String name,
+    String bio,
+    List<String> specialties,
+    List<String> locations
+) {
+
+    public static GetPhotographerInfoResult of(
+        Photographer photographer,
+        List<String> photographerSpecialties,
+        List<String> photographerAvailableLocations
+    ) {
+        return new GetPhotographerInfoResult(
+            photographer.getId(),
+            photographer.getNickname(),
+            photographer.getBio(),
+            photographerSpecialties,
+            photographerAvailableLocations
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPortfolioDetailResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPortfolioDetailResult.java
@@ -1,0 +1,19 @@
+package org.sopt.snappinserver.domain.portfolio.service.dto.response;
+
+import java.util.List;
+
+public record GetPortfolioDetailResult(
+    Long id,
+    String description,
+    List<String> images,
+    boolean isLiked,
+    int likeCount,
+    String snapCategory,
+    String place,
+    String startsAt,
+    List<String> moods,
+    GetPhotographerInfoResult photographerInfo,
+    GetProductInfoResult productInfo
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetProductInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetProductInfoResult.java
@@ -1,0 +1,35 @@
+package org.sopt.snappinserver.domain.portfolio.service.dto.response;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult;
+
+public record GetProductInfoResult(
+    Long id,
+    String imageUrl,
+    String title,
+    Double rate,
+    long reviewCount,
+    String photographer,
+    int price,
+    List<String> moods
+) {
+
+    public static GetProductInfoResult of(
+        Product product,
+        String productImageUrl,
+        ProductReviewStatsResult productReviewStatsResult,
+        List<String> productMoods
+        ) {
+        return new GetProductInfoResult(
+            product.getId(),
+            productImageUrl,
+            product.getTitle(),
+            productReviewStatsResult.averageRating(),
+            productReviewStatsResult.reviewCount(),
+            product.getPhotographer().getNickname(),
+            product.getPrice(),
+            productMoods
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/LikeStatusProjection.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/LikeStatusProjection.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.portfolio.service.dto.response;
+
+public record LikeStatusProjection(
+    Integer likeCount,
+    Boolean liked
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/PortfolioDetailProjection.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/PortfolioDetailProjection.java
@@ -1,0 +1,18 @@
+package org.sopt.snappinserver.domain.portfolio.service.dto.response;
+
+import org.sopt.snappinserver.global.enums.SnapCategory;
+
+public record PortfolioDetailProjection(
+    Long portfolioId,
+    String description,
+    SnapCategory snapCategory,
+    String startsAt,
+    String placeName,
+    Long photographerId,
+    String photographerName,
+    Long productId,
+    String productName,
+    int price
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/mapper/PortfolioDetailMapper.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/mapper/PortfolioDetailMapper.java
@@ -1,0 +1,68 @@
+package org.sopt.snappinserver.domain.portfolio.service.mapper;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPhotographerInfoResult;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioDetailResult;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetProductInfoResult;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.PortfolioDetailProjection;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult;
+import org.sopt.snappinserver.global.s3.S3Service;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class PortfolioDetailMapper {
+
+    private final S3Service s3Service;
+
+    public GetPortfolioDetailResult toResult(
+        PortfolioDetailProjection portfolio,
+        LikeStatusProjection likeStatus,
+        List<String> portfolioImageUrls,
+        List<String> portfolioMoods,
+        Photographer photographer,
+        List<String> photographerSpecialties,
+        List<String> photographerLocations,
+        Product product,
+        String productThumbnailUrl,
+        ProductReviewStatsResult reviewStats,
+        List<String> productMoods
+    ) {
+
+        List<String> presignedPortfolioImages =
+            portfolioImageUrls.stream()
+                .map(s3Service::getPresignedUrl)
+                .toList();
+
+        String presignedProductThumbnail =
+            s3Service.getPresignedUrl(productThumbnailUrl);
+
+        return new GetPortfolioDetailResult(
+            portfolio.portfolioId(),
+            portfolio.description(),
+            presignedPortfolioImages,
+            likeStatus.liked(),
+            likeStatus.likeCount(),
+            portfolio.snapCategory().getCategory(),
+            portfolio.placeName(),
+            portfolio.startsAt(),
+            portfolioMoods,
+            GetPhotographerInfoResult.of(
+                photographer,
+                photographerSpecialties,
+                photographerLocations
+            ),
+            GetProductInfoResult.of(
+                product,
+                presignedProductThumbnail,
+                reviewStats,
+                productMoods
+            )
+        );
+    }
+}
+

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/usecase/GetPortfolioDetailUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/usecase/GetPortfolioDetailUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.portfolio.service.usecase;
+
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioDetailResult;
+
+public interface GetPortfolioDetailUseCase {
+
+    GetPortfolioDetailResult findPortfolioDetail(Long userId, Long portfolioId);
+}


### PR DESCRIPTION
## 👀 Summary

- close #102

## 🖇️ Tasks

- 기존 리포지토리 jpa 코드를 query dsl 에서 fetch join으로 변경하여 성능 최적화
- 각 조회 결과를 서비스 단 DTO로 만드는 과정에서 Service, Mapper 코드 분리
- 포트폴리오 상세 조회 코드 작성

## 🔍 To Reviewer

### ❶ 포트폴리오 상세 조회 로직 변경
기존에는 포트폴리오 id로 포트폴리오 객체를 조회한 후, 연관 엔티티 목록을 포트폴리오 객체로 조회하는 방식을 사용했습니다. 이렇게 구현하면 총 11번의 쿼리가 나가는 부작용이 있고, 서비스 특성 상 데이터가 많아지면 성능에 악영향이 있을 것이라고 생각했습니다. 따라서, query dsl에서 fetch join을 활용했고, 해당 API 특성 상 엔티티 값을 변경하는 코드가 없기 때문에 DTO Projection으로 필요한 컬럼만 가져오는 것이 더 적절하다고 판단했습니다.

### ❷ 서비스 책임 증가에 따른 코드 분리
기존에는 서비스 코드의 결과를 DTO 로 변환하는 코드를 서비스 코드 내부에서 작성했습니다. 이에 따라 서비스 코드에 조회 코드 모음, DTO 변환으로 서비스가 지나치게 길어진다고 생각했고, 이에 따라 서비스 코드에서는 조회를 모으는 역할만 하고, DTO 변환은 Mapper 클래스를 만들어 결과를 각각의 DTO로 변환할 수 있도록  분리하여 서비스 코드의 책임을 덜어냈습니다.