### PR TITLE
[FEAT] #119: 예약 거절 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
@@ -39,6 +39,11 @@ public enum ReservationSuccessCode implements SuccessCode {
         "RESERVATION_200_005",
         "예약 확정 처리에 성공했습니다."
     ),
+    PATCH_RESERVATION_REFUSE_OK(
+        200,
+        "RESERVATION_200_006",
+        "예약 거절 처리에 성공했습니다."
+    ),
 
     // 201 CREATED
     POST_RESERVATION_REVIEW_CREATED(201, "RESERVATION_201_001", "예약 리뷰 등록에 성공했습니다.");

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
@@ -13,6 +13,7 @@ import org.sopt.snappinserver.api.reservation.dto.response.CompleteReservationRe
 import org.sopt.snappinserver.api.reservation.dto.response.ConfirmReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.CreateReservationReviewResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.PayReservationResponse;
+import org.sopt.snappinserver.api.reservation.dto.response.RefuseReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationDetailResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationListResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
@@ -120,6 +121,20 @@ public interface ReservationApi {
     )
     @PatchMapping("/{reservationId}/confirm")
     ApiResponseBody<ConfirmReservationResponse, Void> updateReservationConfirm(
+
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo,
+
+        @Schema(description = "예약 아이디", example = "1")
+        @PathVariable @NotNull @Positive Long reservationId
+    );
+
+    @Operation(
+        summary = "예약 거절 (작가)",
+        description = "작가에게 들어온 예약에 대해 예약 거절 상태로 변경합니다."
+    )
+    @PatchMapping("/{reservationId}/refuse")
+    ApiResponseBody<RefuseReservationResponse, Void> updateReservationRefuse(
 
         @Parameter(hidden = true)
         CustomUserInfo userInfo,

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
@@ -8,6 +8,7 @@ import org.sopt.snappinserver.api.reservation.dto.response.CompleteReservationRe
 import org.sopt.snappinserver.api.reservation.dto.response.ConfirmReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.CreateReservationReviewResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.PayReservationResponse;
+import org.sopt.snappinserver.api.reservation.dto.response.RefuseReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationDetailResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationListResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
@@ -20,6 +21,7 @@ import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservatio
 import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationCompleteUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationConfirmUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationPayUseCase;
+import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationRefuseUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.PostReservationReviewUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -38,6 +40,7 @@ public class ReservationController implements ReservationApi {
     private final PatchReservationCancelUseCase patchReservationCancelUseCase;
     private final PatchReservationCompleteUseCase patchReservationCompleteUseCase;
     private final PatchReservationConfirmUseCase patchReservationConfirmUseCase;
+    private final PatchReservationRefuseUseCase patchReservationRefuseUseCase;
 
     @Override
     public ApiResponseBody<CreateReservationReviewResponse, Void> createReview(
@@ -148,6 +151,22 @@ public class ReservationController implements ReservationApi {
             ReservationSuccessCode.PATCH_RESERVATION_CONFIRM_OK,
             ConfirmReservationResponse.from(
                 patchReservationConfirmUseCase.confirmReservation(
+                    userInfo.userId(),
+                    reservationId
+                )
+            )
+        );
+    }
+
+    @Override
+    public ApiResponseBody<RefuseReservationResponse, Void> updateReservationRefuse(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        Long reservationId
+    ) {
+        return ApiResponseBody.ok(
+            ReservationSuccessCode.PATCH_RESERVATION_REFUSE_OK,
+            RefuseReservationResponse.from(
+                patchReservationRefuseUseCase.refuseReservation(
                     userInfo.userId(),
                     reservationId
                 )

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/RefuseReservationResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/RefuseReservationResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.snappinserver.api.reservation.dto.response;
+
+import org.sopt.snappinserver.domain.reservation.service.dto.response.RefuseReservationResult;
+
+public record RefuseReservationResponse(Long reservationId, String status) {
+
+    public static RefuseReservationResponse from(RefuseReservationResult result) {
+        return new RefuseReservationResponse(result.reservationId(), result.status().name());
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
@@ -224,9 +224,6 @@ public class Reservation extends BaseEntity {
         ) {
             throw new ReservationException(ReservationErrorCode.RESERVATION_CANNOT_REFUSE);
         }
-        if (this.reservationStatus == ReservationStatus.RESERVATION_REFUSED) {
-            throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_REFUSED);
-        }
 
         this.previousCancelStatus = this.reservationStatus;
         this.reservationStatus = ReservationStatus.RESERVATION_REFUSED;

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
@@ -217,6 +217,22 @@ public class Reservation extends BaseEntity {
         this.reservationStatus = ReservationStatus.RESERVATION_CANCELED;
     }
 
+    public void refuse() {
+        if (this.reservationStatus != ReservationStatus.PHOTOGRAPHER_CHECKING
+            && this.reservationStatus != ReservationStatus.PAYMENT_REQUESTED
+            && this.reservationStatus != ReservationStatus.PAYMENT_COMPLETED
+        ) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_CANNOT_REFUSE);
+        }
+        if (this.reservationStatus == ReservationStatus.RESERVATION_REFUSED) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_REFUSED);
+        }
+
+        this.previousCancelStatus = this.reservationStatus;
+        this.reservationStatus = ReservationStatus.RESERVATION_REFUSED;
+    }
+
+
     public void confirm() {
         if (this.reservationStatus != ReservationStatus.PAYMENT_COMPLETED) {
             throw new ReservationException(ReservationErrorCode.RESERVATION_NOT_PAYMENT_COMPLETED);

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
@@ -232,7 +232,6 @@ public class Reservation extends BaseEntity {
         this.reservationStatus = ReservationStatus.RESERVATION_REFUSED;
     }
 
-
     public void confirm() {
         if (this.reservationStatus != ReservationStatus.PAYMENT_COMPLETED) {
             throw new ReservationException(ReservationErrorCode.RESERVATION_NOT_PAYMENT_COMPLETED);

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
@@ -37,7 +37,9 @@ public enum ReservationErrorCode implements ErrorCode {
     RESERVATION_ALREADY_COMPLETED(409, "RESERVATION_409_004", "촬영 완료된 예약은 취소할 수 없습니다."),
     RESERVATION_ALREADY_CANCELED(409, "RESERVATION_409_005", "이미 취소된 예약입니다."),
     RESERVATION_NOT_CONFIRMED(409, "RESERVATION_409_006", "예약 확정 상태의 예약만 촬영 완료 처리할 수 있습니다."),
-    RESERVATION_NOT_PAYMENT_COMPLETED(409, "RESERVATION_409_007", "결제된 예약만 예약 확정 처리할 수 있습니다.");
+    RESERVATION_NOT_PAYMENT_COMPLETED(409, "RESERVATION_409_007", "결제된 예약만 예약 확정 처리할 수 있습니다."),
+    RESERVATION_CANNOT_REFUSE(409, "RESERVATION_409_008", "현재 예약 상태에서는 예약 거절이 불가합니다."),
+    RESERVATION_ALREADY_REFUSED(409, "RESERVATION_409_009", "이미 거절된 예약입니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationRefuseService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationRefuseService.java
@@ -1,0 +1,45 @@
+package org.sopt.snappinserver.domain.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
+import org.sopt.snappinserver.domain.reservation.domain.exception.ReservationErrorCode;
+import org.sopt.snappinserver.domain.reservation.domain.exception.ReservationException;
+import org.sopt.snappinserver.domain.reservation.repository.ReservationRepository;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.RefuseReservationResult;
+import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationRefuseUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PatchReservationRefuseService
+    implements PatchReservationRefuseUseCase {
+
+    private final ReservationRepository reservationRepository;
+
+    @Override
+    public RefuseReservationResult refuseReservation(Long photographerId, Long reservationId) {
+        Reservation reservation = getReservation(reservationId);
+        validateReservationPhotographer(photographerId, reservation);
+
+        reservation.refuse();
+
+        return new RefuseReservationResult(reservation.getId(), reservation.getReservationStatus());
+    }
+
+    private Reservation getReservation(Long reservationId) {
+        return reservationRepository.findById(reservationId)
+            .orElseThrow(() -> new ReservationException(
+                ReservationErrorCode.RESERVATION_NOT_FOUND
+            ));
+    }
+
+    private static void validateReservationPhotographer(Long photographerId, Reservation reservation) {
+        if (!reservation.isReservationPhotographer(photographerId)) {
+            throw new ReservationException(
+                ReservationErrorCode.RESERVATION_USER_NOT_MATCH
+            );
+        }
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/RefuseReservationResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/RefuseReservationResult.java
@@ -1,0 +1,7 @@
+package org.sopt.snappinserver.domain.reservation.service.dto.response;
+
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
+
+public record RefuseReservationResult(Long reservationId, ReservationStatus status) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/PatchReservationRefuseUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/PatchReservationRefuseUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.reservation.service.usecase;
+
+import org.sopt.snappinserver.domain.reservation.service.dto.response.RefuseReservationResult;
+
+public interface PatchReservationRefuseUseCase {
+
+    RefuseReservationResult refuseReservation(Long photographerId, Long reservationId);
+}


### PR DESCRIPTION
## 👀 Summary

- close #119 

작가에게 들어온 예약 요청을 거절할 수 있는 예약 거절 Patch API를 구현했습니다.
예약 상태를 RESERVATION_REFUSED로 변경하면서, 거절이 발생한 직전 예약 상태를 함께 저장해 어느 단계에서 거절되었는지 확인할 수 있도록 했습니다. 다만, 예약 취소 로직과는 다르게 UI 상에서 이전 상태를 보여주는 뷰가 없어 응답 구조에는 포함하지 않았습니다.

## 🖇️ Tasks

- [x] PATCH API 추가
- [x] 예약 거절 처리 유스케이스 정의 및 구현
- [x] 예약 거절 결과 전달을 위한 도메인 결과 DTO 추가
- [x] API 응답 DTO 구현
- [x] 작가 권한 검증 로직 추가
- [x] 예약 거절 가능 상태 검증
- [x] 이미 거절된 예약에 대한 중복 거절 방지 처리
- [x] 예약 거절 시점의 상태를 previousCancelStatus로 저장
- [x] 예약 상태 변경 로직을 Reservation 엔티티 메서드로 분리 

## 🔍 To Reviewer

### ❶ 예약 거절 가능 상태 범위

예약 거절은 작가 확인 중, 결제 요청, 결제 완료 단계에서 가능합니다. 이에 따라 거절 가능 상태를 `PHOTOGRAPHER_CHECKING`, `PAYMENT_REQUESTED`, `PAYMENT_COMPLETED`로 제한해놓았습니다.
또, 중복 요청이 들어왔을 때를 방지할 수 있도록 이미 거절된 상태라면 예외가 발생할 수 있도록 처리했습니다.

### ❷ 상태 변경 로직의 위치 (Service vs Entity)

예약 확정 처리는 작가만 수행 가능하므로 Service에서 예약 소유자를 검증합니다. 이에 따라 기존의 예약 소유자 검증 메서드를 고객과 작가로 분리하고 예약 거절 변경에서는 작가 검증을 수행합니다.

> 모든 예약 상태 변경 로직은 Patch API 전반에서 설계 패턴을 통일할 예정입니다.
