### PR TITLE
[FEAT] #117: 예약 확정 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
@@ -34,6 +34,11 @@ public enum ReservationSuccessCode implements SuccessCode {
         "RESERVATION_200_005",
         "촬영 완료 처리에 성공했습니다."
     ),
+    PATCH_RESERVATION_CONFIRM_OK(
+        200,
+        "RESERVATION_200_005",
+        "예약 확정 처리에 성공했습니다."
+    ),
 
     // 201 CREATED
     POST_RESERVATION_REVIEW_CREATED(201, "RESERVATION_201_001", "예약 리뷰 등록에 성공했습니다.");

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.Positive;
 import org.sopt.snappinserver.api.reservation.dto.request.CreateReservationReviewRequest;
 import org.sopt.snappinserver.api.reservation.dto.response.CancelReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.CompleteReservationResponse;
+import org.sopt.snappinserver.api.reservation.dto.response.ConfirmReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.CreateReservationReviewResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.PayReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationDetailResponse;
@@ -105,6 +106,20 @@ public interface ReservationApi {
     )
     @PatchMapping("/{reservationId}/complete")
     ApiResponseBody<CompleteReservationResponse, Void> updateReservationComplete(
+
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo,
+
+        @Schema(description = "예약 아이디", example = "1")
+        @PathVariable @NotNull @Positive Long reservationId
+    );
+
+    @Operation(
+        summary = "예약 확정 (작가)",
+        description = "결제 완료된 작가의 예약을 예약 확정 상태로 변경합니다."
+    )
+    @PatchMapping("/{reservationId}/confirm")
+    ApiResponseBody<ConfirmReservationResponse, Void> updateReservationConfirm(
 
         @Parameter(hidden = true)
         CustomUserInfo userInfo,

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
@@ -5,6 +5,7 @@ import org.sopt.snappinserver.api.reservation.code.ReservationSuccessCode;
 import org.sopt.snappinserver.api.reservation.dto.request.CreateReservationReviewRequest;
 import org.sopt.snappinserver.api.reservation.dto.response.CancelReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.CompleteReservationResponse;
+import org.sopt.snappinserver.api.reservation.dto.response.ConfirmReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.CreateReservationReviewResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.PayReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationDetailResponse;
@@ -17,6 +18,7 @@ import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationD
 import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationListUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationCancelUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationCompleteUseCase;
+import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationConfirmUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationPayUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.PostReservationReviewUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
@@ -35,6 +37,7 @@ public class ReservationController implements ReservationApi {
     private final PatchReservationPayUseCase patchReservationPayUseCase;
     private final PatchReservationCancelUseCase patchReservationCancelUseCase;
     private final PatchReservationCompleteUseCase patchReservationCompleteUseCase;
+    private final PatchReservationConfirmUseCase patchReservationConfirmUseCase;
 
     @Override
     public ApiResponseBody<CreateReservationReviewResponse, Void> createReview(
@@ -129,6 +132,22 @@ public class ReservationController implements ReservationApi {
             ReservationSuccessCode.PATCH_RESERVATION_COMPLETE_OK,
             CompleteReservationResponse.from(
                 patchReservationCompleteUseCase.completeReservation(
+                    userInfo.userId(),
+                    reservationId
+                )
+            )
+        );
+    }
+
+    @Override
+    public ApiResponseBody<ConfirmReservationResponse, Void> updateReservationConfirm(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        Long reservationId
+    ) {
+        return ApiResponseBody.ok(
+            ReservationSuccessCode.PATCH_RESERVATION_CONFIRM_OK,
+            ConfirmReservationResponse.from(
+                patchReservationConfirmUseCase.confirmReservation(
                     userInfo.userId(),
                     reservationId
                 )

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/CompleteReservationResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/CompleteReservationResponse.java
@@ -2,16 +2,9 @@ package org.sopt.snappinserver.api.reservation.dto.response;
 
 import org.sopt.snappinserver.domain.reservation.service.dto.response.CompleteReservationResult;
 
-public record CompleteReservationResponse(
-    Long reservationId,
-    String status
-) {
-    public static CompleteReservationResponse from(
-        CompleteReservationResult result
-    ) {
-        return new CompleteReservationResponse(
-            result.reservationId(),
-            result.status().name()
-        );
+public record CompleteReservationResponse(Long reservationId, String status) {
+
+    public static CompleteReservationResponse from(CompleteReservationResult result) {
+        return new CompleteReservationResponse(result.reservationId(), result.status().name());
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ConfirmReservationResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/ConfirmReservationResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.snappinserver.api.reservation.dto.response;
+
+import org.sopt.snappinserver.domain.reservation.service.dto.response.ConfirmReservationResult;
+
+public record ConfirmReservationResponse(Long reservationId, String status) {
+
+    public static ConfirmReservationResponse from(ConfirmReservationResult result) {
+        return new ConfirmReservationResponse(result.reservationId(), result.status().name());
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
@@ -217,6 +217,13 @@ public class Reservation extends BaseEntity {
         this.reservationStatus = ReservationStatus.RESERVATION_CANCELED;
     }
 
+    public void confirm() {
+        if (this.reservationStatus != ReservationStatus.PAYMENT_COMPLETED) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_NOT_PAYMENT_COMPLETED);
+        }
+        this.reservationStatus = ReservationStatus.RESERVATION_CONFIRMED;
+    }
+
     public void completeShooting() {
         if (this.reservationStatus != ReservationStatus.RESERVATION_CONFIRMED) {
             throw new ReservationException(ReservationErrorCode.RESERVATION_NOT_CONFIRMED);

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
@@ -36,7 +36,8 @@ public enum ReservationErrorCode implements ErrorCode {
     RESERVATION_NOT_PAYMENT_REQUESTED(409, "RESERVATION_409_003", "결제 요청 상태의 예약만 결제를 진행할 수 있습니다."),
     RESERVATION_ALREADY_COMPLETED(409, "RESERVATION_409_004", "촬영 완료된 예약은 취소할 수 없습니다."),
     RESERVATION_ALREADY_CANCELED(409, "RESERVATION_409_005", "이미 취소된 예약입니다."),
-    RESERVATION_NOT_CONFIRMED(409, "RESERVATION_409_006", "예약 확정 상태의 예약만 촬영 완료 처리할 수 있습니다.");
+    RESERVATION_NOT_CONFIRMED(409, "RESERVATION_409_006", "예약 확정 상태의 예약만 촬영 완료 처리할 수 있습니다."),
+    RESERVATION_NOT_PAYMENT_COMPLETED(409, "RESERVATION_409_007", "결제된 예약만 예약 확정 처리할 수 있습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationConfirmService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationConfirmService.java
@@ -1,0 +1,43 @@
+package org.sopt.snappinserver.domain.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
+import org.sopt.snappinserver.domain.reservation.domain.exception.ReservationErrorCode;
+import org.sopt.snappinserver.domain.reservation.domain.exception.ReservationException;
+import org.sopt.snappinserver.domain.reservation.repository.ReservationRepository;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.ConfirmReservationResult;
+import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationConfirmUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PatchReservationConfirmService implements PatchReservationConfirmUseCase {
+
+    private final ReservationRepository reservationRepository;
+
+    @Override
+    public ConfirmReservationResult confirmReservation(Long photographerId, Long reservationId) {
+        Reservation reservation = getReservation(reservationId);
+        validateReservationPhotographer(photographerId, reservation);
+
+        reservation.confirm();
+
+        return new ConfirmReservationResult(reservation.getId(),
+            reservation.getReservationStatus()
+        );
+    }
+
+    private Reservation getReservation(Long reservationId) {
+        return reservationRepository.findById(reservationId).orElseThrow(
+            () -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND)
+        );
+    }
+
+    private void validateReservationPhotographer(Long photographerId, Reservation reservation) {
+        if (!reservation.isReservationPhotographer(photographerId)) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_USER_NOT_MATCH);
+        }
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/CompleteReservationResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/CompleteReservationResult.java
@@ -2,8 +2,6 @@ package org.sopt.snappinserver.domain.reservation.service.dto.response;
 
 import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
 
-public record CompleteReservationResult(
-    Long reservationId,
-    ReservationStatus status
-) {
+public record CompleteReservationResult(Long reservationId, ReservationStatus status) {
+
 }

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/ConfirmReservationResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/ConfirmReservationResult.java
@@ -1,0 +1,7 @@
+package org.sopt.snappinserver.domain.reservation.service.dto.response;
+
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
+
+public record ConfirmReservationResult(Long reservationId, ReservationStatus status) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/PatchReservationConfirmUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/PatchReservationConfirmUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.reservation.service.usecase;
+
+import org.sopt.snappinserver.domain.reservation.service.dto.response.ConfirmReservationResult;
+
+public interface PatchReservationConfirmUseCase {
+
+    ConfirmReservationResult confirmReservation(Long photographerId, Long reservationId);
+}


### PR DESCRIPTION
## 👀 Summary

- close #117

결제 완료된 예약에 대해 작가가 예약을 확정하는 예약 확정 API를 구현했습니다.


## 🖇️ Tasks

- PATCH API 추가
- 촬영 완료 처리 usecase 정의
- 촬영 완료 결과를 전달하기 위한 도메인 결과 DTO 추가
- API 응답 DTO구현
- 작가 권한 검증 로직 추가
- 결제 완료 상태에서만 촬영 완료 가능하도록 예약 상태 검증
- 예약 상태 전이 로직을 Reservation 엔티티 메서드로 캡슐화


## 🔍 To Reviewer

### ❶ 상태 변경 로직의 위치 (Service vs Entity)
예약 확정과 같은 상태 변경은 도메인 상에서의 불변 조건이므로 Service가 아닌 Reservation 엔티티에 위치시키는 것이 적절하다고 판단했습니다. Service는 언제 어떤 상태를 변경할지에 대한 usecase 흐름만 담당하고, 상태 변경 가능 여부 확인과 실제 변경은 엔티티 계층에서 책임지도록 분리했습니다.

### ❷ 작가 권한 검증 위치
예약 확정 처리는 작가만 수행 가능하므로 Service에서 예약 소유자를 검증합니다. 이에 따라 기존의 예약 소유자 검증 메서드를 고객과 작가로 분리했습니다.

> 모든 예약 상태 변경 로직은 Patch API 전반에서 설계 패턴을 통일할 예정입니다.