### PR TITLE
[FEAT] #105: 예약 취소 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
@@ -24,6 +24,11 @@ public enum ReservationSuccessCode implements SuccessCode {
         "RESERVATION_200_003",
         "예약 결제에 성공했습니다."
     ),
+    PATCH_RESERVATION_CANCEL_OK(
+        200,
+        "RESERVATION_200_004",
+        "예약 취소에 성공했습니다."
+    ),
 
     // 201 CREATED
     POST_RESERVATION_REVIEW_CREATED(201, "RESERVATION_201_001", "예약 리뷰 등록에 성공했습니다.");

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import org.sopt.snappinserver.api.reservation.dto.request.CreateReservationReviewRequest;
+import org.sopt.snappinserver.api.reservation.dto.response.CancelReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.CreateReservationReviewResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.PayReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationDetailResponse;
@@ -83,4 +84,17 @@ public interface ReservationApi {
         @PathVariable @NotNull @Positive Long reservationId
     );
 
+    @Operation(
+        summary = "예약 취소",
+        description = "고객의 예약을 취소 상태로 변경합니다."
+    )
+    @PatchMapping("/{reservationId}/cancel")
+    ApiResponseBody<CancelReservationResponse, Void> updateReservationCancel(
+
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo,
+
+        @Schema(description = "예약 아이디", example = "1")
+        @PathVariable @NotNull @Positive Long reservationId
+    );
 }

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
@@ -3,6 +3,7 @@ package org.sopt.snappinserver.api.reservation.controller;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.reservation.code.ReservationSuccessCode;
 import org.sopt.snappinserver.api.reservation.dto.request.CreateReservationReviewRequest;
+import org.sopt.snappinserver.api.reservation.dto.response.CancelReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.CreateReservationReviewResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.PayReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationDetailResponse;
@@ -13,11 +14,11 @@ import org.sopt.snappinserver.domain.reservation.service.dto.request.CreateReser
 import org.sopt.snappinserver.domain.reservation.service.dto.response.CreateReservationReviewResult;
 import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationDetailUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationListUseCase;
