### PR TITLE
[FEAT] #110: 스냅 명소 및 작가 추천 목록 조회

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/home/code/HomeSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/home/code/HomeSuccessCode.java
@@ -1,0 +1,21 @@
+package org.sopt.snappinserver.api.home.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.global.response.code.common.SuccessCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum HomeSuccessCode implements SuccessCode {
+
+    // 200 OK
+    GET_PLACE_PHOTOGRAPHER_RECOMMENDATION_OK(200, "HOME_200_001", "성공적으로 장소, 작가 추천 목록을 조회했습니다."),
+
+    // 201 CREATED
+
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/sopt/snappinserver/api/home/controller/HomeApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/home/controller/HomeApi.java
@@ -1,8 +1,17 @@
 package org.sopt.snappinserver.api.home.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.snappinserver.api.home.dto.response.GetPlacePhotographerRecommendationResponse;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 
 @Tag(name = "04 - Home", description = "홈 화면에서 사용되는 API")
 public interface HomeApi {
+
+    @Operation(
+        summary = "스냅 명소 및 작가 추천 목록 조회 API",
+        description = "최근 1개월 간 예약 건수가 가장 많은 장소 5곳과 랜덤으로 작가 5명을 추천합니다."
+    )
+    ApiResponseBody<GetPlacePhotographerRecommendationResponse, Void> getRecommendation();
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/home/controller/HomeController.java
+++ b/src/main/java/org/sopt/snappinserver/api/home/controller/HomeController.java
@@ -1,12 +1,40 @@
 package org.sopt.snappinserver.api.home.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.home.code.HomeSuccessCode;
+import org.sopt.snappinserver.api.home.dto.response.GetPlacePhotographerRecommendationResponse;
+import org.sopt.snappinserver.domain.photographer.service.dto.response.GetRandomPhotographersResult;
+import org.sopt.snappinserver.domain.photographer.service.usecase.GetRandomPhotographersUseCase;
+import org.sopt.snappinserver.domain.place.service.dto.response.GetRecommendationPlaceResult;
+import org.sopt.snappinserver.domain.place.service.usecase.GetRecommendationPlaceUseCase;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/home")
 @RequiredArgsConstructor
 @RestController
-public class HomeController implements HomeApi{
+public class HomeController implements HomeApi {
+
+    private final GetRecommendationPlaceUseCase getRecommendationPlaceUseCase;
+    private final GetRandomPhotographersUseCase getRandomPhotographersUseCase;
+
+    @Override
+    @GetMapping("/recommendation")
+    public ApiResponseBody<GetPlacePhotographerRecommendationResponse, Void> getRecommendation() {
+        List<GetRecommendationPlaceResult> placeResult = getRecommendationPlaceUseCase
+            .getPlaceRecommendation();
+        List<GetRandomPhotographersResult> photographersResults = getRandomPhotographersUseCase
+            .getRandomPhotographersResult();
+        GetPlacePhotographerRecommendationResponse response =
+            GetPlacePhotographerRecommendationResponse.of(placeResult, photographersResults);
+
+        return ApiResponseBody.ok(
+            HomeSuccessCode.GET_PLACE_PHOTOGRAPHER_RECOMMENDATION_OK,
+            response
+        );
+    }
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/home/dto/response/GetPhotographerInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/home/dto/response/GetPhotographerInfoResponse.java
@@ -1,0 +1,35 @@
+package org.sopt.snappinserver.api.home.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.photographer.service.dto.response.GetRandomPhotographersResult;
+
+@Schema(description = "추천 작가 응답 DTO")
+public record GetPhotographerInfoResponse(
+
+    @Schema(description = "작가 ID")
+    Long id,
+
+    @Schema(description = "작가명")
+    String name,
+
+    @Schema(description = "작가 프로필 이미지")
+    String profileImageUrl,
+
+    @Schema(description = "신규 작가 여부")
+    boolean isNew,
+
+    @Schema(description = "작가 촬영 상품 목록")
+    List<String> specialties
+) {
+
+    public static GetPhotographerInfoResponse from(GetRandomPhotographersResult result) {
+        return new GetPhotographerInfoResponse(
+            result.id(),
+            result.name(),
+            result.profileImageUrl(),
+            result.isNew(),
+            result.specialties()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/home/dto/response/GetPlaceInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/home/dto/response/GetPlaceInfoResponse.java
@@ -1,0 +1,26 @@
+package org.sopt.snappinserver.api.home.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.place.service.dto.response.GetRecommendationPlaceResult;
+
+@Schema(description = "추천 장소 응답 DTO")
+public record GetPlaceInfoResponse(
+
+    @Schema(description = "장소 ID")
+    Long id,
+
+    @Schema(description = "장소 이름")
+    String name,
+
+    @Schema(description = "장소 이미지 url")
+    String imageUrl
+) {
+
+    public static GetPlaceInfoResponse from(GetRecommendationPlaceResult result) {
+        return new GetPlaceInfoResponse(
+            result.id(),
+            result.name(),
+            result.imageUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/home/dto/response/GetPlacePhotographerRecommendationResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/home/dto/response/GetPlacePhotographerRecommendationResponse.java
@@ -1,0 +1,32 @@
+package org.sopt.snappinserver.api.home.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.photographer.service.dto.response.GetRandomPhotographersResult;
+import org.sopt.snappinserver.domain.place.service.dto.response.GetRecommendationPlaceResult;
+
+@Schema(description = "스냅 명소 및 작가 추천 목록 조회 응답 DTO")
+public record GetPlacePhotographerRecommendationResponse(
+
+    @Schema(description = "추천 장소 목록")
+    List<GetPlaceInfoResponse> places,
+
+    @Schema(description = "추천 작가 목록")
+    List<GetPhotographerInfoResponse> photographers
+) {
+
+    public static GetPlacePhotographerRecommendationResponse of(
+        List<GetRecommendationPlaceResult> placeResults,
+        List<GetRandomPhotographersResult> photographersResults
+    ) {
+        return new GetPlacePhotographerRecommendationResponse(
+            placeResults.stream()
+                .map(GetPlaceInfoResponse::from)
+                .toList(),
+
+            photographersResults.stream()
+                .map(GetPhotographerInfoResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/Photographer.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/Photographer.java
@@ -32,6 +32,7 @@ public class Photographer extends BaseEntity {
     private static final int MAX_NAME_LENGTH = 10;
     private static final int MAX_NICKNAME_LENGTH = 20;
     private static final int MAX_BIO_LENGTH = 200;
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "photographer_seq_gen")
@@ -158,7 +159,7 @@ public class Photographer extends BaseEntity {
     }
 
     public boolean isNewPhotographer() {
-        Instant oneMonthAgo = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
+        Instant oneMonthAgo = ZonedDateTime.now(KOREA_ZONE)
             .minusMonths(1)
             .toInstant();
 

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/Photographer.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/Photographer.java
@@ -11,6 +11,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -152,5 +155,13 @@ public class Photographer extends BaseEntity {
         if (bio != null && bio.length() > MAX_BIO_LENGTH) {
             throw new PhotographerException(PhotographerErrorCode.BIO_TOO_LONG);
         }
+    }
+
+    public boolean isNewPhotographer() {
+        Instant oneMonthAgo = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
+            .minusMonths(1)
+            .toInstant();
+
+        return this.createdAt.isAfter(oneMonthAgo);
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/repository/PhotographerRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/repository/PhotographerRepository.java
@@ -1,12 +1,27 @@
 package org.sopt.snappinserver.domain.photographer.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PhotographerRepository extends JpaRepository<Photographer, Long> {
 
     Optional<Photographer> findByUser(User user);
+
     boolean existsByUser(User user);
+
+    @Query(
+        value = """
+                SELECT *
+                FROM photographer
+                ORDER BY RANDOM()
+                LIMIT :limit
+            """,
+        nativeQuery = true
+    )
+    List<Photographer> findRandom(@Param("limit") int limit);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetRandomPhotographersService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetRandomPhotographersService.java
@@ -1,0 +1,33 @@
+package org.sopt.snappinserver.domain.photographer.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+import org.sopt.snappinserver.domain.photographer.domain.entity.PhotographerSpecialty;
+import org.sopt.snappinserver.domain.photographer.repository.PhotographerRepository;
+import org.sopt.snappinserver.domain.photographer.repository.PhotographerSpecialtyRepository;
+import org.sopt.snappinserver.domain.photographer.service.dto.response.GetRandomPhotographersResult;
+import org.sopt.snappinserver.domain.photographer.service.usecase.GetRandomPhotographersUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class GetRandomPhotographersService implements GetRandomPhotographersUseCase {
+
+    private final PhotographerRepository photographerRepository;
+    private final PhotographerSpecialtyRepository photographerSpecialtyRepository;
+
+    public List<GetRandomPhotographersResult> getRandomPhotographersResult() {
+        List<Photographer> photographers = photographerRepository.findRandom(5);
+        return photographers.stream()
+            .map(photographer -> {
+                List<PhotographerSpecialty> specialties = photographerSpecialtyRepository
+                    .findAllByPhotographer(photographer);
+
+                return GetRandomPhotographersResult.of(photographer, specialties);
+            })
+            .toList();
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/dto/response/GetRandomPhotographersResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/dto/response/GetRandomPhotographersResult.java
@@ -1,0 +1,33 @@
+package org.sopt.snappinserver.domain.photographer.service.dto.response;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+import org.sopt.snappinserver.domain.photographer.domain.entity.PhotographerSpecialty;
+import org.sopt.snappinserver.global.enums.SnapCategory;
+
+public record GetRandomPhotographersResult(
+    Long id,
+    String name,
+    String profileImageUrl,
+    boolean isNew,
+    String bio,
+    List<String> specialties
+) {
+
+    public static GetRandomPhotographersResult of(
+        Photographer photographer,
+        List<PhotographerSpecialty> specialties
+    ) {
+        return new GetRandomPhotographersResult(
+            photographer.getId(),
+            photographer.getNickname(),
+            photographer.getUser().getProfileImageUrl(),
+            photographer.isNewPhotographer(),
+            photographer.getBio(),
+            specialties.stream()
+                .map(PhotographerSpecialty::getSpecialty)
+                .map(SnapCategory::getCategory)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/usecase/GetRandomPhotographersUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/usecase/GetRandomPhotographersUseCase.java
@@ -1,0 +1,9 @@
+package org.sopt.snappinserver.domain.photographer.service.usecase;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.photographer.service.dto.response.GetRandomPhotographersResult;
+
+public interface GetRandomPhotographersUseCase {
+
+    List<GetRandomPhotographersResult> getRandomPhotographersResult();
+}

--- a/src/main/java/org/sopt/snappinserver/domain/place/service/GetRecommendationPlaceService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/place/service/GetRecommendationPlaceService.java
@@ -1,0 +1,41 @@
+package org.sopt.snappinserver.domain.place.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.place.domain.entity.Place;
+import org.sopt.snappinserver.domain.place.service.dto.response.GetRecommendationPlaceResult;
+import org.sopt.snappinserver.domain.place.service.usecase.GetRecommendationPlaceUseCase;
+import org.sopt.snappinserver.domain.portfolio.repository.PortfolioRepositoryCustom;
+import org.sopt.snappinserver.domain.reservation.repository.ReservationRepositoryCustom;
+import org.sopt.snappinserver.global.s3.S3Service;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class GetRecommendationPlaceService implements GetRecommendationPlaceUseCase {
+
+    private final ReservationRepositoryCustom reservationRepositoryCustom;
+    private final PortfolioRepositoryCustom portfolioRepositoryCustom;
+    private final S3Service s3Service;
+
+    @Override
+    public List<GetRecommendationPlaceResult> getPlaceRecommendation() {
+        List<Place> places = reservationRepositoryCustom.findTop5MostReservedPlacesInLastMonth();
+
+        return places.stream()
+            .map(place -> {
+                String imageKey = portfolioRepositoryCustom
+                    .findBestPortfolioImageByPlaceId(place.getId())
+                    .orElse(null);
+
+                String presignedUrl = (imageKey != null)
+                    ? s3Service.getPresignedUrl(imageKey)
+                    : null;
+
+                return GetRecommendationPlaceResult.of(place, presignedUrl);
+            })
+            .toList();
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/place/service/dto/response/GetRecommendationPlaceResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/place/service/dto/response/GetRecommendationPlaceResult.java
@@ -1,0 +1,18 @@
+package org.sopt.snappinserver.domain.place.service.dto.response;
+
+import org.sopt.snappinserver.domain.place.domain.entity.Place;
+
+public record GetRecommendationPlaceResult(
+    Long id,
+    String name,
+    String imageUrl
+) {
+
+    public static GetRecommendationPlaceResult of(Place place, String imageUrl) {
+        return new GetRecommendationPlaceResult(
+            place.getId(),
+            place.getName(),
+            imageUrl
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/place/service/usecase/GetRecommendationPlaceUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/place/service/usecase/GetRecommendationPlaceUseCase.java
@@ -1,0 +1,9 @@
+package org.sopt.snappinserver.domain.place.service.usecase;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.place.service.dto.response.GetRecommendationPlaceResult;
+
+public interface GetRecommendationPlaceUseCase {
+
+    List<GetRecommendationPlaceResult> getPlaceRecommendation();
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryCustom.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryCustom.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.portfolio.repository;
+
+import java.util.Optional;
+
+public interface PortfolioRepositoryCustom {
+
+    Optional<String> findBestPortfolioImageByPlaceId(Long placeId);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -35,6 +35,7 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
 
     private final JPAQueryFactory jpaQueryFactory;
 
+    @Override
     public Optional<String> findBestPortfolioImageByPlaceId(Long placeId) {
         NumberExpression<Double> random = Expressions.numberTemplate(
             Double.class,

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -1,0 +1,42 @@
+package org.sopt.snappinserver.domain.portfolio.repository;
+
+import static org.sopt.snappinserver.domain.photo.domain.entity.QPhoto.photo;
+import static org.sopt.snappinserver.domain.portfolio.domain.entity.QPortfolio.portfolio;
+import static org.sopt.snappinserver.domain.portfolio.domain.entity.QPortfolioPhoto.portfolioPhoto;
+import static org.sopt.snappinserver.domain.portfolio.domain.entity.QPortfolioPlace.portfolioPlace;
+import static org.sopt.snappinserver.domain.wish.domain.entity.QWishPortfolio.wishPortfolio;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public Optional<String> findBestPortfolioImageByPlaceId(Long placeId) {
+        String imageKey = jpaQueryFactory
+            .select(photo.imageUrl)
+            .from(portfolio)
+            .join(portfolioPlace).on(portfolioPlace.portfolio.eq(portfolio))
+            .leftJoin(wishPortfolio).on(wishPortfolio.portfolio.eq(portfolio))
+            .join(portfolioPhoto).on(portfolioPhoto.portfolio.eq(portfolio))
+            .join(portfolioPhoto.photo, photo)
+            .where(
+                portfolioPlace.place.id.eq(placeId),
+                portfolioPhoto.displayOrder.eq(1)
+            )
+            .groupBy(portfolio.id, photo.imageUrl)
+            .orderBy(
+                wishPortfolio.count().desc(),
+                portfolio.id.desc()
+            )
+            .limit(1)
+            .fetchOne();
+
+        return Optional.ofNullable(imageKey);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -6,6 +6,8 @@ import static org.sopt.snappinserver.domain.portfolio.domain.entity.QPortfolioPh
 import static org.sopt.snappinserver.domain.portfolio.domain.entity.QPortfolioPlace.portfolioPlace;
 import static org.sopt.snappinserver.domain.wish.domain.entity.QWishPortfolio.wishPortfolio;
 
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,11 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
     public Optional<String> findBestPortfolioImageByPlaceId(Long placeId) {
+        NumberExpression<Double> random = Expressions.numberTemplate(
+            Double.class,
+            "function('random')"
+        );
+
         String imageKey = jpaQueryFactory
             .select(photo.imageUrl)
             .from(portfolio)
@@ -32,7 +39,7 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
             .groupBy(portfolio.id, photo.imageUrl)
             .orderBy(
                 wishPortfolio.count().desc(),
-                portfolio.id.desc()
+                random.asc()
             )
             .limit(1)
             .fetchOne();

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepositoryCustom.java
@@ -1,0 +1,9 @@
+package org.sopt.snappinserver.domain.reservation.repository;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.place.domain.entity.Place;
+
+public interface ReservationRepositoryCustom {
+
+    List<Place> findTop5MostReservedPlacesInLastMonth();
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepositoryImpl.java
@@ -1,0 +1,36 @@
+package org.sopt.snappinserver.domain.reservation.repository;
+
+import static org.sopt.snappinserver.domain.place.domain.entity.QPlace.place;
+import static org.sopt.snappinserver.domain.reservation.domain.entity.QReservation.reservation;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.place.domain.entity.Place;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Place> findTop5MostReservedPlacesInLastMonth() {
+        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
+
+        return jpaQueryFactory
+            .select(reservation.place)
+            .from(reservation)
+            .join(reservation.place, place)
+            .where(
+                reservation.createdAt.goe(Instant.from(oneMonthAgo))
+            )
+            .groupBy(reservation.place)
+            .orderBy(reservation.count().desc())
+            .limit(5)
+            .fetch();
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepositoryImpl.java
@@ -31,7 +31,7 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
             .from(reservation)
             .join(reservation.place, place)
             .where(
-                reservation.createdAt.goe(Instant.from(oneMonthAgo))
+                reservation.createdAt.goe(oneMonthAgo)
             )
             .groupBy(reservation.place)
             .orderBy(reservation.count().desc())

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepositoryImpl.java
@@ -6,6 +6,7 @@ import static org.sopt.snappinserver.domain.reservation.domain.entity.QReservati
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.domain.place.domain.entity.Place;
@@ -19,7 +20,11 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
 
     @Override
     public List<Place> findTop5MostReservedPlacesInLastMonth() {
-        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
+        Instant oneMonthAgo =
+            LocalDateTime.now()
+                .minusMonths(1)
+                .atZone(ZoneId.systemDefault())
+                .toInstant();
 
         return jpaQueryFactory
             .select(reservation.place)


### PR DESCRIPTION
## 👀 Summary

- close #110


## 🖇️ Tasks

-  최근 1개월 내 예약 건수가 가장 많은 장소 조회
- 해당 장소에서 찍은 포트폴리오에 대해 좋아요 수가 가장 많은 포트폴리오의 썸네일 이미지 함께 반환
- 랜덤 5개 작가 목록 반환


## 🔍 To Reviewer

### ❶ 좋아요가 없거나, 좋아요가 동률인 포트폴리오 처리 방법
좋아요가 없거나, 한 장소에 대해서 여러 포트폴리오의 좋아요가 동률인 경우, 이미지가 제대로 반환되지 않는 문제가 있었습니다. 따라서, 기획과 해당 부분 논의 후 특정 장소에 대해 좋아요가 없거나 좋아요가 동률인 포트폴리오가 여러 개 있을 경우, 해당 포트폴리오 중 랜덤 1개의 썸네일을 사용하는 로직으로 구현했습니다.

### ❷ 장소 & 포폴 이미지 조회 시 성능 문제 관련
현재 인기 장소 목록 조회(1회) 후, 각 장소에 대해서 포트폴리오 이미지(N회)를 조회하는 방식입니다. 현재 기획 상 인기 장소가 5개로 고정되어 있어 복잡한 fetch join을 사용해서 N+1을 해결하는 것보다 코드 가독성을 높이는 것이 더 중요하다고 생각했습니다. 추후 노출 개수가 늘어나는 경우 리팩토링 예정입니다.