### PR TITLE
[FEAT] #121: 큐레이션 기반 포폴 추천 목록 조회

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/portfolio/code/PortfolioSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/code/PortfolioSuccessCode.java
@@ -11,6 +11,7 @@ public enum PortfolioSuccessCode implements SuccessCode {
     // 200 OK
     GET_POPULAR_PORTFOLIOS_OK(200, "PORTFOLIO_200_001", "성공적으로 인기 무드 기반 포트폴리오 목록을 조회했습니다."),
     GET_PORTFOLIO_DETAIL_OK(200, "PORTFOLIO_200_002", "성공적으로 포트폴리오 상세를 조회했습니다."),
+    GET_CURATED_PORTFOLIO_OK(200, "PORTFOLIO_200_003", "성공적으로 무드 큐레이션 기반 포트폴리오 목록을 조회했습니다."),
 
     // 201 CREATED
 

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioApi.java
@@ -32,7 +32,7 @@ public interface PortfolioApi {
 
     @Operation(
         summary = "로그인 시 큐레이션 기반 포폴 추천 목록 조회",
-        description = "큐레이션 기반 포트폴리오 추천 목록을 조회했습니다."
+        description = "큐레이션 기반 포트폴리오 추천 목록을 조회합니다."
     )
     ApiResponseBody<GetCurationResponse, Void> getCuratedPortfolios(
         @Parameter(hidden = true)

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioApi.java
@@ -3,6 +3,7 @@ package org.sopt.snappinserver.api.portfolio.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.snappinserver.api.portfolio.dto.response.GetCurationResponse;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetPopularPortfolioListResponse;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetPortfolioDetailResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
@@ -27,5 +28,14 @@ public interface PortfolioApi {
         CustomUserInfo userInfo,
 
         @PathVariable Long portfolioId
+    );
+
+    @Operation(
+        summary = "로그인 시 큐레이션 기반 포폴 추천 목록 조회",
+        description = "큐레이션 기반 포트폴리오 추천 목록을 조회했습니다."
+    )
+    ApiResponseBody<GetCurationResponse, Void> getCuratedPortfolios(
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioController.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioController.java
@@ -8,10 +8,10 @@ import org.sopt.snappinserver.api.portfolio.dto.response.GetCurationResponse;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetPopularPortfolioListResponse;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetPortfolioDetailResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
-import org.sopt.snappinserver.domain.portfolio.service.GetCuratedPortfolioService;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetCuratedPortfolioResult;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPopularPortfolioListResult;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioDetailResult;
+import org.sopt.snappinserver.domain.portfolio.service.usecase.GetCuratedPortfolioUseCase;
 import org.sopt.snappinserver.domain.portfolio.service.usecase.GetPopularPortfolioListUseCase;
 import org.sopt.snappinserver.domain.portfolio.service.usecase.GetPortfolioDetailUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
@@ -28,7 +28,7 @@ public class PortfolioController implements PortfolioApi {
 
     private final GetPopularPortfolioListUseCase getPopularPortfolioListUseCase;
     private final GetPortfolioDetailUseCase getPortfolioDetailUseCase;
-    private final GetCuratedPortfolioService getCuratedPortfolioService;
+    private final GetCuratedPortfolioUseCase getCuratedPortfolioUseCase;
 
     @Override
     @GetMapping("/popular")
@@ -61,7 +61,7 @@ public class PortfolioController implements PortfolioApi {
     public ApiResponseBody<GetCurationResponse, Void> getCuratedPortfolios(
         @AuthenticationPrincipal CustomUserInfo userInfo
     ) {
-        GetCuratedPortfolioResult result = getCuratedPortfolioService.getCuratedPortfolio(
+        GetCuratedPortfolioResult result = getCuratedPortfolioUseCase.getCuratedPortfolio(
             userInfo.userId()
         );
         GetCurationResponse response = GetCurationResponse.from(result);

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioController.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioController.java
@@ -4,9 +4,12 @@ import static org.sopt.snappinserver.api.portfolio.code.PortfolioSuccessCode.GET
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.portfolio.code.PortfolioSuccessCode;
+import org.sopt.snappinserver.api.portfolio.dto.response.GetCurationResponse;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetPopularPortfolioListResponse;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetPortfolioDetailResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.domain.portfolio.service.GetCuratedPortfolioService;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetCuratedPortfolioResult;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPopularPortfolioListResult;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioDetailResult;
 import org.sopt.snappinserver.domain.portfolio.service.usecase.GetPopularPortfolioListUseCase;
@@ -25,6 +28,7 @@ public class PortfolioController implements PortfolioApi {
 
     private final GetPopularPortfolioListUseCase getPopularPortfolioListUseCase;
     private final GetPortfolioDetailUseCase getPortfolioDetailUseCase;
+    private final GetCuratedPortfolioService getCuratedPortfolioService;
 
     @Override
     @GetMapping("/popular")
@@ -50,5 +54,18 @@ public class PortfolioController implements PortfolioApi {
         GetPortfolioDetailResponse response = GetPortfolioDetailResponse.from(result);
 
         return ApiResponseBody.ok(PortfolioSuccessCode.GET_PORTFOLIO_DETAIL_OK, response);
+    }
+
+    @Override
+    @GetMapping("/recommendation")
+    public ApiResponseBody<GetCurationResponse, Void> getCuratedPortfolios(
+        @AuthenticationPrincipal CustomUserInfo userInfo
+    ) {
+        GetCuratedPortfolioResult result = getCuratedPortfolioService.getCuratedPortfolio(
+            userInfo.userId()
+        );
+        GetCurationResponse response = GetCurationResponse.from(result);
+
+        return ApiResponseBody.ok(PortfolioSuccessCode.GET_CURATED_PORTFOLIO_OK, response);
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetCurationResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetCurationResponse.java
@@ -1,0 +1,25 @@
+package org.sopt.snappinserver.api.portfolio.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetCuratedPortfolioResult;
+
+@Schema(description = "로그인 시 큐레이션 기반 포폴 추천 목록 조회")
+public record GetCurationResponse(
+
+    @Schema(description = "큐레이션된 무드 태그 목록")
+    List<String> curatedMoods,
+
+    @Schema(description = "추천 포트폴리오 목록")
+    List<GetPortfolioResponse> portfolios
+) {
+
+    public static GetCurationResponse from(GetCuratedPortfolioResult result) {
+        return new GetCurationResponse(
+            result.curatedMoods(),
+            result.portfolios().stream()
+                .map(GetPortfolioResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetPortfolioResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetPortfolioResponse.java
@@ -1,0 +1,33 @@
+package org.sopt.snappinserver.api.portfolio.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioResult;
+
+@Schema(description = "포트폴리오 응답 DTO")
+public record GetPortfolioResponse(
+
+    @Schema(description = "포트폴리오 ID")
+    Long id,
+
+    @Schema(description = "포트폴리오 이미지 목록")
+    List<GetImageResponse> images,
+
+    @Schema(description = "포트폴리오 관련 무드")
+    List<String> moods,
+
+    @Schema(description = "작가명")
+    String photographerName
+) {
+
+    public static GetPortfolioResponse from(GetPortfolioResult result) {
+        return new GetPortfolioResponse(
+            result.id(),
+            result.images().stream()
+                .map(GetImageResponse::from)
+                .toList(),
+            result.moods(),
+            result.photographerName()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/curation/repository/CurationRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/repository/CurationRepository.java
@@ -1,10 +1,13 @@
 package org.sopt.snappinserver.domain.curation.repository;
 
+import java.util.List;
 import org.sopt.snappinserver.domain.curation.domain.entity.Curation;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CurationRepository extends JpaRepository<Curation, Long> {
 
+    List<Curation> findTop3ByUserOrderByRankAscCreatedAtDesc(User user);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/domain/exception/PortfolioErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/domain/exception/PortfolioErrorCode.java
@@ -23,7 +23,8 @@ public enum PortfolioErrorCode implements ErrorCode {
     PORTFOLIO_NOT_FOUND(404, "PORTFOLIO_404_001", "해당 포트폴리오를 찾을 수 없습니다."),
     PLACE_NOT_FOUND(404, "PORTFOLIO_404_002", "해당 장소를 찾을 수 없습니다."),
     PRODUCT_PHOTO_NOT_FOUND(404, "PORTFOLIO_404_003", "해당 상품 이미지를 찾을 수 없습니다."),
-    PRODUCT_NOT_FOUND(404, "PRODUCT_404_004", "해당 상품을 찾을 수 없습니다."),
+    PRODUCT_NOT_FOUND(404, "PORTFOLIO_404_004", "해당 상품을 찾을 수 없습니다."),
+    USER_NOT_FOUND(404, "PORTFOLIO_404_005", "해당 유저를 찾을 수 없습니다."),
 
     ;
 

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryCustom.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryCustom.java
@@ -2,6 +2,8 @@ package org.sopt.snappinserver.domain.portfolio.repository;
 
 import java.util.Optional;
 import java.util.List;
+import java.util.Set;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.PortfolioDetailProjection;
 
@@ -24,4 +26,11 @@ public interface PortfolioRepositoryCustom {
     List<String> findPhotographerSpecialties(Long photographerId);
 
     List<String> findPhotographerAvailableLocations(Long photographerId);
+
+    List<Portfolio> findByMatchCountExcludeIds(
+        List<Long> curatedMoodIds,
+        Set<Long> excludedPortfolioIds,
+        int matchCount,
+        int limit
+    );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -27,8 +27,6 @@ import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
-import org.sopt.snappinserver.domain.portfolio.domain.entity.QPortfolio;
-import org.sopt.snappinserver.domain.portfolio.domain.entity.QPortfolioMood;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.PortfolioDetailProjection;
 import org.springframework.stereotype.Repository;
@@ -220,9 +218,6 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
         int matchCount,
         int limit
     ) {
-        QPortfolio portfolio = QPortfolio.portfolio;
-        QPortfolioMood portfolioMood = QPortfolioMood.portfolioMood;
-
         return jpaQueryFactory
             .select(portfolio)
             .from(portfolioMood)

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -24,7 +24,11 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.QPortfolio;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.QPortfolioMood;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.PortfolioDetailProjection;
 import org.springframework.stereotype.Repository;
@@ -206,6 +210,33 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
             .where(
                 photographerAvailableLocation.photographer.id.eq(photographerId)
             )
+            .fetch();
+    }
+
+    @Override
+    public List<Portfolio> findByMatchCountExcludeIds(
+        List<Long> curatedMoodIds,
+        Set<Long> excludedPortfolioIds,
+        int matchCount,
+        int limit
+    ) {
+        QPortfolio portfolio = QPortfolio.portfolio;
+        QPortfolioMood portfolioMood = QPortfolioMood.portfolioMood;
+
+        return jpaQueryFactory
+            .select(portfolio)
+            .from(portfolioMood)
+            .join(portfolioMood.portfolio, portfolio)
+            .where(
+                portfolioMood.mood.id.in(curatedMoodIds),
+                excludedPortfolioIds.isEmpty()
+                    ? null
+                    : portfolio.id.notIn(excludedPortfolioIds)
+            )
+            .groupBy(portfolio.id)
+            .having(portfolioMood.mood.id.countDistinct().eq((long) matchCount))
+            .orderBy(Expressions.numberTemplate(Double.class, "function('random')").asc())
+            .limit(limit)
             .fetch();
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetCuratedPortfolioService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetCuratedPortfolioService.java
@@ -26,7 +26,9 @@ import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.sopt.snappinserver.domain.user.repository.UserRepository;
 import org.sopt.snappinserver.global.s3.S3Service;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @Service
 @RequiredArgsConstructor
 public class GetCuratedPortfolioService implements GetCuratedPortfolioUseCase {
@@ -86,9 +88,7 @@ public class GetCuratedPortfolioService implements GetCuratedPortfolioUseCase {
             .toList();
 
         Map<Long, List<PortfolioPhoto>> photosByPortfolioId =
-            portfolioPhotoRepository.findByPortfolioIds(
-                    portfolios.stream().map(Portfolio::getId).toList()
-                ).stream()
+            portfolioPhotoRepository.findByPortfolioIds(portfolioIds).stream()
                 .collect(Collectors.groupingBy(pp -> pp.getPortfolio().getId()));
 
         Map<Long, List<PortfolioMood>> moodsByPortfolioId =

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetCuratedPortfolioService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetCuratedPortfolioService.java
@@ -34,6 +34,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class GetCuratedPortfolioService implements GetCuratedPortfolioUseCase {
 
     private static final int PAGE_SIZE = 3;
+    private static final int MAX_MATCH_COUNT = 3;
+    private static final int LEAST_MATCH_COUNT = 1;
 
     private final UserRepository userRepository;
     private final CurationRepository curationRepository;
@@ -64,7 +66,7 @@ public class GetCuratedPortfolioService implements GetCuratedPortfolioUseCase {
         List<Portfolio> portfolios = new ArrayList<>();
         Set<Long> excludedIds = new HashSet<>();
 
-        for (int matchCount = 3; matchCount >= 1; matchCount--) {
+        for (int matchCount = MAX_MATCH_COUNT; matchCount >= LEAST_MATCH_COUNT; matchCount--) {
             if (portfolios.size() == PAGE_SIZE) {
                 break;
             }

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetCuratedPortfolioService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetCuratedPortfolioService.java
@@ -1,0 +1,101 @@
+package org.sopt.snappinserver.domain.portfolio.service;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.curation.domain.entity.Curation;
+import org.sopt.snappinserver.domain.curation.repository.CurationRepository;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioMood;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioPhoto;
+import org.sopt.snappinserver.domain.portfolio.domain.exception.PortfolioErrorCode;
+import org.sopt.snappinserver.domain.portfolio.domain.exception.PortfolioException;
+import org.sopt.snappinserver.domain.portfolio.repository.PortfolioMoodRepository;
+import org.sopt.snappinserver.domain.portfolio.repository.PortfolioPhotoRepository;
+import org.sopt.snappinserver.domain.portfolio.repository.PortfolioRepositoryCustom;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetCuratedPortfolioResult;
+import org.sopt.snappinserver.domain.portfolio.service.usecase.GetCuratedPortfolioUseCase;
+import org.sopt.snappinserver.domain.portfolio.service.usecase.GetPopularPortfolioListUseCase;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
+import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetCuratedPortfolioService implements GetCuratedPortfolioUseCase {
+
+    private static final int PAGE_SIZE = 3;
+
+    private final UserRepository userRepository;
+    private final CurationRepository curationRepository;
+    private final PortfolioRepositoryCustom portfolioRepositoryCustom;
+    private final PortfolioPhotoRepository portfolioPhotoRepository;
+    private final PortfolioMoodRepository portfolioMoodRepository;
+    private final GetPopularPortfolioListUseCase getPopularPortfolioListUseCase;
+
+    @Override
+    public GetCuratedPortfolioResult getCuratedPortfolio(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new PortfolioException(PortfolioErrorCode.USER_NOT_FOUND));
+
+        List<Curation> curations = curationRepository
+            .findTop3ByUserOrderByRankAscCreatedAtDesc(user);
+
+        if (curations.isEmpty()) {
+            return GetCuratedPortfolioResult.from(
+                getPopularPortfolioListUseCase.getPopularPortfolioList()
+            );
+        }
+
+        List<Long> curatedMoodIds = curations.stream()
+            .map(c -> c.getMood().getId())
+            .toList();
+
+        List<Portfolio> portfolios = new ArrayList<>();
+        Set<Long> excludedIds = new HashSet<>();
+
+        for (int matchCount = 3; matchCount >= 1; matchCount--) {
+            if (portfolios.size() == PAGE_SIZE) break;
+
+            List<Portfolio> found =
+                portfolioRepositoryCustom.findByMatchCountExcludeIds(
+                    curatedMoodIds,
+                    excludedIds,
+                    matchCount,
+                    PAGE_SIZE - portfolios.size()
+                );
+
+            found.forEach(p -> {
+                portfolios.add(p);
+                excludedIds.add(p.getId());
+            });
+        }
+
+        List<Long> portfolioIds = portfolios.stream()
+            .map(Portfolio::getId)
+            .toList();
+
+        Map<Long, List<PortfolioPhoto>> photosByPortfolioId =
+            portfolioPhotoRepository.findByPortfolioIds(
+                    portfolios.stream().map(Portfolio::getId).toList()
+                ).stream()
+                .collect(Collectors.groupingBy(pp -> pp.getPortfolio().getId()));
+
+        Map<Long, List<PortfolioMood>> moodsByPortfolioId =
+            portfolioMoodRepository.findByPortfolioIds(portfolioIds).stream()
+                .collect(Collectors.groupingBy(pm -> pm.getPortfolio().getId()));
+
+        return GetCuratedPortfolioResult.of(
+            curations,
+            portfolios,
+            photosByPortfolioId,
+            moodsByPortfolioId
+        );
+    }
+}
+
+

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetCuratedPortfolioService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetCuratedPortfolioService.java
@@ -18,10 +18,13 @@ import org.sopt.snappinserver.domain.portfolio.repository.PortfolioMoodRepositor
 import org.sopt.snappinserver.domain.portfolio.repository.PortfolioPhotoRepository;
 import org.sopt.snappinserver.domain.portfolio.repository.PortfolioRepositoryCustom;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetCuratedPortfolioResult;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetImageResult;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioResult;
 import org.sopt.snappinserver.domain.portfolio.service.usecase.GetCuratedPortfolioUseCase;
 import org.sopt.snappinserver.domain.portfolio.service.usecase.GetPopularPortfolioListUseCase;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.sopt.snappinserver.global.s3.S3Service;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -36,6 +39,7 @@ public class GetCuratedPortfolioService implements GetCuratedPortfolioUseCase {
     private final PortfolioPhotoRepository portfolioPhotoRepository;
     private final PortfolioMoodRepository portfolioMoodRepository;
     private final GetPopularPortfolioListUseCase getPopularPortfolioListUseCase;
+    private final S3Service s3Service;
 
     @Override
     public GetCuratedPortfolioResult getCuratedPortfolio(Long userId) {
@@ -59,7 +63,9 @@ public class GetCuratedPortfolioService implements GetCuratedPortfolioUseCase {
         Set<Long> excludedIds = new HashSet<>();
 
         for (int matchCount = 3; matchCount >= 1; matchCount--) {
-            if (portfolios.size() == PAGE_SIZE) break;
+            if (portfolios.size() == PAGE_SIZE) {
+                break;
+            }
 
             List<Portfolio> found =
                 portfolioRepositoryCustom.findByMatchCountExcludeIds(
@@ -89,13 +95,30 @@ public class GetCuratedPortfolioService implements GetCuratedPortfolioUseCase {
             portfolioMoodRepository.findByPortfolioIds(portfolioIds).stream()
                 .collect(Collectors.groupingBy(pm -> pm.getPortfolio().getId()));
 
+        List<GetPortfolioResult> portfolioResults = portfolios.stream()
+            .map(portfolio -> {
+                List<PortfolioPhoto> photos = photosByPortfolioId.getOrDefault(
+                    portfolio.getId(),
+                    List.of()
+                );
+
+                List<GetImageResult> imageResults = photos.stream()
+                    .map(portfolioPhoto -> GetImageResult.of(
+                        s3Service.getPresignedUrl(portfolioPhoto.getPhoto().getImageUrl()),
+                        portfolioPhoto.getDisplayOrder()
+                    ))
+                    .toList();
+
+                List<PortfolioMood> moods = moodsByPortfolioId.getOrDefault(portfolio.getId(),
+                    List.of());
+
+                return GetPortfolioResult.of(portfolio, imageResults, moods);
+            })
+            .toList();
+
         return GetCuratedPortfolioResult.of(
             curations,
-            portfolios,
-            photosByPortfolioId,
-            moodsByPortfolioId
+            portfolioResults
         );
     }
 }
-
-

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetCuratedPortfolioResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetCuratedPortfolioResult.java
@@ -1,12 +1,8 @@
 package org.sopt.snappinserver.domain.portfolio.service.dto.response;
 
 import java.util.List;
-import java.util.Map;
 import org.sopt.snappinserver.domain.curation.domain.entity.Curation;
 import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
-import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
-import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioMood;
-import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioPhoto;
 
 public record GetCuratedPortfolioResult(
     List<String> curatedMoods,
@@ -24,22 +20,14 @@ public record GetCuratedPortfolioResult(
 
     public static GetCuratedPortfolioResult of(
         List<Curation> curations,
-        List<Portfolio> portfolios,
-        Map<Long, List<PortfolioPhoto>> photosByPortfolioId,
-        Map<Long, List<PortfolioMood>> moodsByPortfolioId
+        List<GetPortfolioResult> portfolioResults
     ) {
         return new GetCuratedPortfolioResult(
             curations.stream()
                 .map(Curation::getMood)
-                .map((Mood::getName))
+                .map(Mood::getName)
                 .toList(),
-            portfolios.stream()
-                .map(p -> GetPortfolioResult.of(
-                    p,
-                    photosByPortfolioId.getOrDefault(p.getId(), List.of()),
-                    moodsByPortfolioId.getOrDefault(p.getId(), List.of())
-                ))
-                .toList()
+            portfolioResults
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetCuratedPortfolioResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetCuratedPortfolioResult.java
@@ -1,0 +1,45 @@
+package org.sopt.snappinserver.domain.portfolio.service.dto.response;
+
+import java.util.List;
+import java.util.Map;
+import org.sopt.snappinserver.domain.curation.domain.entity.Curation;
+import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioMood;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioPhoto;
+
+public record GetCuratedPortfolioResult(
+    List<String> curatedMoods,
+    List<GetPortfolioResult> portfolios
+) {
+
+    public static GetCuratedPortfolioResult from(GetPopularPortfolioListResult result) {
+        return new GetCuratedPortfolioResult(
+            result.popularMoods(),
+            result.portfolios().stream()
+                .map(GetPortfolioResult::from)
+                .toList()
+        );
+    }
+
+    public static GetCuratedPortfolioResult of(
+        List<Curation> curations,
+        List<Portfolio> portfolios,
+        Map<Long, List<PortfolioPhoto>> photosByPortfolioId,
+        Map<Long, List<PortfolioMood>> moodsByPortfolioId
+    ) {
+        return new GetCuratedPortfolioResult(
+            curations.stream()
+                .map(Curation::getMood)
+                .map((Mood::getName))
+                .toList(),
+            portfolios.stream()
+                .map(p -> GetPortfolioResult.of(
+                    p,
+                    photosByPortfolioId.getOrDefault(p.getId(), List.of()),
+                    moodsByPortfolioId.getOrDefault(p.getId(), List.of())
+                ))
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetImageResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetImageResult.java
@@ -6,11 +6,16 @@ public record GetImageResult(
     String imageUrl,
     int order
 ) {
+
     public static GetImageResult from(PortfolioPhoto portfolioPhoto) {
         return new GetImageResult(
             portfolioPhoto.getPhoto().getImageUrl(),
             portfolioPhoto.getDisplayOrder()
         );
+    }
+
+    public static GetImageResult of(String presignedUrl, int order) {
+        return new GetImageResult(presignedUrl, order);
     }
 }
 

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPortfolioResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPortfolioResult.java
@@ -1,10 +1,8 @@
 package org.sopt.snappinserver.domain.portfolio.service.dto.response;
 
 import java.util.List;
-import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioMood;
-import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioPhoto;
 
 public record GetPortfolioResult(
     Long id,
@@ -24,17 +22,14 @@ public record GetPortfolioResult(
 
     public static GetPortfolioResult of(
         Portfolio portfolio,
-        List<PortfolioPhoto> portfolioPhotos,
-        List<PortfolioMood> portfolioMoods
+        List<GetImageResult> images,
+        List<PortfolioMood> moods
     ) {
         return new GetPortfolioResult(
             portfolio.getId(),
-            portfolioPhotos.stream()
-                .map(GetImageResult::from)
-                .toList(),
-            portfolioMoods.stream()
-                .map(PortfolioMood::getMood)
-                .map(Mood::getName)
+            images,
+            moods.stream()
+                .map(pm -> pm.getMood().getName())
                 .toList(),
             portfolio.getProduct().getPhotographer().getNickname()
         );

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPortfolioResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPortfolioResult.java
@@ -1,0 +1,43 @@
+package org.sopt.snappinserver.domain.portfolio.service.dto.response;
+
+import java.util.List;
+import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioMood;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioPhoto;
+
+public record GetPortfolioResult(
+    Long id,
+    List<GetImageResult> images,
+    List<String> moods,
+    String photographerName
+) {
+
+    public static GetPortfolioResult from(GetPopularPortfolioResult result) {
+        return new GetPortfolioResult(
+            result.id(),
+            result.images(),
+            result.moods(),
+            result.photographerName()
+        );
+    }
+
+    public static GetPortfolioResult of(
+        Portfolio portfolio,
+        List<PortfolioPhoto> portfolioPhotos,
+        List<PortfolioMood> portfolioMoods
+    ) {
+        return new GetPortfolioResult(
+            portfolio.getId(),
+            portfolioPhotos.stream()
+                .map(GetImageResult::from)
+                .toList(),
+            portfolioMoods.stream()
+                .map(PortfolioMood::getMood)
+                .map(Mood::getName)
+                .toList(),
+            portfolio.getProduct().getPhotographer().getNickname()
+        );
+    }
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/usecase/GetCuratedPortfolioUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/usecase/GetCuratedPortfolioUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.portfolio.service.usecase;
+
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetCuratedPortfolioResult;
+
+public interface GetCuratedPortfolioUseCase {
+
+    GetCuratedPortfolioResult getCuratedPortfolio(Long userId);
+}


### PR DESCRIPTION
## 👀 Summary

- close #121


## 🖇️ Tasks

- 무드 큐레이션 최근 결과 3개 조회
- 해당 큐레이션 결과와 일치율이 높은 포트폴리오 목록 3개 조회


## 🔍 To Reviewer

### ❶ 로그인 시 큐레이션하지 않은 유저의 포폴 추천 목록 조회
화면설계서에 따라 해당 부분은 비로그인 시와 동일하게 동작하여, 비로그인 시의 `GetPopularPortfolioListUseCase` 를 사용하여 구현했고, 무드 조회 이후의 로직은 QueryDSL 사용해서 개발했습니다.