### PR TITLE
[FEAT] #104: 결제하기 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
@@ -19,6 +19,11 @@ public enum ReservationSuccessCode implements SuccessCode {
         "RESERVATION_200_002",
         "예약 상세 및 촬영 내역 조회에 성공했습니다."
     ),
+    PATCH_RESERVATION_PAY_OK(
+        200,
+        "RESERVATION_200_003",
+        "예약 결제에 성공했습니다."
+    ),
 
     // 201 CREATED
     POST_RESERVATION_REVIEW_CREATED(201, "RESERVATION_201_001", "예약 리뷰 등록에 성공했습니다.");

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
@@ -8,12 +8,14 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import org.sopt.snappinserver.api.reservation.dto.request.CreateReservationReviewRequest;
 import org.sopt.snappinserver.api.reservation.dto.response.CreateReservationReviewResponse;
+import org.sopt.snappinserver.api.reservation.dto.response.PayReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationDetailResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationListResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatusTab;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -58,6 +60,20 @@ public interface ReservationApi {
     )
     @GetMapping("/{reservationId}")
     ApiResponseBody<ReservationDetailResponse, Void> getReservationDetail(
+
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo,
+
+        @Schema(description = "예약 아이디", example = "1")
+        @PathVariable @NotNull Long reservationId
+    );
+
+    @Operation(
+        summary = "결제하기",
+        description = "고객에게 결제 요청된 예약에 대해 결제 완료 상태로 변경합니다."
+    )
+    @PatchMapping("/{reservationId}/pay")
+    ApiResponseBody<PayReservationResponse, Void> patchReservationPay(
 
         @Parameter(hidden = true)
         CustomUserInfo userInfo,

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
@@ -73,7 +73,7 @@ public interface ReservationApi {
         description = "고객에게 결제 요청된 예약에 대해 결제 완료 상태로 변경합니다."
     )
     @PatchMapping("/{reservationId}/pay")
-    ApiResponseBody<PayReservationResponse, Void> patchReservationPay(
+    ApiResponseBody<PayReservationResponse, Void> updateReservationPayment(
 
         @Parameter(hidden = true)
         CustomUserInfo userInfo,

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import org.sopt.snappinserver.api.reservation.dto.request.CreateReservationReviewRequest;
 import org.sopt.snappinserver.api.reservation.dto.response.CreateReservationReviewResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.PayReservationResponse;
@@ -79,7 +80,7 @@ public interface ReservationApi {
         CustomUserInfo userInfo,
 
         @Schema(description = "예약 아이디", example = "1")
-        @PathVariable @NotNull Long reservationId
+        @PathVariable @NotNull @Positive Long reservationId
     );
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.reservation.code.ReservationSuccessCode;
 import org.sopt.snappinserver.api.reservation.dto.request.CreateReservationReviewRequest;
 import org.sopt.snappinserver.api.reservation.dto.response.CreateReservationReviewResponse;
+import org.sopt.snappinserver.api.reservation.dto.response.PayReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationDetailResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationListResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
@@ -12,6 +13,7 @@ import org.sopt.snappinserver.domain.reservation.service.dto.request.CreateReser
 import org.sopt.snappinserver.domain.reservation.service.dto.response.CreateReservationReviewResult;
 import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationDetailUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationListUseCase;
+import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationPayUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.PostReservationReviewUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,6 +29,7 @@ public class ReservationController implements ReservationApi {
     private final PostReservationReviewUseCase postReservationReviewUseCase;
     private final GetReservationListUseCase getReservationListUseCase;
     private final GetReservationDetailUseCase getReservationDetailUseCase;
+    private final PatchReservationPayUseCase patchReservationPayUseCase;
 
     @Override
     public ApiResponseBody<CreateReservationReviewResponse, Void> createReview(
@@ -79,4 +82,21 @@ public class ReservationController implements ReservationApi {
             )
         );
     }
+
+    @Override
+    public ApiResponseBody<PayReservationResponse, Void> patchReservationPay(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        Long reservationId
+    ) {
+        return ApiResponseBody.ok(
+            ReservationSuccessCode.PATCH_RESERVATION_PAY_OK,
+            PayReservationResponse.from(
+                patchReservationPayUseCase.patchReservationPay(
+                    userInfo.userId(),
+                    reservationId
+                )
+            )
+        );
+    }
+
 }

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
@@ -84,7 +84,7 @@ public class ReservationController implements ReservationApi {
     }
 
     @Override
-    public ApiResponseBody<PayReservationResponse, Void> patchReservationPay(
+    public ApiResponseBody<PayReservationResponse, Void> updateReservationPayment(
         @AuthenticationPrincipal CustomUserInfo userInfo,
         Long reservationId
     ) {

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
@@ -91,7 +91,7 @@ public class ReservationController implements ReservationApi {
         return ApiResponseBody.ok(
             ReservationSuccessCode.PATCH_RESERVATION_PAY_OK,
             PayReservationResponse.from(
-                patchReservationPayUseCase.patchReservationPay(
+                patchReservationPayUseCase.payReservation(
                     userInfo.userId(),
                     reservationId
                 )

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/PayReservationResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/PayReservationResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.snappinserver.api.reservation.dto.response;
+
+import org.sopt.snappinserver.domain.reservation.service.dto.response.PayReservationResult;
+
+public record PayReservationResponse(Long reservationId, String status) {
+
+    public static PayReservationResponse from(PayReservationResult result) {
+        return new PayReservationResponse(result.reservationId(), result.status().name());
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
@@ -190,7 +190,18 @@ public class Reservation extends BaseEntity {
         }
     }
 
-    public boolean validateReservationClient(Long userId) {
+    public boolean isReservationClient(Long userId) {
         return this.user.getId().equals(userId);
     }
+
+    public void completePayment() {
+        if (this.reservationStatus != ReservationStatus.PAYMENT_REQUESTED) {
+            throw new ReservationException(
+                ReservationErrorCode.RESERVATION_NOT_PAYMENT_REQUESTED
+            );
+        }
+
+        this.reservationStatus = ReservationStatus.PAYMENT_COMPLETED;
+    }
+
 }

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
@@ -32,8 +32,8 @@ public enum ReservationErrorCode implements ErrorCode {
 
     // 409 CONFLICT
     RESERVATION_TIME_CONFLICT(409, "RESERVATION_409_001", "해당 시간에 이미 예약이 존재합니다."),
-    RESERVATION_NOT_COMPLETED(409, "RESERVATION_409_002", "촬영이 완료된 예약만 리뷰를 작성할 수 있습니다.");
-
+    RESERVATION_NOT_COMPLETED(409, "RESERVATION_409_002", "촬영이 완료된 예약만 리뷰를 작성할 수 있습니다."),
+    RESERVATION_NOT_PAYMENT_REQUESTED(409, "RESERVATION_409_003", "결제 요청 상태의 예약만 결제를 진행할 수 있습니다." );
 
     private final int status;
     private final String code;

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
@@ -33,7 +33,7 @@ public enum ReservationErrorCode implements ErrorCode {
     // 409 CONFLICT
     RESERVATION_TIME_CONFLICT(409, "RESERVATION_409_001", "해당 시간에 이미 예약이 존재합니다."),
     RESERVATION_NOT_COMPLETED(409, "RESERVATION_409_002", "촬영이 완료된 예약만 리뷰를 작성할 수 있습니다."),
-    RESERVATION_NOT_PAYMENT_REQUESTED(409, "RESERVATION_409_003", "결제 요청 상태의 예약만 결제를 진행할 수 있습니다." );
+    RESERVATION_NOT_PAYMENT_REQUESTED(409, "RESERVATION_409_003", "결제 요청 상태의 예약만 결제를 진행할 수 있습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
@@ -63,7 +63,7 @@ public class GetReservationDetailService implements GetReservationDetailUseCase 
         Reservation reservation = reservationRepository.findById(reservationId)
             .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
 
-        if (!reservation.validateReservationClient(userId)) {
+        if (!reservation.isReservationClient(userId)) {
             throw new ReservationException(ReservationErrorCode.RESERVATION_USER_NOT_MATCH);
         }
 

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationPayService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationPayService.java
@@ -19,7 +19,7 @@ public class PatchReservationPayService implements PatchReservationPayUseCase {
     private final ReservationRepository reservationRepository;
 
     @Override
-    public PayReservationResult patchReservationPay(Long userId, Long reservationId) {
+    public PayReservationResult payReservation(Long userId, Long reservationId) {
         Reservation reservation = getReservation(reservationId);
 
         validateReservationClient(userId, reservation);

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationPayService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationPayService.java
@@ -1,0 +1,50 @@
+package org.sopt.snappinserver.domain.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
+import org.sopt.snappinserver.domain.reservation.domain.exception.ReservationErrorCode;
+import org.sopt.snappinserver.domain.reservation.domain.exception.ReservationException;
+import org.sopt.snappinserver.domain.reservation.repository.ReservationRepository;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.PayReservationResult;
+import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationPayUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PatchReservationPayService implements PatchReservationPayUseCase {
+
+    private final ReservationRepository reservationRepository;
+
+    @Override
+    public PayReservationResult patchReservationPay(Long userId, Long reservationId) {
+        Reservation reservation = getReservation(reservationId);
+
+        validateReservationClient(userId, reservation);
+        validatePaymentRequested(reservation);
+
+        reservation.completePayment();
+
+        return new PayReservationResult(reservation.getId(), reservation.getReservationStatus());
+    }
+
+    private Reservation getReservation(Long reservationId) {
+        return reservationRepository.findById(reservationId)
+            .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+    }
+
+    private void validateReservationClient(Long userId, Reservation reservation) {
+        if (!reservation.isReservationClient(userId)) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_USER_NOT_MATCH);
+        }
+    }
+
+    private void validatePaymentRequested(Reservation reservation) {
+        if (reservation.getReservationStatus() != ReservationStatus.PAYMENT_REQUESTED) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_NOT_PAYMENT_REQUESTED);
+        }
+    }
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/PostReservationReviewService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/PostReservationReviewService.java
@@ -61,7 +61,7 @@ public class PostReservationReviewService implements PostReservationReviewUseCas
     }
 
     private void validateReservationClient(Reservation reservation, Long userId) {
-        if (!reservation.validateReservationClient(userId)) {
+        if (!reservation.isReservationClient(userId)) {
             throw new ReservationException(ReservationErrorCode.RESERVATION_USER_NOT_MATCH);
         }
     }

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/PayReservationResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/PayReservationResult.java
@@ -1,0 +1,7 @@
+package org.sopt.snappinserver.domain.reservation.service.dto.response;
+
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
+
+public record PayReservationResult(Long reservationId, ReservationStatus status) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/PatchReservationPayUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/PatchReservationPayUseCase.java
@@ -4,5 +4,5 @@ import org.sopt.snappinserver.domain.reservation.service.dto.response.PayReserva
 
 public interface PatchReservationPayUseCase {
 
-    PayReservationResult patchReservationPay(Long userId, Long reservationId);
+    PayReservationResult payReservation(Long userId, Long reservationId);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/PatchReservationPayUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/PatchReservationPayUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.reservation.service.usecase;
+
+import org.sopt.snappinserver.domain.reservation.service.dto.response.PayReservationResult;
+
+public interface PatchReservationPayUseCase {
+
+    PayReservationResult patchReservationPay(Long userId, Long reservationId);
+}


### PR DESCRIPTION
## 👀 Summary

- close #104 

예약 결제 요청 상태(`PAYMENT_REQUESTED`)에 대해 결제를 진행하고 예약 상태를 결제 완료(`PAYMENT_COMPLETED`)로 변경하는 결제 처리 Patch API를 구현했습니다.

> 앱잼 기간동안만 사용할 비즈니스 로직으로 실제 결제 기능은 존재하지 않습니다.

## 🖇️ Tasks

- [x] PATCH API 추가
- [x] 결제 처리 useCase 구현
- [x] 결제 처리 결과 전달을 위한 도메인 결과 DTO 추가
- [x] API 응답 DTO(PayReservationResponse) 구현
- [x] 예약 소유자 검증 로직 추가
- [x] 예약 상태 검증 (PAYMENT_REQUESTED 상태에서만 결제 가능)
- [x] 예약 상태 변경 Reservation 엔티티 메서드 추가


## 🔍 To Reviewer

### ❶ Patch API에서도 도메인 결과 DTO가 필요한지

단순 상태 변경 API라도 변경된 상태를 응답으로 내려주는 경우, Service → Controller 간 결과 전달을 명확하게 하기 위해
도메인 결과 DTO(PayReservationResult)를 사용했습니다.


### ❷ 상태 변경 로직의 위치 (Service vs Entity)

예약 상태 변경은 도메인 상에서의 불변 조건이므로 Service가 아닌 Reservation 엔티티에 위치시키는 것이 적절하다고 판단했습니다.
Service는 언제 결제할지에 대한 usecase 흐름만 담당하고, 상태 변경 가능 여부 확인과 실제 변경은 엔티티 계층에서 책임지도록 분리했습니다.
