### PR TITLE
[FEAT] #134: 리뷰 상세 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/review/code/ReviewSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/review/code/ReviewSuccessCode.java
@@ -10,6 +10,7 @@ public enum ReviewSuccessCode implements SuccessCode {
 
     // 200 OK
     POST_PRESIGNED_URL_OK(200, "REVIEW_200_001", "성공적으로 리뷰 이미지 Presigned URL을 발급했습니다."),
+    GET_REVIEW_DETAIL_OK(200, "REVIEW_200_002", "리뷰 상세 조회에 성공했습니다." )
 
     // 201 CREATED
 

--- a/src/main/java/org/sopt/snappinserver/api/review/code/ReviewSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/review/code/ReviewSuccessCode.java
@@ -10,7 +10,7 @@ public enum ReviewSuccessCode implements SuccessCode {
 
     // 200 OK
     POST_PRESIGNED_URL_OK(200, "REVIEW_200_001", "성공적으로 리뷰 이미지 Presigned URL을 발급했습니다."),
-    GET_REVIEW_DETAIL_OK(200, "REVIEW_200_002", "리뷰 상세 조회에 성공했습니다." )
+    GET_REVIEW_DETAIL_OK(200, "REVIEW_200_002", "리뷰 상세 조회에 성공했습니다.")
 
     // 201 CREATED
 

--- a/src/main/java/org/sopt/snappinserver/api/review/controller/ReviewApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/review/controller/ReviewApi.java
@@ -2,12 +2,18 @@ package org.sopt.snappinserver.api.review.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import org.sopt.snappinserver.api.product.dto.response.GetProductDetailResponse;
 import org.sopt.snappinserver.api.review.dto.request.PostPresignedUrlRequest;
+import org.sopt.snappinserver.api.review.dto.response.GetReviewDetailResponse;
 import org.sopt.snappinserver.api.review.dto.response.PostPresignedUrlResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "011 - Review", description = "리뷰 관련 API")
@@ -22,5 +28,18 @@ public interface ReviewApi {
         CustomUserInfo userInfo,
 
         @Valid @RequestBody PostPresignedUrlRequest request
+    );
+
+    @Operation(
+        summary = "리뷰 상세 조회",
+        description = "상품 상세 조회와 고객/작가 예약에서 리뷰 상세 정보를 조회합니다."
+    )
+    @GetMapping("/{reviewId}")
+    ApiResponseBody<GetReviewDetailResponse, Void> getReviewDetail(
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo,
+
+        @Schema(description = "리뷰 ID")
+        @PathVariable @NotNull Long reviewId
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/review/controller/ReviewApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/review/controller/ReviewApi.java
@@ -35,9 +35,6 @@ public interface ReviewApi {
     )
     @GetMapping("/{reviewId}")
     ApiResponseBody<GetReviewDetailResponse, Void> getReviewDetail(
-        @Parameter(hidden = true)
-        CustomUserInfo userInfo,
-
         @Schema(description = "리뷰 ID")
         @PathVariable @NotNull Long reviewId
     );

--- a/src/main/java/org/sopt/snappinserver/api/review/controller/ReviewApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/review/controller/ReviewApi.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import org.sopt.snappinserver.api.product.dto.response.GetProductDetailResponse;
 import org.sopt.snappinserver.api.review.dto.request.PostPresignedUrlRequest;
 import org.sopt.snappinserver.api.review.dto.response.GetReviewDetailResponse;
 import org.sopt.snappinserver.api.review.dto.response.PostPresignedUrlResponse;

--- a/src/main/java/org/sopt/snappinserver/api/review/controller/ReviewController.java
+++ b/src/main/java/org/sopt/snappinserver/api/review/controller/ReviewController.java
@@ -44,11 +44,10 @@ public class ReviewController implements ReviewApi {
 
     @Override
     public ApiResponseBody<GetReviewDetailResponse, Void> getReviewDetail(
-        @AuthenticationPrincipal CustomUserInfo userInfo,
         Long reviewId
     ) {
         GetReviewDetailResult result =
-            getReviewDetailUseCase.getReviewDetail(userInfo.userId(), reviewId);
+            getReviewDetailUseCase.getReviewDetail(reviewId);
         GetReviewDetailResponse response = GetReviewDetailResponse.from(result);
 
         return ApiResponseBody.ok(ReviewSuccessCode.GET_REVIEW_DETAIL_OK, response);

--- a/src/main/java/org/sopt/snappinserver/api/review/controller/ReviewController.java
+++ b/src/main/java/org/sopt/snappinserver/api/review/controller/ReviewController.java
@@ -4,11 +4,15 @@ import static org.sopt.snappinserver.api.review.code.ReviewSuccessCode.POST_PRES
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.review.code.ReviewSuccessCode;
 import org.sopt.snappinserver.api.review.dto.request.PostPresignedUrlRequest;
+import org.sopt.snappinserver.api.review.dto.response.GetReviewDetailResponse;
 import org.sopt.snappinserver.api.review.dto.response.PostPresignedUrlResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.review.service.dto.request.PostPresignedUrlCommand;
+import org.sopt.snappinserver.domain.review.service.dto.response.GetReviewDetailResult;
 import org.sopt.snappinserver.domain.review.service.dto.response.PostPresignedUrlResult;
+import org.sopt.snappinserver.domain.review.service.usecase.GetReviewDetailUseCase;
 import org.sopt.snappinserver.domain.review.service.usecase.PostPresignedUrlUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReviewController implements ReviewApi {
 
     private final PostPresignedUrlUseCase postPresignedUrlUseCase;
+    private final GetReviewDetailUseCase getReviewDetailUseCase;
 
     @Override
     @PostMapping("/image")
@@ -36,6 +41,19 @@ public class ReviewController implements ReviewApi {
 
         return ApiResponseBody.ok(POST_PRESIGNED_URL_OK, response);
     }
+
+    @Override
+    public ApiResponseBody<GetReviewDetailResponse, Void> getReviewDetail(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        Long reviewId
+    ) {
+        GetReviewDetailResult result =
+            getReviewDetailUseCase.getReviewDetail(userInfo.userId(), reviewId);
+        GetReviewDetailResponse response = GetReviewDetailResponse.from(result);
+
+        return ApiResponseBody.ok(ReviewSuccessCode.GET_REVIEW_DETAIL_OK, response);
+    }
+
 
     private PostPresignedUrlCommand getPostPresignedUrlCommand(
         CustomUserInfo userInfo,

--- a/src/main/java/org/sopt/snappinserver/api/review/dto/response/GetReviewDetailResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/review/dto/response/GetReviewDetailResponse.java
@@ -1,0 +1,26 @@
+package org.sopt.snappinserver.api.review.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.sopt.snappinserver.domain.review.service.dto.response.GetReviewDetailResult;
+
+public record GetReviewDetailResponse(
+    Long id,
+    String reviewer,
+    Integer rating,
+    LocalDate createdAt,
+    List<String> images,
+    String content
+) {
+
+    public static GetReviewDetailResponse from(GetReviewDetailResult result) {
+        return new GetReviewDetailResponse(
+            result.id(),
+            result.reviewer(),
+            result.rating(),
+            result.createdAt(),
+            result.images(),
+            result.content()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/review/domain/exception/ReviewErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/domain/exception/ReviewErrorCode.java
@@ -26,6 +26,7 @@ public enum ReviewErrorCode implements ErrorCode {
 
     // 404 NOT FOUND
     USER_NOT_FOUND(404, "REVIEW_404_001", "해당 유저를 찾을 수 없습니다."),
+    REVIEW_NOT_FOUND(404, "REVIEW_404_002", "해당 리뷰를 찾을 수 없습니다."),
 
     ;
 

--- a/src/main/java/org/sopt/snappinserver/domain/review/service/GetReviewDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/service/GetReviewDetailService.java
@@ -1,0 +1,46 @@
+package org.sopt.snappinserver.domain.review.service;
+
+import java.util.List;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.review.domain.entity.Review;
+import org.sopt.snappinserver.domain.review.domain.exception.ReviewErrorCode;
+import org.sopt.snappinserver.domain.review.domain.exception.ReviewException;
+import org.sopt.snappinserver.domain.review.repository.ReviewPhotoRepository;
+import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
+import org.sopt.snappinserver.domain.review.service.dto.response.GetReviewDetailResult;
+import org.sopt.snappinserver.domain.review.service.usecase.GetReviewDetailUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class GetReviewDetailService implements GetReviewDetailUseCase {
+
+    private final ReviewRepository reviewRepository;
+    private final ReviewPhotoRepository reviewPhotoRepository;
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
+    @Override
+    public GetReviewDetailResult getReviewDetail(Long userId, Long reviewId) {
+
+        Review review = reviewRepository.findById(reviewId)
+            .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
+
+        List<String> images = reviewPhotoRepository
+            .findAllByReviewIds(List.of(reviewId))
+            .stream()
+            .map(rp -> rp.getPhoto().getImageUrl())
+            .toList();
+
+        return new GetReviewDetailResult(
+            review.getId(),
+            review.getReservation().getUser().getName(),
+            review.getRating(),
+            review.getCreatedAt().atZone(KOREA_ZONE).toLocalDate(),
+            images,
+            review.getContent()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/review/service/GetReviewDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/service/GetReviewDetailService.java
@@ -10,6 +10,7 @@ import org.sopt.snappinserver.domain.review.repository.ReviewPhotoRepository;
 import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
 import org.sopt.snappinserver.domain.review.service.dto.response.GetReviewDetailResult;
 import org.sopt.snappinserver.domain.review.service.usecase.GetReviewDetailUseCase;
+import org.sopt.snappinserver.global.s3.S3Service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +23,7 @@ public class GetReviewDetailService implements GetReviewDetailUseCase {
 
     private final ReviewRepository reviewRepository;
     private final ReviewPhotoRepository reviewPhotoRepository;
+    private final S3Service s3Service;
 
     @Override
     public GetReviewDetailResult getReviewDetail(Long reviewId) {
@@ -33,6 +35,7 @@ public class GetReviewDetailService implements GetReviewDetailUseCase {
             .findAllByReviewIds(List.of(reviewId))
             .stream()
             .map(rp -> rp.getPhoto().getImageUrl())
+            .map(s3Service::getPresignedUrl)
             .toList();
 
         return new GetReviewDetailResult(

--- a/src/main/java/org/sopt/snappinserver/domain/review/service/GetReviewDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/service/GetReviewDetailService.java
@@ -18,9 +18,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class GetReviewDetailService implements GetReviewDetailUseCase {
 
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
     private final ReviewRepository reviewRepository;
     private final ReviewPhotoRepository reviewPhotoRepository;
-    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
     @Override
     public GetReviewDetailResult getReviewDetail(Long userId, Long reviewId) {

--- a/src/main/java/org/sopt/snappinserver/domain/review/service/GetReviewDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/service/GetReviewDetailService.java
@@ -24,7 +24,7 @@ public class GetReviewDetailService implements GetReviewDetailUseCase {
     private final ReviewPhotoRepository reviewPhotoRepository;
 
     @Override
-    public GetReviewDetailResult getReviewDetail(Long userId, Long reviewId) {
+    public GetReviewDetailResult getReviewDetail(Long reviewId) {
 
         Review review = reviewRepository.findById(reviewId)
             .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));

--- a/src/main/java/org/sopt/snappinserver/domain/review/service/dto/response/GetReviewDetailResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/service/dto/response/GetReviewDetailResult.java
@@ -1,0 +1,14 @@
+package org.sopt.snappinserver.domain.review.service.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record GetReviewDetailResult(
+    Long id,
+    String reviewer,
+    Integer rating,
+    LocalDate createdAt,
+    List<String> images,
+    String content
+) {
+}

--- a/src/main/java/org/sopt/snappinserver/domain/review/service/usecase/GetReviewDetailUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/service/usecase/GetReviewDetailUseCase.java
@@ -4,5 +4,5 @@ import org.sopt.snappinserver.domain.review.service.dto.response.GetReviewDetail
 
 public interface GetReviewDetailUseCase {
 
-    GetReviewDetailResult getReviewDetail(Long userId, Long reviewId);
+    GetReviewDetailResult getReviewDetail(Long reviewId);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/review/service/usecase/GetReviewDetailUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/service/usecase/GetReviewDetailUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.review.service.usecase;
+
+import org.sopt.snappinserver.domain.review.service.dto.response.GetReviewDetailResult;
+
+public interface GetReviewDetailUseCase {
+
+    GetReviewDetailResult getReviewDetail(Long userId, Long reviewId);
+}

--- a/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
         "/api/v1/photographers/**",
         "/api/v1/places/**",
         "/api/v1/portfolios/*",
-        "/api/v1/products/**"
+        "/api/v1/products/**",
+        "/api/v1/reviews/*"
     };
 
     private static final String[] AUTHENTICATED_URLS = {
@@ -64,6 +65,8 @@ public class SecurityConfig {
                 .requestMatchers("/actuator/health").permitAll()
                 .requestMatchers(SWAGGER_URLS).permitAll()
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                .requestMatchers("/api/v1/reviews/images").authenticated()
+                .requestMatchers(HttpMethod.GET, "/api/v1/reviews/*").permitAll()
                 .requestMatchers(AUTHENTICATED_URLS).authenticated()
                 .requestMatchers(HttpMethod.POST, "/api/v1/auth/login/kakao").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/v1/auth/reissue").permitAll()

--- a/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
@@ -66,7 +66,6 @@ public class SecurityConfig {
                 .requestMatchers(SWAGGER_URLS).permitAll()
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers("/api/v1/reviews/images").authenticated()
-                .requestMatchers(HttpMethod.GET, "/api/v1/reviews/*").permitAll()
                 .requestMatchers(AUTHENTICATED_URLS).authenticated()
                 .requestMatchers(HttpMethod.POST, "/api/v1/auth/login/kakao").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/v1/auth/reissue").permitAll()


### PR DESCRIPTION
## 👀 Summary

- close #134 

포토 리뷰 상세 조회 API를 구현했습니다.

## 🖇️ Tasks

- [x] 리뷰 상세 조회 API 구현
- [x] 리뷰 도메인 단일 조회 UseCase / Service / DTO 추가
- [x] 리뷰 이미지 조회 시 ReviewPhotoRepository 재사용하여 배치 조회
- [x] 리뷰 생성일 Instant → LocalDate(KST) 변환 로직 적용

## 🔍 To Reviewer

### ❶ 조회 메서드 관련 
단일 리뷰 조회 전용 API인 점을 고려해서 전용 메서드 분리도 고민했으나, 이미 정렬과 fetch join이 보장된 ReviewPhoto 조회 쿼리가 존재하기 때문에 해당 메서드를 사용했습니다. 

### ❷ SecurityConfig 리뷰 엔드포인트 설정
리뷰 상세 조회와 리뷰 이미지 업로드의 접근 성격이 달라 Security 설정에서 경로 보안 설정을 분리했습니다.
리뷰 상세 조회(`/api/v1/reviews/{reviewId}`)는 인증 없이 접근 가능하도록 허용하고, 리뷰 이미지 업로드(`/api/v1/reviews/images`)는 인증이 필요한 요청이므로 Security 설정에서 경로를 명시적으로 분리하여 처리했습니다.