### PR TITLE
[FEAT] #128: 상품 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/product/code/ProductSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/code/ProductSuccessCode.java
@@ -14,6 +14,7 @@ public enum ProductSuccessCode implements SuccessCode {
     GET_PRODUCT_AVAILABLE_DATE_OK(200, "PRODUCT_200_003", "상품의 날짜별 예약 가능 여부 조회에 성공했습니다."),
     GET_PRODUCT_AVAILABLE_TIMES_OK(200, "PRODUCT_200_004", "상품의 시간대별 예약 가능 여부 조회에 성공했습니다."),
     GET_PRODUCT_DETAIL_OK(200, "PRODUCT_200_005", "상품 상세 조회에 성공했습니다."),
+    GET_PRODUCT_LIST_OK(200, "PRODUCT_200_006", "상품 목록 조회에 성공했습니다."),
 
     // 201 CREATED
     POST_PRODUCT_RESERVATION_OK(201, "PRODUCT_201_001", "상품 예약 생성에 성공했습니다.");

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -10,6 +10,8 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import org.sopt.snappinserver.api.product.dto.request.ProductReservationRequest;
 import org.sopt.snappinserver.api.product.dto.response.GetProductDetailResponse;
+import org.sopt.snappinserver.api.product.dto.response.GetProductListMeta;
+import org.sopt.snappinserver.api.product.dto.response.GetProductListResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductAvailableTimesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductClosedDatesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductPeopleRangeResponse;
@@ -17,9 +19,11 @@ import org.sopt.snappinserver.api.product.dto.response.ProductReservationRespons
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.domain.product.service.dto.request.GetProductListQuery;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -115,5 +119,14 @@ public interface ProductApi {
         @Schema(description = "상품 ID")
         @NotNull(message = "상품은 비어있을 수 없습니다.")
         @PathVariable Long productId
+    );
+
+    @Operation(
+        summary = "상품 목록 조회 API",
+        description = "요청받은 조건에 맞게 상품 목록을 필터링하여 반환합니다."
+    )
+    @GetMapping
+    ApiResponseBody<GetProductListResponse, GetProductListMeta> getProductList(
+        @ModelAttribute GetProductListQuery query
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.product.code.ProductSuccessCode;
 import org.sopt.snappinserver.api.product.dto.request.ProductReservationRequest;
 import org.sopt.snappinserver.api.product.dto.response.GetProductDetailResponse;
+import org.sopt.snappinserver.api.product.dto.response.GetProductListMeta;
+import org.sopt.snappinserver.api.product.dto.response.GetProductListResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductAvailableTimesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductClosedDatesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductPeopleRangeResponse;
@@ -13,7 +15,9 @@ import org.sopt.snappinserver.api.product.dto.response.ProductReservationRespons
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.domain.product.service.dto.request.GetProductListQuery;
 import org.sopt.snappinserver.domain.product.service.dto.request.ProductReservationCommand;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetProductListResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductAvailableTimesResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductClosedDatesResult;
@@ -23,12 +27,14 @@ import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewP
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductAvailableTimesUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductClosedDatesUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductDetailUseCase;
+import org.sopt.snappinserver.domain.product.service.usecase.GetProductListUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductPeopleRangeUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.PostProductReservationUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -44,6 +50,7 @@ public class ProductController implements ProductApi {
     private final GetProductAvailableTimesUseCase getProductAvailableTimesUseCase;
     private final PostProductReservationUseCase postProductReservationUseCase;
     private final GetProductDetailUseCase getProductDetailUseCase;
+    private final GetProductListUseCase getProductListUseCase;
 
     @Override
     public ApiResponseBody<ProductReviewsResponse, ProductReviewsMetaResponse> getProductReviews(
@@ -138,5 +145,16 @@ public class ProductController implements ProductApi {
         GetProductDetailResponse response = GetProductDetailResponse.from(result);
 
         return ApiResponseBody.ok(ProductSuccessCode.GET_PRODUCT_DETAIL_OK, response);
+    }
+
+    @Override
+    public ApiResponseBody<GetProductListResponse, GetProductListMeta> getProductList(
+        @ModelAttribute GetProductListQuery query
+    ) {
+        GetProductListResult result = getProductListUseCase.getProductList(query);
+        GetProductListResponse response = GetProductListResponse.from(result);
+        GetProductListMeta meta = GetProductListMeta.from(result.cursorMeta());
+
+        return ApiResponseBody.ok(ProductSuccessCode.GET_PRODUCT_LIST_OK, response, meta);
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetProductCardResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetProductCardResponse.java
@@ -1,0 +1,47 @@
+package org.sopt.snappinserver.api.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetProductCardResult;
+
+@Schema(description = "상품 목록 조회 개별 상품 응답 DTO")
+public record GetProductCardResponse(
+
+    @Schema(description = "상품 ID")
+    Long id,
+
+    @Schema(description = "상품 썸네일")
+    String imageUrl,
+
+    @Schema(description = "상품명")
+    String title,
+
+    @Schema(description = "평균 별점")
+    Double rate,
+
+    @Schema(description = "리뷰 개수")
+    long reviewCount,
+
+    @Schema(description = "상품 등록 작가")
+    String photographer,
+
+    @Schema(description = "상품 가격")
+    int price,
+
+    @Schema(description = "상품 무드 태그 목록")
+    List<String> moods
+) {
+
+    public static GetProductCardResponse from(GetProductCardResult result) {
+        return new GetProductCardResponse(
+            result.id(),
+            result.imageUrl(),
+            result.title(),
+            result.rate(),
+            result.reviewCount(),
+            result.photographer(),
+            result.price(),
+            result.moods()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetProductListMeta.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetProductListMeta.java
@@ -1,0 +1,22 @@
+package org.sopt.snappinserver.api.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.product.service.dto.response.CursorMeta;
+
+@Schema(description = "상품 목록 조회 응답 Meta DTO")
+public record GetProductListMeta(
+
+    @Schema(description = "다음 커서 값")
+    Long nextCursor,
+
+    @Schema(description = "다음 커서 존재 여부")
+    Boolean hasNext
+) {
+
+    public static GetProductListMeta from(CursorMeta meta) {
+        return new GetProductListMeta(
+            meta.nextCursor(),
+            meta.hasNext()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetProductListResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/GetProductListResponse.java
@@ -1,0 +1,21 @@
+package org.sopt.snappinserver.api.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetProductListResult;
+
+@Schema(description = "상품 목록 응답 DTO")
+public record GetProductListResponse(
+
+    @Schema(description = "상품 목록")
+    List<GetProductCardResponse> products
+) {
+
+    public static GetProductListResponse from(GetProductListResult result) {
+        return new GetProductListResponse(
+            result.products().stream()
+                .map(GetProductCardResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductBaseRow.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductBaseRow.java
@@ -1,0 +1,13 @@
+package org.sopt.snappinserver.domain.product.repository;
+
+public record ProductBaseRow(
+    Long id,
+    String imageUrl,
+    String title,
+    Double rate,
+    Long reviewCount,
+    String photographerName,
+    Integer price
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryCustom.java
@@ -1,8 +1,18 @@
 package org.sopt.snappinserver.domain.product.repository;
 
+import java.util.List;
+import java.util.Map;
+import org.sopt.snappinserver.domain.mood.domain.enums.MoodCategory;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
+import org.sopt.snappinserver.domain.product.service.dto.request.GetProductListQuery;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetProductCardResult;
 
 public interface ProductRepositoryCustom {
 
     LikeStatusProjection findLikeStatus(Long productId, Long userId);
+
+    List<GetProductCardResult> findProducts(
+        GetProductListQuery query,
+        Map<MoodCategory, List<Long>> moodGroupMap
+    );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
@@ -1,20 +1,45 @@
 package org.sopt.snappinserver.domain.product.repository;
 
+import static org.sopt.snappinserver.domain.mood.domain.entity.QMood.mood;
+import static org.sopt.snappinserver.domain.photo.domain.entity.QPhoto.photo;
+import static org.sopt.snappinserver.domain.photographer.domain.entity.QPhotographer.photographer;
+import static org.sopt.snappinserver.domain.product.domain.entity.QProduct.product;
+import static org.sopt.snappinserver.domain.product.domain.entity.QProductAvailableLocation.productAvailableLocation;
+import static org.sopt.snappinserver.domain.product.domain.entity.QProductMood.productMood;
+import static org.sopt.snappinserver.domain.product.domain.entity.QProductOption.productOption;
+import static org.sopt.snappinserver.domain.product.domain.entity.QProductPhoto.productPhoto;
+import static org.sopt.snappinserver.domain.reservation.domain.entity.QReservation.reservation;
+import static org.sopt.snappinserver.domain.review.domain.entity.QReview.review;
 import static org.sopt.snappinserver.domain.wish.domain.entity.QWishProduct.wishProduct;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.mood.domain.enums.MoodCategory;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
+import org.sopt.snappinserver.domain.product.domain.enums.ProductOptionCategory;
+import org.sopt.snappinserver.domain.product.service.dto.request.GetProductListQuery;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetProductCardResult;
+import org.sopt.snappinserver.global.enums.SnapCategory;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
 @Repository
 public class ProductRepositoryImpl implements ProductRepositoryCustom {
+
+    private static final int PRODUCT_LIST_QUERY_SIZE = 10;
 
     private final JPAQueryFactory jpaQueryFactory;
 
@@ -59,5 +84,155 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
             .where(wishProduct.product.id.eq(productId))
             .fetchOne();
         return result != null ? result : new LikeStatusProjection(0, false);
+    }
+
+    @Override
+    public List<GetProductCardResult> findProducts(
+        GetProductListQuery query,
+        Map<MoodCategory, List<Long>> moodGroupMap
+    ) {
+        List<ProductBaseRow> baseRows =
+            jpaQueryFactory
+                .select(
+                    Projections.constructor(
+                        ProductBaseRow.class,
+                        product.id,
+                        photo.imageUrl,
+                        product.title,
+                        review.rating.avg().coalesce(0.0),
+                        review.id.countDistinct(),
+                        photographer.nickname,
+                        product.price
+                    )
+                )
+                .from(product)
+                .join(productPhoto).on(
+                    productPhoto.product.id.eq(product.id).and(productPhoto.displayOrder.eq(1))
+                )
+                .join(photo).on(photo.id.eq(productPhoto.photo.id))
+                .leftJoin(reservation).on(reservation.product.id.eq(product.id))
+                .leftJoin(review).on(review.reservation.id.eq(reservation.id))
+                .where(
+                    cursorLt(query.cursor()),
+                    photographerEq(query.photographerId()),
+                    snapCategoryEq(query.snapCategory()),
+                    placeCondition(query.placeId()),
+                    peopleCountCondition(query.peopleCount()),
+                    moodCategoryGroupedCondition(moodGroupMap)
+                )
+                .groupBy(
+                    product.id,
+                    photo.imageUrl,
+                    product.title,
+                    photographer.nickname,
+                    product.price
+                )
+                .orderBy(product.id.desc())
+                .limit(PRODUCT_LIST_QUERY_SIZE + 1)
+                .fetch();
+
+        if (baseRows.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> productIds = baseRows.stream()
+            .map(ProductBaseRow::id)
+            .toList();
+
+        Map<Long, List<String>> moodNamesMap = fetchMoodNames(productIds);
+
+        return baseRows.stream()
+            .map(row -> new GetProductCardResult(
+                row.id(),
+                row.imageUrl(),
+                row.title(),
+                row.rate(),
+                row.reviewCount(),
+                row.photographerName(),
+                row.price(),
+                moodNamesMap.getOrDefault(row.id(), List.of())
+            ))
+            .toList();
+    }
+
+    private BooleanExpression cursorLt(Long cursor) {
+        return cursor == null ? null : product.id.lt(cursor);
+    }
+
+    private BooleanExpression photographerEq(Long photographerId) {
+        return photographerId == null ? null : photographer.id.eq(photographerId);
+    }
+
+    private BooleanExpression snapCategoryEq(SnapCategory snapCategory) {
+        return snapCategory == null ? null : product.snapCategory.eq(snapCategory);
+    }
+
+    private BooleanExpression placeCondition(Long placeId) {
+        if (placeId == null) {
+            return null;
+        }
+
+        return product.id.in(
+            JPAExpressions
+                .select(productAvailableLocation.product.id)
+                .from(productAvailableLocation)
+                .where(productAvailableLocation.availableLocation.id.eq(placeId))
+        );
+    }
+
+    private BooleanExpression peopleCountCondition(Integer peopleCount) {
+        if (peopleCount == null) {
+            return null;
+        }
+        return product.id.in(
+            JPAExpressions
+                .select(productOption.product.id)
+                .from(productOption)
+                .where(
+                    productOption.productOptionCategory.in(ProductOptionCategory.MIN_PEOPLE,
+                        ProductOptionCategory.MAX_PEOPLE)
+                )
+        );
+    }
+
+    private Predicate moodCategoryGroupedCondition(
+        Map<MoodCategory, List<Long>> moodGroupMap
+    ) {
+        if (moodGroupMap == null || moodGroupMap.isEmpty()) {
+            return null;
+        }
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        for (Entry<MoodCategory, List<Long>> entry : moodGroupMap.entrySet()) {
+            builder.and(
+                product.id.in(
+                    JPAExpressions
+                        .select(productMood.product.id)
+                        .from(productMood)
+                        .join(productMood.mood, mood)
+                        .where(
+                            mood.category.eq(entry.getKey()),
+                            mood.id.in(entry.getValue())
+                        )
+                )
+            );
+        }
+
+        return builder;
+    }
+
+    private Map<Long, List<String>> fetchMoodNames(List<Long> productIds) {
+        Map<Long, List<String>> map = new HashMap<>();
+        for (Tuple tuple : jpaQueryFactory
+            .select(productMood.product.id, mood.name)
+            .from(productMood)
+            .join(mood).on(productMood.mood.id.eq(mood.id))
+            .where(productMood.product.id.in(productIds))
+            .fetch()) {
+            String s = tuple.get(mood.name);
+            map.computeIfAbsent(tuple.get(productMood.product.id), k -> new ArrayList<>()).add(s);
+        }
+        return map;
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
@@ -184,15 +184,43 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
         if (peopleCount == null) {
             return null;
         }
-        return product.id.in(
+
+        BooleanExpression minOk =
             JPAExpressions
-                .select(productOption.product.id)
+                .selectOne()
                 .from(productOption)
                 .where(
-                    productOption.productOptionCategory.in(ProductOptionCategory.MIN_PEOPLE,
-                        ProductOptionCategory.MAX_PEOPLE)
+                    productOption.product.id.eq(product.id),
+                    productOption.productOptionCategory.eq(ProductOptionCategory.MIN_PEOPLE),
+                    productOption.answer.castToNum(Integer.class).loe(peopleCount)
                 )
-        );
+                .exists();
+
+        BooleanExpression maxOk =
+            JPAExpressions
+                .selectOne()
+                .from(productOption)
+                .where(
+                    productOption.product.id.eq(product.id),
+                    productOption.productOptionCategory.eq(ProductOptionCategory.MAX_PEOPLE),
+                    productOption.answer.castToNum(Integer.class).goe(peopleCount)
+                )
+                .exists();
+
+        BooleanExpression noLimit =
+            JPAExpressions
+                .selectOne()
+                .from(productOption)
+                .where(
+                    productOption.product.id.eq(product.id),
+                    productOption.productOptionCategory.in(
+                        ProductOptionCategory.MIN_PEOPLE,
+                        ProductOptionCategory.MAX_PEOPLE
+                    )
+                )
+                .notExists();
+
+        return minOk.or(maxOk).or(noLimit);
     }
 
     private Predicate moodCategoryGroupedCondition(

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductListService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductListService.java
@@ -1,0 +1,88 @@
+package org.sopt.snappinserver.domain.product.service;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
+import org.sopt.snappinserver.domain.mood.domain.enums.MoodCategory;
+import org.sopt.snappinserver.domain.mood.repository.MoodRepository;
+import org.sopt.snappinserver.domain.product.repository.ProductRepositoryCustom;
+import org.sopt.snappinserver.domain.product.service.dto.request.GetProductListQuery;
+import org.sopt.snappinserver.domain.product.service.dto.response.CursorMeta;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetProductCardResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetProductListResult;
+import org.sopt.snappinserver.domain.product.service.usecase.GetProductListUseCase;
+import org.sopt.snappinserver.global.s3.S3Service;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class GetProductListService implements GetProductListUseCase {
+
+    private static final int PAGE_SIZE = 10;
+
+    private final ProductRepositoryCustom productRepository;
+    private final MoodRepository moodRepository;
+    private final S3Service s3Service;
+
+    public GetProductListResult getProductList(GetProductListQuery query) {
+        Map<MoodCategory, List<Long>> moodGroupMap = groupByCategory(query.moodIds());
+        List<GetProductCardResult> results = productRepository.findProducts(query, moodGroupMap);
+
+        List<GetProductCardResult> resultsWithPresignedUrl =
+            results.stream()
+                .map(result -> {
+                    String presignedUrl = (result.imageUrl() != null && !result.imageUrl().isBlank())
+                        ? s3Service.getPresignedUrl(result.imageUrl())
+                        : null;
+
+                    return new GetProductCardResult(
+                        result.id(),
+                        presignedUrl,
+                        result.title(),
+                        result.rate(),
+                        result.reviewCount(),
+                        result.photographer(),
+                        result.price(),
+                        result.moods()
+                    );
+                })
+                .toList();
+
+        boolean hasNext = resultsWithPresignedUrl.size() > PAGE_SIZE;
+        if (hasNext) {
+            resultsWithPresignedUrl = resultsWithPresignedUrl.subList(0, PAGE_SIZE);
+        }
+
+        Long nextCursor = resultsWithPresignedUrl.isEmpty()
+            ? null
+            : resultsWithPresignedUrl.get(resultsWithPresignedUrl.size() - 1).id();
+
+        return new GetProductListResult(
+            resultsWithPresignedUrl,
+            new CursorMeta(nextCursor, hasNext)
+        );
+    }
+
+    private Map<MoodCategory, List<Long>> groupByCategory(List<Long> moodIds) {
+        if (moodIds == null || moodIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return moodRepository.findAllById(moodIds).stream()
+            .collect(Collectors.groupingBy(
+                    Mood::getCategory,
+                    Collectors.mapping(
+                        Mood::getId,
+                        toList()
+                    )
+                )
+            );
+    }
+}
+

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/request/GetProductListQuery.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/request/GetProductListQuery.java
@@ -1,0 +1,17 @@
+package org.sopt.snappinserver.domain.product.service.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.sopt.snappinserver.global.enums.SnapCategory;
+
+public record GetProductListQuery(
+    List<Long> moodIds,
+    Long photographerId,
+    SnapCategory snapCategory,
+    Long placeId,
+    LocalDate date,
+    Integer peopleCount,
+    Long cursor
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/CursorMeta.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/CursorMeta.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.product.service.dto.response;
+
+public record CursorMeta(
+    Long nextCursor,
+    boolean hasNext
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetProductCardResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetProductCardResult.java
@@ -1,0 +1,16 @@
+package org.sopt.snappinserver.domain.product.service.dto.response;
+
+import java.util.List;
+
+public record GetProductCardResult(
+    Long id,
+    String imageUrl,
+    String title,
+    Double rate,
+    long reviewCount,
+    String photographer,
+    int price,
+    List<String> moods
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetProductListResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetProductListResult.java
@@ -1,0 +1,10 @@
+package org.sopt.snappinserver.domain.product.service.dto.response;
+
+import java.util.List;
+
+public record GetProductListResult(
+    List<GetProductCardResult> products,
+    CursorMeta cursorMeta
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductListUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductListUseCase.java
@@ -1,0 +1,9 @@
+package org.sopt.snappinserver.domain.product.service.usecase;
+
+import org.sopt.snappinserver.domain.product.service.dto.request.GetProductListQuery;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetProductListResult;
+
+public interface GetProductListUseCase {
+
+    GetProductListResult getProductList(GetProductListQuery listQuery);
+}


### PR DESCRIPTION
## 👀 Summary

- close #128


## 🖇️ Tasks

- 탐색 / 작가 상세의 상품 목록에 사용되는 상품 목록 조회 API 구현


## 🔍 To Reviewer

### ❶ QueryDSL 이용하여 동적 필터링 구현

모든 조회 조건은 optional이며, 존재하는 조건만 where 절에 반영하도록 구현했습니다. 무드 필터의 경우, Mood.category를 기준으로 카테고리 내부는 OR, 카테고리 간은 AND 조건이 되도록 그룹화하여 처리했습니다. 또한, QueryDSL의 Predicate / BooleanBuilder를 활용해 조건 조합 로직을 명확히 분리했습니다.

### ❷ 커서 기반 페이지네이션 설계

offset 방식 대신 커서 기반 페이지네이션을 사용해 성능 저하를 방지했고, 이때 최신순 정렬 기준으로 product.id를 커서로 사용합니다. size + 1개를 조회하여 hasNext 여부를 판단하고, 마지막 요소의 id를 nextCursor로 반환합니다. 추후 기획에서 요구한 대로 리소스가 된다면 랜덤  + 커서 기반 페이지네이션으로 구현해 볼 생각입니다!
