### PR TITLE
[FEAT] #132: 기본 촬영 비용 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/product/code/ProductSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/code/ProductSuccessCode.java
@@ -14,6 +14,7 @@ public enum ProductSuccessCode implements SuccessCode {
     GET_PRODUCT_AVAILABLE_DATE_OK(200, "PRODUCT_200_003", "상품의 날짜별 예약 가능 여부 조회에 성공했습니다."),
     GET_PRODUCT_AVAILABLE_TIMES_OK(200, "PRODUCT_200_004", "상품의 시간대별 예약 가능 여부 조회에 성공했습니다."),
     GET_PRODUCT_DETAIL_OK(200, "PRODUCT_200_005", "상품 상세 조회에 성공했습니다."),
+    GET_PRODUCT_PRICE_OK(200, "PRODUCT_200_006", "상품 기본 촬영 비용 조회에 성공했습니다."),
 
     // 201 CREATED
     POST_PRODUCT_RESERVATION_OK(201, "PRODUCT_201_001", "상품 예약 생성에 성공했습니다.");

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -92,7 +92,6 @@ public interface ProductApi {
         @NotNull LocalDate date
     );
 
-
     @Operation(
         summary = "예약하기",
         description = "고객이 선택한 정보를 바탕으로 예약을 요청합니다."
@@ -141,6 +140,6 @@ public interface ProductApi {
         CustomUserInfo userInfo,
 
         @Schema(description = "상품 ID")
-        @PathVariable Long productId
+        @PathVariable @NotNull Long productId
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductApi.java
@@ -13,6 +13,7 @@ import org.sopt.snappinserver.api.product.dto.response.GetProductDetailResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductAvailableTimesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductClosedDatesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductPeopleRangeResponse;
+import org.sopt.snappinserver.api.product.dto.response.ProductPriceResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReservationResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsResponse;
@@ -114,6 +115,19 @@ public interface ProductApi {
 
         @Schema(description = "상품 ID")
         @NotNull(message = "상품은 비어있을 수 없습니다.")
+        @PathVariable Long productId
+    );
+
+    @Operation(
+        summary = "기본 촬영 비용 조회 API",
+        description = "작가의 결제 요청 과정에서 상품의 기본 촬영 비용을 조회합니다."
+    )
+    @GetMapping("/{productId}/price")
+    ApiResponseBody<ProductPriceResponse, Void> getProductPrice(
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo,
+
+        @Schema(description = "상품 ID")
         @PathVariable Long productId
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/controller/ProductController.java
@@ -9,6 +9,7 @@ import org.sopt.snappinserver.api.product.dto.response.GetProductDetailResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductAvailableTimesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductClosedDatesResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductPeopleRangeResponse;
+import org.sopt.snappinserver.api.product.dto.response.ProductPriceResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReservationResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsMetaResponse;
 import org.sopt.snappinserver.api.product.dto.response.ProductReviewsResponse;
@@ -18,12 +19,14 @@ import org.sopt.snappinserver.domain.product.service.dto.response.GetProductResu
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductAvailableTimesResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductClosedDatesResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductPeopleRangeResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductPriceResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductReservationResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewPageResult;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductAvailableTimesUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductClosedDatesUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductDetailUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductPeopleRangeUseCase;
+import org.sopt.snappinserver.domain.product.service.usecase.GetProductPriceUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.PostProductReservationUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
@@ -44,6 +47,7 @@ public class ProductController implements ProductApi {
     private final GetProductAvailableTimesUseCase getProductAvailableTimesUseCase;
     private final PostProductReservationUseCase postProductReservationUseCase;
     private final GetProductDetailUseCase getProductDetailUseCase;
+    private final GetProductPriceUseCase getProductPriceUseCase;
 
     @Override
     public ApiResponseBody<ProductReviewsResponse, ProductReviewsMetaResponse> getProductReviews(
@@ -138,5 +142,18 @@ public class ProductController implements ProductApi {
         GetProductDetailResponse response = GetProductDetailResponse.from(result);
 
         return ApiResponseBody.ok(ProductSuccessCode.GET_PRODUCT_DETAIL_OK, response);
+    }
+
+    @Override
+    public ApiResponseBody<ProductPriceResponse, Void> getProductPrice(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        Long productId
+    ) {
+        ProductPriceResult result = getProductPriceUseCase.getProductPrice(productId);
+
+        return ApiResponseBody.ok(
+            ProductSuccessCode.GET_PRODUCT_PRICE_OK,
+            ProductPriceResponse.from(result)
+        );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductPriceResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/product/dto/response/ProductPriceResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.snappinserver.api.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductPriceResult;
+
+@Schema(description = "상품 기본 촬영 비용 응답 DTO")
+public record ProductPriceResponse(
+
+    @Schema(description = "상품 가격", example = "80000")
+    int price
+) {
+
+    public static ProductPriceResponse from(ProductPriceResult result) {
+        return new ProductPriceResponse(result.price());
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepository.java
@@ -1,8 +1,13 @@
 package org.sopt.snappinserver.domain.product.repository;
 
+import java.util.Optional;
 import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
+    @Query("select p.price from Product p where p.id = :productId")
+    Optional<Integer> findProductPriceById(@Param("productId") Long productId);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductPriceService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductPriceService.java
@@ -1,0 +1,30 @@
+package org.sopt.snappinserver.domain.product.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.product.domain.exception.ProductErrorCode;
+import org.sopt.snappinserver.domain.product.domain.exception.ProductException;
+import org.sopt.snappinserver.domain.product.repository.ProductRepository;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductPriceResult;
+import org.sopt.snappinserver.domain.product.service.usecase.GetProductPriceUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetProductPriceService implements GetProductPriceUseCase {
+
+    private final ProductRepository productRepository;
+
+    @Override
+    public ProductPriceResult getProductPrice(Long productId) {
+        int price = getPrice(productId);
+
+        return new ProductPriceResult(price);
+    }
+
+    private int getPrice(Long productId) {
+        return productRepository.findProductPriceById(productId)
+            .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductPriceResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductPriceResult.java
@@ -1,0 +1,5 @@
+package org.sopt.snappinserver.domain.product.service.dto.response;
+
+public record ProductPriceResult(int price) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductPriceUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductPriceUseCase.java
@@ -1,0 +1,7 @@
+package org.sopt.snappinserver.domain.product.service.usecase;
+
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductPriceResult;
+
+public interface GetProductPriceUseCase {
+    ProductPriceResult getProductPrice(Long productId);
+}


### PR DESCRIPTION
## 👀 Summary

- close #132 

상품 결제 요청 과정에서 필요한 기본 촬영 비용 조회 API를 추가했습니다.


## 🖇️ Tasks

- [x] GET API 추가
- [x] 상품 가격 조회 전용 UseCase / Service 구현
- [x] ProductRepository에 price 컬럼 단독 조회 쿼리 추가
- [x] 엔티티 로딩 없이 price만 반환하도록 구조 정리
- [x] 상품 미존재 시 예외 처리 추가

## 🔍 To Reviewer

결제 요청 과정에서 가격 값 하나만 필요한 상황이라, 엔티티 전체를 조회하거나 QueryDSL Custom Repository를 사용하는 대신 JpaRepository에서 price 컬럼만 직접 조회하는 방식을 선택했습니다.

Projection 또는 Custom Repository를 사용할지 고민했지만, 단일 컬럼 조회이기도 하고 단순 `read-only` UseCase 라는 점을 고려해 `@Query` 기반 단일 컬럼 조회가 가장 단순하고 명확하다고 판단했습니다!
