### PR TITLE
[FEAT] #118: 결제 요청 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
@@ -36,17 +36,17 @@ public enum ReservationSuccessCode implements SuccessCode {
     ),
     PATCH_RESERVATION_CONFIRM_OK(
         200,
-        "RESERVATION_200_005",
+        "RESERVATION_200_006",
         "예약 확정 처리에 성공했습니다."
     ),
     PATCH_RESERVATION_REFUSE_OK(
         200,
-        "RESERVATION_200_006",
+        "RESERVATION_200_007",
         "예약 거절 처리에 성공했습니다."
     ),
     PATCH_RESERVATION_REQUEST_PAYMENT_OK(
         200,
-        "RESERVATION_200_006",
+        "RESERVATION_200_008",
         "결제 요청 처리에 성공했습니다."
     ),
 

--- a/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/code/ReservationSuccessCode.java
@@ -44,6 +44,11 @@ public enum ReservationSuccessCode implements SuccessCode {
         "RESERVATION_200_006",
         "예약 거절 처리에 성공했습니다."
     ),
+    PATCH_RESERVATION_REQUEST_PAYMENT_OK(
+        200,
+        "RESERVATION_200_006",
+        "결제 요청 처리에 성공했습니다."
+    ),
 
     // 201 CREATED
     POST_RESERVATION_REVIEW_CREATED(201, "RESERVATION_201_001", "예약 리뷰 등록에 성공했습니다.");

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationApi.java
@@ -8,12 +8,14 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import org.sopt.snappinserver.api.reservation.dto.request.CreateReservationReviewRequest;
+import org.sopt.snappinserver.api.reservation.dto.request.RequestPaymentReservationRequest;
 import org.sopt.snappinserver.api.reservation.dto.response.CancelReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.CompleteReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ConfirmReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.CreateReservationReviewResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.PayReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.RefuseReservationResponse;