+import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationCancelUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationPayUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.PostReservationReviewUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,6 +31,7 @@ public class ReservationController implements ReservationApi {
     private final GetReservationListUseCase getReservationListUseCase;
     private final GetReservationDetailUseCase getReservationDetailUseCase;
     private final PatchReservationPayUseCase patchReservationPayUseCase;
+    private final PatchReservationCancelUseCase patchReservationCancelUseCase;
 
     @Override
     public ApiResponseBody<CreateReservationReviewResponse, Void> createReview(
@@ -92,6 +94,22 @@ public class ReservationController implements ReservationApi {
             ReservationSuccessCode.PATCH_RESERVATION_PAY_OK,
             PayReservationResponse.from(
                 patchReservationPayUseCase.payReservation(
+                    userInfo.userId(),
+                    reservationId
+                )
+            )
+        );
+    }
+
+    @Override
+    public ApiResponseBody<CancelReservationResponse, Void> updateReservationCancel(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        Long reservationId
+    ) {
+        return ApiResponseBody.ok(
+            ReservationSuccessCode.PATCH_RESERVATION_CANCEL_OK,
+            CancelReservationResponse.from(
+                patchReservationCancelUseCase.cancelReservation(
                     userInfo.userId(),
                     reservationId
                 )

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/CancelReservationResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/CancelReservationResponse.java
@@ -1,0 +1,14 @@
+package org.sopt.snappinserver.api.reservation.dto.response;
+
+import org.sopt.snappinserver.domain.reservation.service.dto.response.CancelReservationResult;
+
+public record CancelReservationResponse(Long reservationId, String previousStatus, String status) {
+
+    public static CancelReservationResponse from(CancelReservationResult result) {
+        return new CancelReservationResponse(
+            result.reservationId(),
+            result.previousStatus().name(),
+            result.status().name()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
@@ -196,12 +196,20 @@ public class Reservation extends BaseEntity {
 
     public void completePayment() {
         if (this.reservationStatus != ReservationStatus.PAYMENT_REQUESTED) {
-            throw new ReservationException(
-                ReservationErrorCode.RESERVATION_NOT_PAYMENT_REQUESTED
-            );
+            throw new ReservationException(ReservationErrorCode.RESERVATION_NOT_PAYMENT_REQUESTED);
         }
 
         this.reservationStatus = ReservationStatus.PAYMENT_COMPLETED;
     }
+
+    public void cancel() {
+        if (this.reservationStatus == ReservationStatus.SHOOT_COMPLETED) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_COMPLETED);
+        }
+
+        this.previousCancelStatus = this.reservationStatus;
+        this.reservationStatus = ReservationStatus.RESERVATION_CANCELED;
+    }
+
 
 }

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
@@ -206,7 +206,9 @@ public class Reservation extends BaseEntity {
         if (this.reservationStatus == ReservationStatus.SHOOT_COMPLETED) {
             throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_COMPLETED);
         }
-
+        if (this.reservationStatus == ReservationStatus.RESERVATION_CANCELED) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_CANCELED);
+        }
         this.previousCancelStatus = this.reservationStatus;
         this.reservationStatus = ReservationStatus.RESERVATION_CANCELED;
     }

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
@@ -34,7 +34,7 @@ public enum ReservationErrorCode implements ErrorCode {
     RESERVATION_TIME_CONFLICT(409, "RESERVATION_409_001", "해당 시간에 이미 예약이 존재합니다."),
     RESERVATION_NOT_COMPLETED(409, "RESERVATION_409_002", "촬영이 완료된 예약만 리뷰를 작성할 수 있습니다."),
     RESERVATION_NOT_PAYMENT_REQUESTED(409, "RESERVATION_409_003", "결제 요청 상태의 예약만 결제를 진행할 수 있습니다."),
-    RESERVATION_SHOOT_ALREADY_COMPLETED(409, "RESERVATION_409_004", "촬영 완료된 예약은 취소할 수 없습니다."),
+    RESERVATION_ALREADY_COMPLETED(409, "RESERVATION_409_004", "촬영 완료된 예약은 취소할 수 없습니다."),
     RESERVATION_ALREADY_CANCELED(409, "RESERVATION_409_005", "이미 취소된 예약입니다.");
 
     private final int status;

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
@@ -33,7 +33,8 @@ public enum ReservationErrorCode implements ErrorCode {
     // 409 CONFLICT
     RESERVATION_TIME_CONFLICT(409, "RESERVATION_409_001", "해당 시간에 이미 예약이 존재합니다."),
     RESERVATION_NOT_COMPLETED(409, "RESERVATION_409_002", "촬영이 완료된 예약만 리뷰를 작성할 수 있습니다."),
-    RESERVATION_NOT_PAYMENT_REQUESTED(409, "RESERVATION_409_003", "결제 요청 상태의 예약만 결제를 진행할 수 있습니다.");
+    RESERVATION_NOT_PAYMENT_REQUESTED(409, "RESERVATION_409_003", "결제 요청 상태의 예약만 결제를 진행할 수 있습니다."),
+    RESERVATION_ALREADY_COMPLETED(409, "RESERVATION_409_004", "이미 취소 처리된 예약입니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
@@ -34,7 +34,8 @@ public enum ReservationErrorCode implements ErrorCode {
     RESERVATION_TIME_CONFLICT(409, "RESERVATION_409_001", "해당 시간에 이미 예약이 존재합니다."),
     RESERVATION_NOT_COMPLETED(409, "RESERVATION_409_002", "촬영이 완료된 예약만 리뷰를 작성할 수 있습니다."),
     RESERVATION_NOT_PAYMENT_REQUESTED(409, "RESERVATION_409_003", "결제 요청 상태의 예약만 결제를 진행할 수 있습니다."),
-    RESERVATION_ALREADY_COMPLETED(409, "RESERVATION_409_004", "이미 취소 처리된 예약입니다.");
+    RESERVATION_SHOOT_ALREADY_COMPLETED(409, "RESERVATION_409_004", "촬영 완료된 예약은 취소할 수 없습니다."),
+    RESERVATION_ALREADY_CANCELED(409, "RESERVATION_409_005", "이미 취소된 예약입니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationCancelService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationCancelService.java
@@ -1,0 +1,48 @@
+package org.sopt.snappinserver.domain.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
+import org.sopt.snappinserver.domain.reservation.domain.exception.ReservationErrorCode;
+import org.sopt.snappinserver.domain.reservation.domain.exception.ReservationException;
+import org.sopt.snappinserver.domain.reservation.repository.ReservationRepository;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.CancelReservationResult;
+import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationCancelUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PatchReservationCancelService implements PatchReservationCancelUseCase {
+
+    private final ReservationRepository reservationRepository;
+
+    @Override
+    public CancelReservationResult cancelReservation(Long userId, Long reservationId) {
+        Reservation reservation = getReservation(reservationId);
+
+        validateReservationClient(userId, reservation);
+        ReservationStatus previousStatus = reservation.getReservationStatus();
+
+        reservation.cancel();
+
+        return new CancelReservationResult(
+            reservation.getId(),
+            previousStatus,
+            reservation.getReservationStatus()
+        );
+    }
+
+    private Reservation getReservation(Long reservationId) {
+        return reservationRepository.findById(reservationId).orElseThrow(
+            () -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND)
+        );
+    }
+
+    private static void validateReservationClient(Long userId, Reservation reservation) {
+        if (!reservation.isReservationClient(userId)) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_USER_NOT_MATCH);
+        }
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/CancelReservationResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/CancelReservationResult.java
@@ -1,0 +1,11 @@
+package org.sopt.snappinserver.domain.reservation.service.dto.response;
+
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
+
+public record CancelReservationResult(
+    Long reservationId,
+    ReservationStatus previousStatus,
+    ReservationStatus status
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/PatchReservationCancelUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/PatchReservationCancelUseCase.java
@@ -1,0 +1,9 @@
+package org.sopt.snappinserver.domain.reservation.service.usecase;
+
+import org.sopt.snappinserver.domain.reservation.service.dto.response.CancelReservationResult;
+
+public interface PatchReservationCancelUseCase {
+
+    CancelReservationResult cancelReservation(Long userId, Long reservationId);
+
+}


### PR DESCRIPTION
## 👀 Summary

- close #105 

고객이 예약한 상품에 대해 촬영 완료 이전 단계에서 예약을 취소할 수 있는 예약 취소 Patch API를 구현했습니다.
예약 취소 시, 취소 처리 이전의 예약 상태를 응답 구조에 포함시켜 어느 단계에서 취소되었는지 확인할 수 있도록 합니다.

## 🖇️ Tasks

- [x] PATCH API 추가
- [x] 예약 취소 useCase 구현
- [x] 예약 취소 결과를 전달하기 위한 도메인 결과 DTO 추가
- [x] API 응답 DTO 구현
- [x] 예약검증 로직 추가
- [x] 촬영 완료 이후 예약에 대한 취소 제한 처리
- [x] 예약 취소 시점의 상태를 previousCancelStatus로 저장
- [x] 예약 상태 변경 로직을 Reservation 엔티티 메서드 추가 (cancel)

## 🔍 To Reviewer

### ❶ 상태 변경 로직의 위치 (Service vs Entity)
예약 취소와 같은 상태 변경은 도메인 상에서의 불변 조건이므로 Service가 아닌 Reservation 엔티티에 위치시키는 것이 적절하다고 판단했습니다. Service는 언제 취소할지에 대한 usecase 흐름만 담당하고, 상태 변경 가능 여부 확인과 실제 변경은 엔티티 계층에서 책임지도록 분리했습니다.

### ❷ 예약 취소 직전 상태 검증 위치
촬영 완료 상태에서는 예약 취소가 불가하기 때문에 `SHOOTING_COMPLETED` 상태인지 여부를
Service와 도메인 엔티티 중 어디에서 검증할지 고민했는데, 촬영 완료 여부는 단순한 요청 흐름 검증이 아니라 예약 상태 변경에 선행되는 조건이라고 판단해 Service가 아닌 Reservation 엔티티의 취소 메서드 내부에 촬영 완료 여부를 검증하는 로직도 함께 포함시켰습니다.


> 결제하기 API와 동일하게 모든 예약 상태 변경 로직은 Patch API 전반에서 설계 패턴을 통일할 예정입니다.

