### PR TITLE
[FEAT] #115: 상품 상세 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/product/code/ProductSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/code/ProductSuccessCode.java
@@ -13,6 +13,7 @@ public enum ProductSuccessCode implements SuccessCode {
     GET_PRODUCT_PEOPLE_RANGE_OK(200, "PRODUCT_200_002", "상품의 촬영 가능 인원 수 조회에 성공했습니다."),
     GET_PRODUCT_AVAILABLE_DATE_OK(200, "PRODUCT_200_003", "상품의 날짜별 예약 가능 여부 조회에 성공했습니다."),
     GET_PRODUCT_AVAILABLE_TIMES_OK(200, "PRODUCT_200_004", "상품의 시간대별 예약 가능 여부 조회에 성공했습니다."),
+    GET_PRODUCT_DETAIL_OK(200, "PRODUCT_200_005", "상품 상세 조회에 성공했습니다."),
 
     // 201 CREATED
     POST_PRODUCT_RESERVATION_OK(201, "PRODUCT_201_001", "상품 예약 생성에 성공했습니다.");

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import org.sopt.snappinserver.api.product.dto.request.ProductReservationRequest;
+import org.sopt.snappinserver.api.product.dto.response.GetProductDetailResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductAvailableTimesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductClosedDatesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductPeopleRangeResponse;
@@ -18,7 +19,6 @@ import org.sopt.snappinserver.api.product.dto.response.ProductReviewsResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -66,7 +66,7 @@ public interface ProductApi {
         @Schema(description = "상품 아이디", example = "1")
         @PathVariable @NotNull Long productId,
 
-        @Schema(description = "조회할 연/월 (yyyy-MM)", example = "2026-03", required = true)
+        @Schema(description = "조회할 연/월 (yyyy-MM)", example = "2026-03")
         @RequestParam(value = "date") @NotBlank String date
     );
 
@@ -82,7 +82,7 @@ public interface ProductApi {
         @Schema(description = "상품 아이디", example = "1")
         @PathVariable @NotNull Long productId,
 
-        @Schema(description = "조회할 날짜 (yyyy-MM-dd)", example = "2026-03-15", required = true)
+        @Schema(description = "조회할 날짜 (yyyy-MM-dd)", example = "2026-03-15")
         @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         @NotNull LocalDate date
     );
@@ -103,4 +103,16 @@ public interface ProductApi {
         @RequestBody @Valid @NotNull ProductReservationRequest request
     );
 
+    @Operation(
+        summary = "상품 상세 정보 및 상품 안내 조회 API",
+        description = "상품 상세 정보"
+    )
+    @GetMapping("/{productId}")
+    ApiResponseBody<GetProductDetailResponse, Void> getProductDetail(
+        CustomUserInfo userInfo,
+
+        @Schema(description = "상품 ID")
+        @NotNull(message = "상품은 비어있을 수 없습니다.")
+        @PathVariable Long productId
+    );
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -109,6 +109,7 @@ public interface ProductApi {
     )
     @GetMapping("/{productId}")
     ApiResponseBody<GetProductDetailResponse, Void> getProductDetail(
+        @Parameter(hidden = true)
         CustomUserInfo userInfo,
 
         @Schema(description = "상품 ID")

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -105,7 +105,7 @@ public interface ProductApi {
 
     @Operation(
         summary = "상품 상세 정보 및 상품 안내 조회 API",
-        description = "상품 상세 정보"
+        description = "상품 상세 정보, 상품 안내, 관련 작가, 관련 상품을 함께 조회합니다."
     )
     @GetMapping("/{productId}")
     ApiResponseBody<GetProductDetailResponse, Void> getProductDetail(

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -5,6 +5,7 @@ import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.product.code.ProductSuccessCode;
 import org.sopt.snappinserver.api.product.dto.request.ProductReservationRequest;
+import org.sopt.snappinserver.api.product.dto.response.GetProductDetailResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductAvailableTimesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductClosedDatesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductPeopleRangeResponse;
@@ -13,6 +14,7 @@ import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaRespons
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.product.service.dto.request.ProductReservationCommand;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetProductResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductAvailableTimesResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductClosedDatesResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductPeopleRangeResult;
@@ -20,6 +22,7 @@ import org.sopt.snappinserver.domain.product.service.dto.response.ProductReserva
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewPageResult;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductAvailableTimesUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductClosedDatesUseCase;
+import org.sopt.snappinserver.domain.product.service.usecase.GetProductDetailUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductPeopleRangeUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.PostProductReservationUseCase;
@@ -40,6 +43,7 @@ public class ProductController implements ProductApi {
     private final GetProductClosedDatesUseCase getProductClosedDatesUseCase;
     private final GetProductAvailableTimesUseCase getProductAvailableTimesUseCase;
     private final PostProductReservationUseCase postProductReservationUseCase;
+    private final GetProductDetailUseCase getProductDetailUseCase;
 
     @Override
     public ApiResponseBody<ProductReviewsResponse, ProductReviewsMetaResponse> getProductReviews(
@@ -124,5 +128,15 @@ public class ProductController implements ProductApi {
         );
     }
 
+    @Override
+    public ApiResponseBody<GetProductDetailResponse, Void> getProductDetail(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        Long productId
+    ) {
+        Long userId = (userInfo != null) ? userInfo.userId() : null;
+        GetProductResult result = getProductDetailUseCase.getProductDetail(userId, productId);
+        GetProductDetailResponse response = GetProductDetailResponse.from(result);
 
+        return ApiResponseBody.ok(ProductSuccessCode.GET_PRODUCT_DETAIL_OK, response);
+    }
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetPhotographerInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetPhotographerInfoResponse.java
@@ -1,0 +1,35 @@
+package org.sopt.snappinserver.api.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetPhotographerInfoResult;
+
+@Schema(description = "상품 조회 시 작가 응답 DTO")
+public record GetPhotographerInfoResponse(
+
+    @Schema(description = "작가 ID")
+    Long id,
+
+    @Schema(description = "작가 이름")
+    String name,
+
+    @Schema(description = "한줄 소개")
+    String bio,
+
+    @Schema(description = "촬영 상품 (전문 스냅 유형)")
+    List<String> specialties,
+
+    @Schema(description = "활동 지역")
+    List<String> locations
+) {
+
+    public static GetPhotographerInfoResponse from(GetPhotographerInfoResult result) {
+        return new GetPhotographerInfoResponse(
+            result.id(),
+            result.name(),
+            result.bio(),
+            result.specialties(),
+            result.locations()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetProductDetailResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetProductDetailResponse.java
@@ -29,10 +29,10 @@ public record GetProductDetailResponse(
     int price,
 
     @Schema(description = "스냅 작가 응답 DTO")
-    GetPhotographerInfoResponse getPhotographerInfoResponse,
+    GetPhotographerInfoResponse photographerInfo,
 
     @Schema(description = "상품 상세 조회 응답 DTO")
-    GetProductInfoResponse getProductInfoResponse
+    GetProductInfoResponse productInfo
 ) {
 
     public static GetProductDetailResponse from(

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetProductDetailResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetProductDetailResponse.java
@@ -1,0 +1,53 @@
+package org.sopt.snappinserver.api.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetProductResult;
+
+@Schema(description = "상품 상세 조회 응답 DTO")
+public record GetProductDetailResponse(
+
+    @Schema(description = "상품 ID")
+    Long id,
+
+    @Schema(description = "상품 이미지 목록")
+    List<String> images,
+
+    @Schema(description = "상품명")
+    String title,
+
+    @Schema(description = "좋아요 여부")
+    boolean isLiked,
+
+    @Schema(description = "평균 별점")
+    Double averageRate,
+
+    @Schema(description = "리뷰 개수")
+    long reviewCount,
+
+    @Schema(description = "가격")
+    int price,
+
+    @Schema(description = "스냅 작가 응답 DTO")
+    GetPhotographerInfoResponse getPhotographerInfoResponse,
+
+    @Schema(description = "상품 상세 조회 응답 DTO")
+    GetProductInfoResponse getProductInfoResponse
+) {
+
+    public static GetProductDetailResponse from(
+        GetProductResult result
+    ) {
+        return new GetProductDetailResponse(
+            result.id(),
+            result.images(),
+            result.title(),
+            result.isLiked(),
+            result.averageRate(),
+            result.reviewCount(),
+            result.price(),
+            GetPhotographerInfoResponse.from(result.photographerInfo()),
+            GetProductInfoResponse.from(result.productInfo())
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetProductInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetProductInfoResponse.java
@@ -2,6 +2,7 @@ package org.sopt.snappinserver.api.product.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import java.util.Optional;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductInfoResult;
 
 @Schema(description = "상품 안내 정보 응답 DTO")
@@ -69,9 +70,13 @@ public record GetProductInfoResponse(
             getProductInfoResult.snapCategory(),
             getProductInfoResult.regions(),
             getProductInfoResult.moods(),
-            getProductInfoResult.maxPeople().concat("명"),
+            Optional.ofNullable(getProductInfoResult.maxPeople())
+                .map(m -> m.concat("명"))
+                .orElse(null),
             getProductInfoResult.photographerCount(),
-            getProductInfoResult.durationTime().concat("시간"),
+            Optional.ofNullable(getProductInfoResult.durationTime())
+                .map(d -> d.concat("시간"))
+                .orElse(null),
             getProductInfoResult.provideRaw(),
             getProductInfoResult.provideOriginalJpg(),
             getProductInfoResult.originalJpgCount(),

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetProductInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetProductInfoResponse.java
@@ -1,0 +1,89 @@
+package org.sopt.snappinserver.api.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetProductInfoResult;
+
+@Schema(description = "상품 안내 정보 응답 DTO")
+public record GetProductInfoResponse(
+
+    @Schema(description = "촬영 종류 (유형)")
+    String snapCategory,
+
+    @Schema(description = "촬영 장소 (지역)")
+    List<String> regions,
+
+    @Schema(description = "스냅 무드")
+    List<String> moods,
+
+    @Schema(description = "최대 촬영 인원")
+    String maxPeople,
+
+    @Schema(description = "촬영 작가 인원")
+    String photographerCount,
+
+    @Schema(description = "촬영 시간 (시간단위)")
+    String durationTime,
+
+    @Schema(description = "RAW 파일 제공 여부")
+    String provideRaw,
+
+    @Schema(description = "원본 JPG 제공 여부")
+    String provideOriginalJpg,
+
+    @Schema(description = "원본 JPG 제공 장수")
+    String originalJpgCount,
+
+    @Schema(description = "원본 제공 시점")
+    String originalDeliveryTime,
+
+    @Schema(description = "동영상 제공 여부")
+    String provideVideo,
+
+    @Schema(description = "무료 수정 횟수")
+    String freeRevisionCount,
+
+    @Schema(description = "최종 결과물 제공 장수")
+    String finalCutCount,
+
+    @Schema(description = "최종 결과물 전달 소요시간")
+    String finalDeliveryTime,
+
+    @Schema(description = "상품 소개")
+    String description,
+
+    @Schema(description = "촬영 진행 순서 ")
+    String processDescription,
+
+    @Schema(description = "사용 장비")
+    String equipment,
+
+    @Schema(description = "기타 주의 사항")
+    String caution
+) {
+
+    public static GetProductInfoResponse from(
+        GetProductInfoResult getProductInfoResult
+    ) {
+        return new GetProductInfoResponse(
+            getProductInfoResult.snapCategory(),
+            getProductInfoResult.regions(),
+            getProductInfoResult.moods(),
+            getProductInfoResult.maxPeople().concat("명"),
+            getProductInfoResult.photographerCount(),
+            getProductInfoResult.durationTime().concat("시간"),
+            getProductInfoResult.provideRaw(),
+            getProductInfoResult.provideOriginalJpg(),
+            getProductInfoResult.originalJpgCount(),
+            getProductInfoResult.originalDeliveryTime(),
+            getProductInfoResult.provideVideo(),
+            getProductInfoResult.freeRevisionCount(),
+            getProductInfoResult.finalCutCount(),
+            getProductInfoResult.finalDeliveryTime(),
+            getProductInfoResult.description(),
+            getProductInfoResult.processDescription(),
+            getProductInfoResult.equipment(),
+            getProductInfoResult.caution()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductAvailableLocationRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductAvailableLocationRepository.java
@@ -1,0 +1,14 @@
+package org.sopt.snappinserver.domain.product.repository;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.domain.product.domain.entity.ProductAvailableLocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductAvailableLocationRepository
+    extends JpaRepository<ProductAvailableLocation, Long> {
+
+    List<ProductAvailableLocation> findByProduct(Product product);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductOptionRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductOptionRepository.java
@@ -18,4 +18,6 @@ public interface ProductOptionRepository extends JpaRepository<ProductOption, Lo
         Product product,
         ProductOptionCategory productOptionCategory
     );
+
+    List<ProductOption> findByProduct(Product product);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
@@ -37,4 +37,6 @@ public interface ProductPhotoRepository extends JpaRepository<ProductPhoto, Long
             ));
     }
 
+    List<ProductPhoto> findByProduct(Product product);
+
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryCustom.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.product.repository;
+
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
+
+public interface ProductRepositoryCustom {
+
+    LikeStatusProjection findLikeStatus(Long productId, Long userId);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
@@ -1,0 +1,61 @@
+package org.sopt.snappinserver.domain.product.repository;
+
+import static org.sopt.snappinserver.domain.wish.domain.entity.QWishProduct.wishProduct;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ProductRepositoryImpl implements ProductRepositoryCustom {
+
+    private JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public LikeStatusProjection findLikeStatus(Long productId, Long userId) {
+        NumberExpression<Integer> likeCount = wishProduct.count().intValue();
+
+        if (userId == null) {
+            return jpaQueryFactory
+                .select(
+                    Projections.constructor(
+                        LikeStatusProjection.class,
+                        likeCount,
+                        Expressions.FALSE
+                    )
+                )
+                .from(wishProduct)
+                .where(wishProduct.product.id.eq(productId))
+                .fetchOne();
+        }
+
+        BooleanExpression liked =
+            JPAExpressions
+                .selectOne()
+                .from(wishProduct)
+                .where(
+                    wishProduct.product.id.eq(productId),
+                    wishProduct.user.id.eq(userId)
+                )
+                .exists();
+
+        return jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    LikeStatusProjection.class,
+                    likeCount,
+                    liked
+                )
+            )
+            .from(wishProduct)
+            .where(wishProduct.product.id.eq(productId))
+            .fetchOne();
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
-    private JPAQueryFactory jpaQueryFactory;
+    private final JPAQueryFactory jpaQueryFactory;
 
     @Override
     public LikeStatusProjection findLikeStatus(Long productId, Long userId) {

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
@@ -23,7 +23,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
         NumberExpression<Integer> likeCount = wishProduct.count().intValue();
 
         if (userId == null) {
-            return jpaQueryFactory
+            LikeStatusProjection result = jpaQueryFactory
                 .select(
                     Projections.constructor(
                         LikeStatusProjection.class,
@@ -34,6 +34,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .from(wishProduct)
                 .where(wishProduct.product.id.eq(productId))
                 .fetchOne();
+            return result != null ? result : new LikeStatusProjection(0, false);
         }
 
         BooleanExpression liked =
@@ -46,7 +47,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 )
                 .exists();
 
-        return jpaQueryFactory
+        LikeStatusProjection result = jpaQueryFactory
             .select(
                 Projections.constructor(
                     LikeStatusProjection.class,
@@ -57,5 +58,6 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
             .from(wishProduct)
             .where(wishProduct.product.id.eq(productId))
             .fetchOne();
+        return result != null ? result : new LikeStatusProjection(0, false);
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductDetailService.java
@@ -11,7 +11,6 @@ import org.sopt.snappinserver.domain.photographer.domain.entity.PhotographerSpec
 import org.sopt.snappinserver.domain.photographer.repository.PhotographerAvailableLocationRepository;
 import org.sopt.snappinserver.domain.photographer.repository.PhotographerSpecialtyRepository;
 import org.sopt.snappinserver.domain.place.domain.entity.AvailableLocation;
-import org.sopt.snappinserver.domain.portfolio.repository.PortfolioRepositoryCustom;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
 import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.sopt.snappinserver.domain.product.domain.entity.ProductAvailableLocation;
@@ -26,6 +25,7 @@ import org.sopt.snappinserver.domain.product.repository.ProductMoodRepository;
 import org.sopt.snappinserver.domain.product.repository.ProductOptionRepository;
 import org.sopt.snappinserver.domain.product.repository.ProductPhotoRepository;
 import org.sopt.snappinserver.domain.product.repository.ProductRepository;
+import org.sopt.snappinserver.domain.product.repository.ProductRepositoryCustom;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetPhotographerInfoResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductInfoResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductResult;
@@ -45,7 +45,7 @@ public class GetProductDetailService implements GetProductDetailUseCase {
     private final ProductRepository productRepository;
     private final ProductPhotoRepository productPhotoRepository;
     private final ProductOptionRepository productOptionRepository;
-    private final PortfolioRepositoryCustom portfolioRepositoryCustom;
+    private final ProductRepositoryCustom productRepositoryCustom;
     private final ReviewRepository reviewRepository;
     private final S3Service s3Service;
     private final ProductMoodRepository productMoodRepository;
@@ -107,7 +107,7 @@ public class GetProductDetailService implements GetProductDetailUseCase {
     }
 
     private LikeStatusProjection getLikeStatus(Long userId, Long productId) {
-        return portfolioRepositoryCustom.findLikeStatus(productId,
+        return productRepositoryCustom.findLikeStatus(productId,
             userId);
     }
 

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductDetailService.java
@@ -1,0 +1,166 @@
+package org.sopt.snappinserver.domain.product.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.photo.domain.entity.Photo;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+import org.sopt.snappinserver.domain.photographer.domain.entity.PhotographerAvailableLocation;
+import org.sopt.snappinserver.domain.photographer.domain.entity.PhotographerSpecialty;
+import org.sopt.snappinserver.domain.photographer.repository.PhotographerAvailableLocationRepository;
+import org.sopt.snappinserver.domain.photographer.repository.PhotographerSpecialtyRepository;
+import org.sopt.snappinserver.domain.place.domain.entity.AvailableLocation;
+import org.sopt.snappinserver.domain.portfolio.repository.PortfolioRepositoryCustom;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.domain.product.domain.entity.ProductAvailableLocation;
+import org.sopt.snappinserver.domain.product.domain.entity.ProductMood;
+import org.sopt.snappinserver.domain.product.domain.entity.ProductOption;
+import org.sopt.snappinserver.domain.product.domain.entity.ProductPhoto;
+import org.sopt.snappinserver.domain.product.domain.enums.ProductOptionCategory;
+import org.sopt.snappinserver.domain.product.domain.exception.ProductErrorCode;
+import org.sopt.snappinserver.domain.product.domain.exception.ProductException;
+import org.sopt.snappinserver.domain.product.repository.ProductAvailableLocationRepository;
+import org.sopt.snappinserver.domain.product.repository.ProductMoodRepository;
+import org.sopt.snappinserver.domain.product.repository.ProductOptionRepository;
+import org.sopt.snappinserver.domain.product.repository.ProductPhotoRepository;
+import org.sopt.snappinserver.domain.product.repository.ProductRepository;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetPhotographerInfoResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetProductInfoResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetProductResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult;
+import org.sopt.snappinserver.domain.product.service.usecase.GetProductDetailUseCase;
+import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
+import org.sopt.snappinserver.global.enums.SnapCategory;
+import org.sopt.snappinserver.global.s3.S3Service;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class GetProductDetailService implements GetProductDetailUseCase {
+
+    private final ProductRepository productRepository;
+    private final ProductPhotoRepository productPhotoRepository;
+    private final ProductOptionRepository productOptionRepository;
+    private final PortfolioRepositoryCustom portfolioRepositoryCustom;
+    private final ReviewRepository reviewRepository;
+    private final S3Service s3Service;
+    private final ProductMoodRepository productMoodRepository;
+    private final ProductAvailableLocationRepository productAvailableLocationRepository;
+    private final PhotographerSpecialtyRepository photographerSpecialtyRepository;
+    private final PhotographerAvailableLocationRepository photographerAvailableLocationRepository;
+
+    public GetProductResult getProductDetail(Long userId, Long productId) {
+        Product product = getProduct(productId);
+        List<String> productPhotos = getProductPhotos(product);
+        LikeStatusProjection likeStatus = getLikeStatus(userId, productId);
+        ProductReviewStatsResult reviewStats = reviewRepository
+            .findReviewStatsByProductId(productId);
+
+        List<ProductAvailableLocation> availableLocations = productAvailableLocationRepository
+            .findByProduct(product);
+        List<ProductMood> productMoods = productMoodRepository.findAllByProduct(product);
+
+        Photographer photographer = product.getPhotographer();
+        List<String> specialties = getSpecialties(photographer);
+        List<String> locations = getLocations(photographer);
+
+        List<ProductOption> productOptions = productOptionRepository.findByProduct(product);
+        Map<ProductOptionCategory, String> optionMap = getProductOptions(productOptions);
+
+        GetPhotographerInfoResult photographerInfoResult = getPhotographerInfoResult(
+            photographer,
+            specialties,
+            locations
+        );
+        GetProductInfoResult productInfoResult = getProductInfoResult(
+            product,
+            availableLocations,
+            productMoods,
+            optionMap
+        );
+
+        return GetProductResult.of(
+            product,
+            productPhotos,
+            likeStatus,
+            reviewStats,
+            photographerInfoResult,
+            productInfoResult
+        );
+    }
+
+    private Product getProduct(Long productId) {
+        return productRepository.findById(productId)
+            .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    private List<String> getProductPhotos(Product product) {
+        return productPhotoRepository.findByProduct(product).stream()
+            .map(ProductPhoto::getPhoto)
+            .map(Photo::getImageUrl)
+            .map(s3Service::getPresignedUrl)
+            .toList();
+    }
+
+    private LikeStatusProjection getLikeStatus(Long userId, Long productId) {
+        return portfolioRepositoryCustom.findLikeStatus(productId,
+            userId);
+    }
+
+    private static Map<ProductOptionCategory, String> getProductOptions(
+        List<ProductOption> productOptions) {
+        return productOptions.stream()
+            .collect(
+                Collectors.toMap(
+                    ProductOption::getProductOptionCategory,
+                    ProductOption::getAnswer
+                )
+            );
+    }
+
+    private List<String> getSpecialties(Photographer photographer) {
+        return photographerSpecialtyRepository
+            .findAllByPhotographer(photographer)
+            .stream()
+            .map(PhotographerSpecialty::getSpecialty)
+            .map(SnapCategory::getCategory)
+            .toList();
+    }
+
+    private List<String> getLocations(Photographer photographer) {
+        return photographerAvailableLocationRepository
+            .findAllByPhotographer(photographer)
+            .stream()
+            .map(PhotographerAvailableLocation::getAvailableLocation)
+            .map(AvailableLocation::getFullLocation)
+            .toList();
+    }
+
+    private static GetPhotographerInfoResult getPhotographerInfoResult(Photographer photographer,
+        List<String> specialties, List<String> locations) {
+        return GetPhotographerInfoResult.of(
+            photographer,
+            specialties,
+            locations
+        );
+    }
+
+    private static GetProductInfoResult getProductInfoResult(
+        Product product,
+        List<ProductAvailableLocation> availableLocations,
+        List<ProductMood> productMoods,
+        Map<ProductOptionCategory, String> optionMap
+    ) {
+        return GetProductInfoResult.of(
+            product,
+            availableLocations,
+            productMoods,
+            optionMap
+        );
+    }
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductDetailService.java
@@ -117,7 +117,8 @@ public class GetProductDetailService implements GetProductDetailUseCase {
             .collect(
                 Collectors.toMap(
                     ProductOption::getProductOptionCategory,
-                    ProductOption::getAnswer
+                    ProductOption::getAnswer,
+                    (existing, replacement) -> existing
                 )
             );
     }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetPhotographerInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetPhotographerInfoResult.java
@@ -1,0 +1,27 @@
+package org.sopt.snappinserver.domain.product.service.dto.response;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+
+public record GetPhotographerInfoResult(
+    Long id,
+    String name,
+    String bio,
+    List<String> specialties,
+    List<String> locations
+) {
+
+    public static GetPhotographerInfoResult of(
+        Photographer photographer,
+        List<String> specialties,
+        List<String> locations
+    ) {
+        return new GetPhotographerInfoResult(
+            photographer.getId(),
+            photographer.getNickname(),
+            photographer.getBio(),
+            specialties,
+            locations
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetProductInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetProductInfoResult.java
@@ -1,0 +1,68 @@
+package org.sopt.snappinserver.domain.product.service.dto.response;
+
+import java.util.List;
+import java.util.Map;
+import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
+import org.sopt.snappinserver.domain.mood.domain.enums.MoodCategory;
+import org.sopt.snappinserver.domain.place.domain.entity.AvailableLocation;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.domain.product.domain.entity.ProductAvailableLocation;
+import org.sopt.snappinserver.domain.product.domain.entity.ProductMood;
+import org.sopt.snappinserver.domain.product.domain.enums.ProductOptionCategory;
+
+public record GetProductInfoResult(
+    String snapCategory,
+    List<String> regions,
+    List<String> moods,
+    String maxPeople,
+    String photographerCount,
+    String durationTime,
+    String provideRaw,
+    String provideOriginalJpg,
+    String originalJpgCount,
+    String originalDeliveryTime,
+    String provideVideo,
+    String freeRevisionCount,
+    String finalCutCount,
+    String finalDeliveryTime,
+    String description,
+    String processDescription,
+    String equipment,
+    String caution
+) {
+
+    public static GetProductInfoResult of(
+        Product product,
+        List<ProductAvailableLocation> productAvailableLocations,
+        List<ProductMood> productMoods,
+        Map<ProductOptionCategory, String> options
+    ) {
+        return new GetProductInfoResult(
+            product.getSnapCategory().getCategory(),
+            productAvailableLocations.stream()
+                .map(ProductAvailableLocation::getAvailableLocation)
+                .map(AvailableLocation::getFullLocation)
+                .toList(),
+            productMoods.stream()
+                .map(ProductMood::getMood)
+                .map(Mood::getCategory)
+                .map(MoodCategory::getCategory)
+                .toList(),
+            options.get(ProductOptionCategory.MAX_PEOPLE),
+            options.get(ProductOptionCategory.PHOTOGRAPHER_COUNT),
+            options.get(ProductOptionCategory.DURATION_TIME),
+            options.get(ProductOptionCategory.PROVIDE_RAW),
+            options.get(ProductOptionCategory.PROVIDE_ORIGINAL_JPG),
+            options.get(ProductOptionCategory.ORIGINAL_JPG_COUNT),
+            options.get(ProductOptionCategory.ORIGINAL_DELIVERY_TIME),
+            options.get(ProductOptionCategory.PROVIDE_VIDEO),
+            options.get(ProductOptionCategory.FREE_REVISION_COUNT),
+            options.get(ProductOptionCategory.FINAL_CUT_COUNT),
+            options.get(ProductOptionCategory.FINAL_DELIVERY_TIME),
+            product.getDescription(),
+            product.getProcessDescription(),
+            product.getEquipment(),
+            product.getCaution()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetProductResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetProductResult.java
@@ -1,0 +1,39 @@
+package org.sopt.snappinserver.domain.product.service.dto.response;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+
+public record GetProductResult(
+    Long id,
+    List<String> images,
+    String title,
+    Boolean isLiked,
+    Double averageRate,
+    long reviewCount,
+    int price,
+    GetPhotographerInfoResult photographerInfo,
+    GetProductInfoResult productInfo
+) {
+
+    public static GetProductResult of(
+        Product product,
+        List<String> images,
+        LikeStatusProjection likeStatus,
+        ProductReviewStatsResult reviewStats,
+        GetPhotographerInfoResult getPhotographerInfoResult,
+        GetProductInfoResult getProductInfoResult
+    ) {
+        return new GetProductResult(
+            product.getId(),
+            images,
+            product.getTitle(),
+            likeStatus.liked(),
+            reviewStats.averageRating(),
+            reviewStats.reviewCount(),
+            product.getPrice(),
+            getPhotographerInfoResult,
+            getProductInfoResult
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductDetailUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductDetailUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.product.service.usecase;
+
+import org.sopt.snappinserver.domain.product.service.dto.response.GetProductResult;
+
+public interface GetProductDetailUseCase {
+
+    GetProductResult getProductDetail(Long userId, Long productId);
+}


### PR DESCRIPTION
## 👀 Summary

- close #115


## 🖇️ Tasks

- 상품 상세 조회 API 구현

## 🔍 To Reviewer

### ❶ 상품 옵션 DTO 변환 관련 고민
상품 옵션은 (product_id, product_option_category) 조합이 유니크하여 순서/중복이 아닌 ‘카테고리 기반 값’ 모델로 판단했습니다. 이에 따라 List<ProductOption>을 그대로 DTO에서 순회하지 않고, Service 레벨에서 Map<ProductOptionCategory, String>으로 정규화한 뒤 DTO는 enum 기반 조회만 하도록 분리했습니다.