+import org.sopt.snappinserver.api.reservation.dto.response.RequestPaymentReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationDetailResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationListResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
@@ -141,5 +143,23 @@ public interface ReservationApi {
 
         @Schema(description = "예약 아이디", example = "1")
         @PathVariable @NotNull @Positive Long reservationId
+    );
+
+    @Operation(
+        summary = "결제 요청 (작가)",
+        description = "작가에게 요청된 예약에 대해 결제 금액을 확정하고 고객에게 결제를 요청합니다."
+    )
+    @PatchMapping("/{reservationId}/request-payment")
+    ApiResponseBody<RequestPaymentReservationResponse, Void> updateReservationRequestPayment(
+
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo,
+
+        @Schema(description = "예약 아이디", example = "1")
+        @PathVariable @NotNull @Positive Long reservationId,
+
+        @Schema(description = "결제 정보")
+        @Valid @RequestBody RequestPaymentReservationRequest request
+
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/controller/ReservationController.java
@@ -3,17 +3,20 @@ package org.sopt.snappinserver.api.reservation.controller;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.reservation.code.ReservationSuccessCode;
 import org.sopt.snappinserver.api.reservation.dto.request.CreateReservationReviewRequest;
+import org.sopt.snappinserver.api.reservation.dto.request.RequestPaymentReservationRequest;
 import org.sopt.snappinserver.api.reservation.dto.response.CancelReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.CompleteReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ConfirmReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.CreateReservationReviewResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.PayReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.RefuseReservationResponse;
+import org.sopt.snappinserver.api.reservation.dto.response.RequestPaymentReservationResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationDetailResponse;
 import org.sopt.snappinserver.api.reservation.dto.response.ReservationListResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatusTab;
 import org.sopt.snappinserver.domain.reservation.service.dto.request.CreateReservationReviewCommand;
+import org.sopt.snappinserver.domain.reservation.service.dto.request.RequestPaymentReservationCommand;
 import org.sopt.snappinserver.domain.reservation.service.dto.response.CreateReservationReviewResult;
 import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationDetailUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationListUseCase;
@@ -22,6 +25,7 @@ import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservatio
 import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationConfirmUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationPayUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationRefuseUseCase;
+import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationRequestPaymentUseCase;
 import org.sopt.snappinserver.domain.reservation.service.usecase.PostReservationReviewUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -41,6 +45,7 @@ public class ReservationController implements ReservationApi {
     private final PatchReservationCompleteUseCase patchReservationCompleteUseCase;
     private final PatchReservationConfirmUseCase patchReservationConfirmUseCase;
     private final PatchReservationRefuseUseCase patchReservationRefuseUseCase;
+    private final PatchReservationRequestPaymentUseCase patchReservationRequestPaymentUseCase;
 
     @Override
     public ApiResponseBody<CreateReservationReviewResponse, Void> createReview(
@@ -173,5 +178,26 @@ public class ReservationController implements ReservationApi {
             )
         );
     }
+
+    @Override
+    public ApiResponseBody<RequestPaymentReservationResponse, Void> updateReservationRequestPayment(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        Long reservationId,
+        RequestPaymentReservationRequest request
+    ) {
+        RequestPaymentReservationCommand command = RequestPaymentReservationCommand.from(
+            userInfo.userId(),
+            reservationId,
+            request
+        );
+
+        return ApiResponseBody.ok(
+            ReservationSuccessCode.PATCH_RESERVATION_REQUEST_PAYMENT_OK,
+            RequestPaymentReservationResponse.from(
+                patchReservationRequestPaymentUseCase.requestPaymentReservation(command)
+            )
+        );
+    }
+
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/request/ExtraPriceResult.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/request/ExtraPriceResult.java
@@ -1,0 +1,11 @@
+package org.sopt.snappinserver.api.reservation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record ExtraPriceResult(
+    @NotNull String name,
+    @NotNull @Positive Integer amount
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/request/RequestPaymentReservationRequest.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/request/RequestPaymentReservationRequest.java
@@ -9,15 +9,8 @@ public record RequestPaymentReservationRequest(
 
     @NotNull @Positive Integer basePrice,
 
-    @Valid List<ExtraPrice> extraPrices,
+    @Valid List<ExtraPriceResult> extraPrices,
 
     @NotNull @Positive Integer totalPrice
 ) {
-
-    public record ExtraPrice(
-        @NotNull String name,
-        @NotNull @Positive Integer amount
-    ) {
-
-    }
 }

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/request/RequestPaymentReservationRequest.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/request/RequestPaymentReservationRequest.java
@@ -1,0 +1,23 @@
+package org.sopt.snappinserver.api.reservation.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+
+public record RequestPaymentReservationRequest(
+
+    @NotNull @Positive Integer basePrice,
+
+    @Valid List<ExtraPrice> extraPrices,
+
+    @NotNull @Positive Integer totalPrice
+) {
+
+    public record ExtraPrice(
+        @NotNull String name,
+        @NotNull @Positive Integer amount
+    ) {
+
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/RequestPaymentReservationResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/reservation/dto/response/RequestPaymentReservationResponse.java
@@ -1,0 +1,27 @@
+package org.sopt.snappinserver.api.reservation.dto.response;
+
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.RequestPaymentReservationResult;
+
+public record RequestPaymentReservationResponse(
+    Long reservationId,
+    ReservationStatus status,
+    Payment payment
+) {
+
+    public static RequestPaymentReservationResponse from(RequestPaymentReservationResult result) {
+        return new RequestPaymentReservationResponse(
+            result.reservationId(),
+            result.status(),
+            new Payment(
+                result.basePrice(),
+                result.extraPrice(),
+                result.totalPrice()
+            )
+        );
+    }
+
+    public record Payment(int basePrice, int extraPrice, int totalPrice) {
+
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
@@ -206,6 +206,13 @@ public class Reservation extends BaseEntity {
         this.reservationStatus = ReservationStatus.PAYMENT_COMPLETED;
     }
 
+    public void requestPayment() {
+        if (this.reservationStatus != ReservationStatus.PHOTOGRAPHER_CHECKING) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_CANNOT_REQUEST_PAYMENT);
+        }
+        this.reservationStatus = ReservationStatus.PAYMENT_REQUESTED;
+    }
+
     public void cancel() {
         if (this.reservationStatus == ReservationStatus.SHOOT_COMPLETED) {
             throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_COMPLETED);

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/exception/ReservationErrorCode.java
@@ -22,6 +22,9 @@ public enum ReservationErrorCode implements ErrorCode {
     ADDITIONAL_PAYMENT_NAME_TOO_LONG(400, "RESERVATION_400_011", "추가 요청 금액명 길이는 100자 이하입니다."),
     ADDITIONAL_PAYMENT_AMOUNT_REQUIRED(400, "RESERVATION_400_012", "추가 요청 금액은 필수입니다."),
     ADDITIONAL_PAYMENT_AMOUNT_TOO_SMALL(400, "RESERVATION_400_013", "추가 요청 금액은 10원 이상이어야 합니다."),
+    INVALID_BASE_PRICE(400, "RESERVATION_400_014", "기본 촬영 금액이 상품 가격과 일치하지 않습니다."),
+    INVALID_TOTAL_PRICE(400, "RESERVATION_400_015", "기본 금액과 추가 금액의 합이 최종 결제 금액과 일치하지 않습니다."),
+
     // 401 UNAUTHORIZED
 
     // 403 FORBIDDEN
@@ -39,7 +42,8 @@ public enum ReservationErrorCode implements ErrorCode {
     RESERVATION_NOT_CONFIRMED(409, "RESERVATION_409_006", "예약 확정 상태의 예약만 촬영 완료 처리할 수 있습니다."),
     RESERVATION_NOT_PAYMENT_COMPLETED(409, "RESERVATION_409_007", "결제된 예약만 예약 확정 처리할 수 있습니다."),
     RESERVATION_CANNOT_REFUSE(409, "RESERVATION_409_008", "현재 예약 상태에서는 예약 거절이 불가합니다."),
-    RESERVATION_ALREADY_REFUSED(409, "RESERVATION_409_009", "이미 거절된 예약입니다.");
+    RESERVATION_ALREADY_REFUSED(409, "RESERVATION_409_009", "이미 거절된 예약입니다."),
+    RESERVATION_CANNOT_REQUEST_PAYMENT(409, "RESERVATION_409_010", "작가 확인 중 상태의 예약에만 결제를 요청할 수 있습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationRequestPaymentService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationRequestPaymentService.java
@@ -32,8 +32,9 @@ public class PatchReservationRequestPaymentService implements
 
         validateReservationPhotographer(command, reservation);
         validateBasePrice(command, reservation);
-        int extraTotal = saveExtraPrice(command, reservation);
+        int extraTotal = calculateExtraTotal(command);
         validateTotalPrice(command, extraTotal);
+        saveExtraPrices(command, reservation);
 
         reservation.requestPayment();
 
@@ -48,7 +49,8 @@ public class PatchReservationRequestPaymentService implements
 
     private Reservation getReservation(RequestPaymentReservationCommand command) {
         return reservationRepository.findById(command.reservationId())
-            .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+            .orElseThrow(
+                () -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
     }
 
     private void validateReservationPhotographer(
@@ -70,21 +72,22 @@ public class PatchReservationRequestPaymentService implements
         }
     }
 
-    private int saveExtraPrice(RequestPaymentReservationCommand command, Reservation reservation) {
-        int extraTotal = 0;
-        for (ExtraPriceCommand extra
-            : command.extraPrices()) {
+    private int calculateExtraTotal(RequestPaymentReservationCommand command) {
+        return command.extraPrices().stream().mapToInt(ExtraPriceCommand::amount).sum();
+    }
 
+    private void saveExtraPrices(
+        RequestPaymentReservationCommand command,
+        Reservation reservation
+    ) {
+        for (ExtraPriceCommand extra : command.extraPrices()) {
             ReservationAdditionalPayment payment = ReservationAdditionalPayment.create(
                 reservation,
                 extra.name(),
                 extra.amount()
             );
-
             additionalPaymentRepository.save(payment);
-            extraTotal += extra.amount();
         }
-        return extraTotal;
     }
 
     private void validateTotalPrice(

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationRequestPaymentService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationRequestPaymentService.java
@@ -1,0 +1,98 @@
+package org.sopt.snappinserver.domain.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
+import org.sopt.snappinserver.domain.reservation.domain.entity.ReservationAdditionalPayment;
+import org.sopt.snappinserver.domain.reservation.domain.exception.ReservationErrorCode;
+import org.sopt.snappinserver.domain.reservation.domain.exception.ReservationException;
+import org.sopt.snappinserver.domain.reservation.repository.ReservationAdditionalPaymentRepository;
+import org.sopt.snappinserver.domain.reservation.repository.ReservationRepository;
+import org.sopt.snappinserver.domain.reservation.service.dto.request.ExtraPriceCommand;
+import org.sopt.snappinserver.domain.reservation.service.dto.request.RequestPaymentReservationCommand;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.RequestPaymentReservationResult;
+import org.sopt.snappinserver.domain.reservation.service.usecase.PatchReservationRequestPaymentUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PatchReservationRequestPaymentService implements
+    PatchReservationRequestPaymentUseCase {
+
+    private final ReservationRepository reservationRepository;
+    private final ReservationAdditionalPaymentRepository additionalPaymentRepository;
+
+
+    @Override
+    public RequestPaymentReservationResult requestPaymentReservation(
+        RequestPaymentReservationCommand command
+    ) {
+        Reservation reservation = getReservation(command);
+
+        validateReservationPhotographer(command, reservation);
+        validateBasePrice(command, reservation);
+        int extraTotal = saveExtraPrice(command, reservation);
+        validateTotalPrice(command, extraTotal);
+
+        reservation.requestPayment();
+
+        return new RequestPaymentReservationResult(
+            reservation.getId(),
+            reservation.getReservationStatus(),
+            command.basePrice(),
+            extraTotal,
+            command.totalPrice()
+        );
+    }
+
+    private Reservation getReservation(RequestPaymentReservationCommand command) {
+        return reservationRepository.findById(command.reservationId())
+            .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+    }
+
+    private void validateReservationPhotographer(
+        RequestPaymentReservationCommand command,
+        Reservation reservation
+    ) {
+        if (!reservation.isReservationPhotographer(command.photographerUserId())) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_USER_NOT_MATCH);
+        }
+    }
+
+    private void validateBasePrice(
+        RequestPaymentReservationCommand command,
+        Reservation reservation
+    ) {
+        int productPrice = reservation.getProduct().getPrice();
+        if (productPrice != command.basePrice()) {
+            throw new ReservationException(ReservationErrorCode.INVALID_BASE_PRICE);
+        }
+    }
+
+    private int saveExtraPrice(RequestPaymentReservationCommand command, Reservation reservation) {
+        int extraTotal = 0;
+        for (ExtraPriceCommand extra
+            : command.extraPrices()) {
+
+            ReservationAdditionalPayment payment = ReservationAdditionalPayment.create(
+                reservation,
+                extra.name(),
+                extra.amount()
+            );
+
+            additionalPaymentRepository.save(payment);
+            extraTotal += extra.amount();
+        }
+        return extraTotal;
+    }
+
+    private void validateTotalPrice(
+        RequestPaymentReservationCommand command,
+        int extraTotal
+    ) {
+        if (command.basePrice() + extraTotal != command.totalPrice()) {
+            throw new ReservationException(ReservationErrorCode.INVALID_TOTAL_PRICE);
+        }
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/request/ExtraPriceCommand.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/request/ExtraPriceCommand.java
@@ -1,0 +1,14 @@
+package org.sopt.snappinserver.domain.reservation.service.dto.request;
+
+import org.sopt.snappinserver.api.reservation.dto.request.RequestPaymentReservationRequest;
+
+public record ExtraPriceCommand(String name, int amount) {
+
+    public static ExtraPriceCommand from(RequestPaymentReservationRequest.ExtraPrice extraPrice)
+    {
+        return new ExtraPriceCommand(
+            extraPrice.name(),
+            extraPrice.amount()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/request/ExtraPriceCommand.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/request/ExtraPriceCommand.java
@@ -1,15 +1,10 @@
 package org.sopt.snappinserver.domain.reservation.service.dto.request;
 
 import org.sopt.snappinserver.api.reservation.dto.request.ExtraPriceResult;
-import org.sopt.snappinserver.api.reservation.dto.request.RequestPaymentReservationRequest;
 
 public record ExtraPriceCommand(String name, int amount) {
 
-    public static ExtraPriceCommand from(ExtraPriceResult extraPrice)
-    {
-        return new ExtraPriceCommand(
-            extraPrice.name(),
-            extraPrice.amount()
-        );
+    public static ExtraPriceCommand from(ExtraPriceResult extraPrice) {
+        return new ExtraPriceCommand(extraPrice.name(), extraPrice.amount());
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/request/ExtraPriceCommand.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/request/ExtraPriceCommand.java
@@ -1,10 +1,11 @@
 package org.sopt.snappinserver.domain.reservation.service.dto.request;
 
+import org.sopt.snappinserver.api.reservation.dto.request.ExtraPriceResult;
 import org.sopt.snappinserver.api.reservation.dto.request.RequestPaymentReservationRequest;
 
 public record ExtraPriceCommand(String name, int amount) {
 
-    public static ExtraPriceCommand from(RequestPaymentReservationRequest.ExtraPrice extraPrice)
+    public static ExtraPriceCommand from(ExtraPriceResult extraPrice)
     {
         return new ExtraPriceCommand(
             extraPrice.name(),

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/request/RequestPaymentReservationCommand.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/request/RequestPaymentReservationCommand.java
@@ -1,0 +1,29 @@
+package org.sopt.snappinserver.domain.reservation.service.dto.request;
+
+import java.util.List;
+import org.sopt.snappinserver.api.reservation.dto.request.RequestPaymentReservationRequest;
+
+public record RequestPaymentReservationCommand(
+    Long photographerUserId,
+    Long reservationId,
+    int basePrice,
+    List<ExtraPriceCommand> extraPrices,
+    int totalPrice
+) {
+
+    public static RequestPaymentReservationCommand from(
+        Long photographerUserId,
+        Long reservationId,
+        RequestPaymentReservationRequest request
+    ) {
+        return new RequestPaymentReservationCommand(
+            photographerUserId,
+            reservationId,
+            request.basePrice(),
+            request.extraPrices() == null
+                ? List.of()
+                : request.extraPrices().stream().map(ExtraPriceCommand::from).toList(),
+            request.totalPrice()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/RequestPaymentReservationResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/RequestPaymentReservationResult.java
@@ -1,0 +1,13 @@
+package org.sopt.snappinserver.domain.reservation.service.dto.response;
+
+import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
+
+public record RequestPaymentReservationResult(
+    Long reservationId,
+    ReservationStatus status,
+    int basePrice,
+    int extraPrice,
+    int totalPrice
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/PatchReservationRequestPaymentUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/PatchReservationRequestPaymentUseCase.java
@@ -1,0 +1,11 @@
+package org.sopt.snappinserver.domain.reservation.service.usecase;
+
+import org.sopt.snappinserver.domain.reservation.service.dto.request.RequestPaymentReservationCommand;
+import org.sopt.snappinserver.domain.reservation.service.dto.response.RequestPaymentReservationResult;
+
+public interface PatchReservationRequestPaymentUseCase {
+
+    RequestPaymentReservationResult requestPaymentReservation(
+        RequestPaymentReservationCommand command
+    );
+}


### PR DESCRIPTION
## 👀 Summary

- close #118 

작가가 고객의 예약에 대해 결제 금액을 확정하고 결제를 요청할 수 있도록
예약 결제 요청 API를 구현했습니다.

- 결제 요청 시 기본 금액, 추가 금액, 최종 금액 검증을 수행합니다.
- 추가 결제 항목은 ReservationAdditionalPayment 엔티티로 저장됩니다.
- 결제 요청 성공 시 예약 상태는 `PAYMENT_REQUESTED`로 변경됩니다.


## 🖇️ Tasks

- [x] PATCH API 구현
- [x] 결제 요청 시 기본 금액 / 추가 금액 / 최종 금액 검증 로직 추가
- [x] 추가 결제 항목(ReservationAdditionalPayment) 저장 로직 구현
- [x] 예약 상태를 PAYMENT_REQUESTED로 변경하는 도메인 로직 추가
- [x] Command 생성 단계에서 추가 결제 null 허용 및 입력 정규화 처리
- [x] 결제 요청 관련 예외 및 에러 코드 추가

## 🔍 To Reviewer

### ❶ 상태 변경 로직의 위치 (Service vs Entity)
예약 확정과 같은 상태 변경은 도메인 상에서의 불변 조건이므로 Service가 아닌 Reservation 엔티티에 위치시키는 것이 적절하다고 판단했습니다. Service는 언제 어떤 상태를 변경할지에 대한 usecase 흐름만 담당하고, 상태 변경 가능 여부 확인과 실제 변경은 엔티티 계층에서 책임지도록 분리했습니다.

### ❷ 작가 권한 검증 위치
결제 요청 처리는 작가만 수행 가능하므로 Service에서 예약 소유자를 검증합니다. 기존의 고객/작가로 분리되어 있던 예약 소유자 검증 메서드를 사용합니다.

### ❸ 결제 금액 검증 책임 분리
결제 금액은 예약의 상태라기보다는 요청 시점에 검증되어야 할 값이라고 판단하여,
Reservation 엔티티에는 금액 정보를 저장하지 않고 Service 계층에서 기본 금액, 추가 금액, 최종 금액을 검증하도록 구현했습니다.

> 모든 예약 상태 변경 로직은 Patch API 전반에서 설계 패턴을 통일했습니다.
