### PR TITLE
[FEAT] #131: 포트폴리오 목록 조회

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/portfolio/code/PortfolioSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/code/PortfolioSuccessCode.java
@@ -12,6 +12,7 @@ public enum PortfolioSuccessCode implements SuccessCode {
     GET_POPULAR_PORTFOLIOS_OK(200, "PORTFOLIO_200_001", "성공적으로 인기 무드 기반 포트폴리오 목록을 조회했습니다."),
     GET_PORTFOLIO_DETAIL_OK(200, "PORTFOLIO_200_002", "성공적으로 포트폴리오 상세를 조회했습니다."),
     GET_CURATED_PORTFOLIO_OK(200, "PORTFOLIO_200_003", "성공적으로 무드 큐레이션 기반 포트폴리오 목록을 조회했습니다."),
+    GET_PORTFOLIO_LIST_OK(200,  "PORTFOLIO_200_004","성공적으로 포트폴리오 목록을 조회했습니다.")
 
     // 201 CREATED
 

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/code/PortfolioSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/code/PortfolioSuccessCode.java
@@ -12,7 +12,7 @@ public enum PortfolioSuccessCode implements SuccessCode {
     GET_POPULAR_PORTFOLIOS_OK(200, "PORTFOLIO_200_001", "성공적으로 인기 무드 기반 포트폴리오 목록을 조회했습니다."),
     GET_PORTFOLIO_DETAIL_OK(200, "PORTFOLIO_200_002", "성공적으로 포트폴리오 상세를 조회했습니다."),
     GET_CURATED_PORTFOLIO_OK(200, "PORTFOLIO_200_003", "성공적으로 무드 큐레이션 기반 포트폴리오 목록을 조회했습니다."),
-    GET_PORTFOLIO_LIST_OK(200,  "PORTFOLIO_200_004","성공적으로 포트폴리오 목록을 조회했습니다.")
+    GET_PORTFOLIO_LIST_OK(200, "PORTFOLIO_200_004", "성공적으로 포트폴리오 목록을 조회했습니다."),
 
     // 201 CREATED
 

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioApi.java
@@ -3,11 +3,15 @@ package org.sopt.snappinserver.api.portfolio.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.snappinserver.api.portfolio.dto.request.GetPortfolioListRequest;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetCurationResponse;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetPopularPortfolioListResponse;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetPortfolioDetailResponse;
+import org.sopt.snappinserver.api.portfolio.dto.response.GetPortfolioListResponse;
+import org.sopt.snappinserver.api.portfolio.dto.response.GetPortfolioMetaResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "08 - Portfolio", description = "포트폴리오 관련 API")
@@ -37,5 +41,13 @@ public interface PortfolioApi {
     ApiResponseBody<GetCurationResponse, Void> getCuratedPortfolios(
         @Parameter(hidden = true)
         CustomUserInfo userInfo
+    );
+
+    @Operation(
+        summary = "포폴 목록 조회 (전체조회/필터링(무드&상품)/검색) API",
+        description = "포트폴리오 전체 조회, 필터링, 검색 시 사용되는 API 입니다."
+    )
+    ApiResponseBody<GetPortfolioListResponse, GetPortfolioMetaResponse> getPortfolioList(
+        @ModelAttribute GetPortfolioListRequest request
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioApi.java
@@ -3,6 +3,7 @@ package org.sopt.snappinserver.api.portfolio.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.sopt.snappinserver.api.portfolio.dto.request.GetPortfolioListRequest;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetCurationResponse;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetPopularPortfolioListResponse;
@@ -48,6 +49,6 @@ public interface PortfolioApi {
         description = "포트폴리오 전체 조회, 필터링, 검색 시 사용되는 API 입니다."
     )
     ApiResponseBody<GetPortfolioListResponse, GetPortfolioMetaResponse> getPortfolioList(
-        @ModelAttribute GetPortfolioListRequest request
+        @Valid @ModelAttribute GetPortfolioListRequest request
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioController.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioController.java
@@ -85,9 +85,7 @@ public class PortfolioController implements PortfolioApi {
         GetPortfolioListQuery query = getQuery(request);
         GetPortfolioListResult result = getPortfolioListUseCase.getPortfolioList(query);
         GetPortfolioListResponse response = GetPortfolioListResponse.from(result);
-        GetPortfolioMetaResponse meta = GetPortfolioMetaResponse.from(
-            result.meta()
-        );
+        GetPortfolioMetaResponse meta = GetPortfolioMetaResponse.from(result.meta());
 
         return ApiResponseBody.ok(PortfolioSuccessCode.GET_PORTFOLIO_LIST_OK, response, meta);
     }

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioController.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioController.java
@@ -4,19 +4,26 @@ import static org.sopt.snappinserver.api.portfolio.code.PortfolioSuccessCode.GET
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.portfolio.code.PortfolioSuccessCode;
+import org.sopt.snappinserver.api.portfolio.dto.request.GetPortfolioListRequest;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetCurationResponse;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetPopularPortfolioListResponse;
 import org.sopt.snappinserver.api.portfolio.dto.response.GetPortfolioDetailResponse;
+import org.sopt.snappinserver.api.portfolio.dto.response.GetPortfolioListResponse;
+import org.sopt.snappinserver.api.portfolio.dto.response.GetPortfolioMetaResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.domain.portfolio.service.dto.request.GetPortfolioListQuery;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetCuratedPortfolioResult;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPopularPortfolioListResult;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioDetailResult;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioListResult;
 import org.sopt.snappinserver.domain.portfolio.service.usecase.GetCuratedPortfolioUseCase;
 import org.sopt.snappinserver.domain.portfolio.service.usecase.GetPopularPortfolioListUseCase;
 import org.sopt.snappinserver.domain.portfolio.service.usecase.GetPortfolioDetailUseCase;
+import org.sopt.snappinserver.domain.portfolio.service.usecase.GetPortfolioListUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,6 +36,7 @@ public class PortfolioController implements PortfolioApi {
     private final GetPopularPortfolioListUseCase getPopularPortfolioListUseCase;
     private final GetPortfolioDetailUseCase getPortfolioDetailUseCase;
     private final GetCuratedPortfolioUseCase getCuratedPortfolioUseCase;
+    private final GetPortfolioListUseCase getPortfolioListUseCase;
 
     @Override
     @GetMapping("/popular")
@@ -67,5 +75,33 @@ public class PortfolioController implements PortfolioApi {
         GetCurationResponse response = GetCurationResponse.from(result);
 
         return ApiResponseBody.ok(PortfolioSuccessCode.GET_CURATED_PORTFOLIO_OK, response);
+    }
+
+    @Override
+    @GetMapping
+    public ApiResponseBody<GetPortfolioListResponse, GetPortfolioMetaResponse> getPortfolioList(
+        @ModelAttribute GetPortfolioListRequest request
+    ) {
+        GetPortfolioListQuery query = getQuery(request);
+        GetPortfolioListResult result = getPortfolioListUseCase.getPortfolioList(query);
+        GetPortfolioListResponse response = GetPortfolioListResponse.from(result);
+        GetPortfolioMetaResponse meta = GetPortfolioMetaResponse.from(
+            result.getPortfolioListMeta()
+        );
+
+        return ApiResponseBody.ok(PortfolioSuccessCode.GET_PORTFOLIO_LIST_OK, response, meta);
+    }
+
+    private GetPortfolioListQuery getQuery(GetPortfolioListRequest request) {
+        return new GetPortfolioListQuery(
+            request.moodIds(),
+            request.productId(),
+            request.photographerId(),
+            request.snapCategory(),
+            request.placeId(),
+            request.date(),
+            request.peopleCount(),
+            request.cursor()
+        );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioController.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioController.java
@@ -86,7 +86,7 @@ public class PortfolioController implements PortfolioApi {
         GetPortfolioListResult result = getPortfolioListUseCase.getPortfolioList(query);
         GetPortfolioListResponse response = GetPortfolioListResponse.from(result);
         GetPortfolioMetaResponse meta = GetPortfolioMetaResponse.from(
-            result.getPortfolioListMeta()
+            result.meta()
         );
 
         return ApiResponseBody.ok(PortfolioSuccessCode.GET_PORTFOLIO_LIST_OK, response, meta);

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioController.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/controller/PortfolioController.java
@@ -97,8 +97,6 @@ public class PortfolioController implements PortfolioApi {
             request.photographerId(),
             request.snapCategory(),
             request.placeId(),
-            request.date(),
-            request.peopleCount(),
             request.cursor()
         );
     }

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/dto/request/GetPortfolioListRequest.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/dto/request/GetPortfolioListRequest.java
@@ -1,10 +1,7 @@
 package org.sopt.snappinserver.api.portfolio.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
-import java.time.LocalDate;
 import java.util.List;
 import org.sopt.snappinserver.global.enums.SnapCategory;
 
@@ -28,14 +25,6 @@ public record GetPortfolioListRequest(
     @Schema(description = "장소 ID")
     @Positive(message = "장소 ID는 양수값이어야 합니다.")
     Long placeId,
-
-    @Schema(description = "촬영 일정 (YYYY-MM-DD)")
-    LocalDate date,
-
-    @Schema(description = "촬영 인원")
-    @Positive(message = "촬영 인원은 양수여야 합니다.")
-    @Min(value = 1, message = "촬영 인원은 최소 1명부터 입력할 수 있습니다.")
-    Integer peopleCount,
 
     @Schema(description = "커서 값")
     Long cursor

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/dto/request/GetPortfolioListRequest.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/dto/request/GetPortfolioListRequest.java
@@ -1,0 +1,42 @@
+package org.sopt.snappinserver.api.portfolio.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import java.time.LocalDate;
+import java.util.List;
+import org.sopt.snappinserver.global.enums.SnapCategory;
+
+@Schema(description = "포폴 목록 조회 요청 DTO - 쿼리 파라미터용")
+@Valid
+public record GetPortfolioListRequest(
+
+    @Schema(description = "무드 아이디 목록(,로 구분, 개수 제한 없음)")
+    List<Long> moodIds,
+
+    @Schema(description = "상품 ID")
+    @Positive(message = "상품 ID는 양수값이어야 합니다.")
+    Long productId,
+
+    @Schema(description = "스냅 작가 ID")
+    @Positive(message = "스냅 작가 ID는 양수값이어야 합니다.")
+    Long photographerId,
+
+    @Schema(description = "촬영 상황 (스냅 유형)")
+    SnapCategory snapCategory,
+
+    @Schema(description = "장소 ID")
+    @Positive(message = "장소 ID는 양수값이어야 합니다.")
+    Long placeId,
+
+    @Schema(description = "촬영 일정 (YYYY-MM-DD)")
+    LocalDate date,
+
+    @Schema(description = "촬영 인원")
+    Integer peopleCount,
+
+    @Schema(description = "커서 값")
+    Long cursor
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/dto/request/GetPortfolioListRequest.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/dto/request/GetPortfolioListRequest.java
@@ -2,13 +2,13 @@ package org.sopt.snappinserver.api.portfolio.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
 import java.util.List;
 import org.sopt.snappinserver.global.enums.SnapCategory;
 
 @Schema(description = "포폴 목록 조회 요청 DTO - 쿼리 파라미터용")
-@Valid
 public record GetPortfolioListRequest(
 
     @Schema(description = "무드 아이디 목록(,로 구분, 개수 제한 없음)")
@@ -33,6 +33,8 @@ public record GetPortfolioListRequest(
     LocalDate date,
 
     @Schema(description = "촬영 인원")
+    @Positive(message = "촬영 인원은 양수여야 합니다.")
+    @Min(value = 1, message = "촬영 인원은 최소 1명부터 입력할 수 있습니다.")
     Integer peopleCount,
 
     @Schema(description = "커서 값")

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetPortfolioCardResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetPortfolioCardResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.snappinserver.api.portfolio.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioCardResult;
+
+@Schema(description = "포트폴리오 카드 조회 응답 DTO")
+public record GetPortfolioCardResponse(
+
+    @Schema(description = "포트폴리오 ID")
+    Long id,
+
+    @Schema(description = "포트폴리오 이미지 url")
+    String imageUrl
+) {
+
+    public static GetPortfolioCardResponse from(GetPortfolioCardResult result) {
+        return new GetPortfolioCardResponse(
+            result.id(),
+            result.imageUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetPortfolioListResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetPortfolioListResponse.java
@@ -1,0 +1,21 @@
+package org.sopt.snappinserver.api.portfolio.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioListResult;
+
+@Schema(description = "포트폴리오 목록 조회 응답 DTO")
+public record GetPortfolioListResponse(
+
+    @Schema(description = "포트폴리오 카드 목록")
+    List<GetPortfolioCardResponse> portfolios
+) {
+
+    public static GetPortfolioListResponse from(GetPortfolioListResult result) {
+        return new GetPortfolioListResponse(
+            result.portfolios().stream()
+                .map(GetPortfolioCardResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetPortfolioMetaResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/portfolio/dto/response/GetPortfolioMetaResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.snappinserver.api.portfolio.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioListMeta;
+
+@Schema(description = "포트폴리오 목록 조회 메타 정보")
+public record GetPortfolioMetaResponse(
+
+    @Schema(description = "다음 커서 값")
+    Long nextCursor,
+
+    @Schema(description = "다음 커서 존재 여부")
+    Boolean hasNext
+) {
+
+    public static GetPortfolioMetaResponse from(GetPortfolioListMeta result) {
+        return new GetPortfolioMetaResponse(
+            result.nextCursor(),
+            result.hasNext()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioBaseRow.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioBaseRow.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.portfolio.repository;
+
+public record PortfolioBaseRow(
+    Long id,
+    String imageUrl
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryCustom.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryCustom.java
@@ -1,9 +1,11 @@
 package org.sopt.snappinserver.domain.portfolio.repository;
 
-import java.util.Optional;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
+import org.sopt.snappinserver.domain.portfolio.service.dto.request.GetPortfolioListQuery;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioCardResult;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.PortfolioDetailProjection;
 
@@ -32,5 +34,11 @@ public interface PortfolioRepositoryCustom {
         Set<Long> excludedPortfolioIds,
         int matchCount,
         int limit
+    );
+
+    List<GetPortfolioCardResult> findPortfolioCards(
+        Long cursor,
+        GetPortfolioListQuery query,
+        int size
     );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -253,6 +253,8 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
                 )
             )
             .from(portfolio)
+            .join(portfolio.product, product)
+            .join(product.photographer, photographer)
             .join(portfolioPhoto).on(
                 portfolioPhoto.portfolio.id.eq(portfolio.id)
                     .and(portfolioPhoto.displayOrder.eq(1))

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -262,9 +262,11 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
             .leftJoin(portfolioMood).on(portfolioMood.portfolio.id.eq(portfolio.id))
             .where(
                 cursorLt(cursor),
+                moodIn(query.moodIds()),
+                productIdEq(query.productId()),
+                photographerIdEq(query.photographerId()),
                 snapCategoryEq(query.snapCategory()),
-                placeEq(query.placeId()),
-                moodIn(query.moodIds())
+                placeEq(query.placeId())
             )
             .distinct()
             .orderBy(portfolio.id.desc())
@@ -276,17 +278,25 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
         return cursor == null ? null : portfolio.id.lt(cursor);
     }
 
+    private BooleanExpression moodIn(List<Long> moodIds) {
+        if (moodIds == null || moodIds.isEmpty()) return null;
+        return portfolioMood.mood.id.in(moodIds);
+    }
+
+    private BooleanExpression productIdEq(Long productId) {
+        return productId == null ? null : product.id.eq(productId);
+    }
+
+    private BooleanExpression photographerIdEq(Long photographerId) {
+        return photographerId == null ? null : photographer.id.eq(photographerId);
+    }
+
     private BooleanExpression snapCategoryEq(SnapCategory category) {
         return category == null ? null : portfolio.snapCategory.eq(category);
     }
 
     private BooleanExpression placeEq(Long placeId) {
         return placeId == null ? null : portfolioPlace.place.id.eq(placeId);
-    }
-
-    private BooleanExpression moodIn(List<Long> moodIds) {
-        if (moodIds == null || moodIds.isEmpty()) return null;
-        return portfolioMood.mood.id.in(moodIds);
     }
 
 }

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -27,8 +27,11 @@ import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
+import org.sopt.snappinserver.domain.portfolio.service.dto.request.GetPortfolioListQuery;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioCardResult;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.PortfolioDetailProjection;
+import org.sopt.snappinserver.global.enums.SnapCategory;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -234,4 +237,56 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
             .limit(limit)
             .fetch();
     }
+
+    @Override
+    public List<GetPortfolioCardResult> findPortfolioCards(
+        Long cursor,
+        GetPortfolioListQuery query,
+        int size
+    ) {
+        return jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    GetPortfolioCardResult.class,
+                    portfolio.id,
+                    portfolioPhoto.photo.imageUrl
+                )
+            )
+            .from(portfolio)
+            .join(portfolioPhoto).on(
+                portfolioPhoto.portfolio.id.eq(portfolio.id)
+                    .and(portfolioPhoto.displayOrder.eq(1))
+            )
+            .join(portfolioPhoto.photo, photo)
+            .leftJoin(portfolioPlace).on(portfolioPlace.portfolio.id.eq(portfolio.id))
+            .leftJoin(portfolioMood).on(portfolioMood.portfolio.id.eq(portfolio.id))
+            .where(
+                cursorLt(cursor),
+                snapCategoryEq(query.snapCategory()),
+                placeEq(query.placeId()),
+                moodIn(query.moodIds())
+            )
+            .distinct()
+            .orderBy(portfolio.id.desc())
+            .limit(size + 1)
+            .fetch();
+    }
+
+    private BooleanExpression cursorLt(Long cursor) {
+        return cursor == null ? null : portfolio.id.lt(cursor);
+    }
+
+    private BooleanExpression snapCategoryEq(SnapCategory category) {
+        return category == null ? null : portfolio.snapCategory.eq(category);
+    }
+
+    private BooleanExpression placeEq(Long placeId) {
+        return placeId == null ? null : portfolioPlace.place.id.eq(placeId);
+    }
+
+    private BooleanExpression moodIn(List<Long> moodIds) {
+        if (moodIds == null || moodIds.isEmpty()) return null;
+        return portfolioMood.mood.id.in(moodIds);
+    }
+
 }

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetPortfolioListService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetPortfolioListService.java
@@ -14,12 +14,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
-public class GetPortfolioService implements GetPortfolioListUseCase {
+public class GetPortfolioListService implements GetPortfolioListUseCase {
 
     private static final int PAGE_SIZE = 30;
 
     private final PortfolioRepositoryCustom portfolioRepositoryCustom;
 
+    @Override
     public GetPortfolioListResult getPortfolioList(GetPortfolioListQuery query) {
 
         List<GetPortfolioCardResult> rows =

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetPortfolioListService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetPortfolioListService.java
@@ -8,6 +8,7 @@ import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolio
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioListMeta;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioListResult;
 import org.sopt.snappinserver.domain.portfolio.service.usecase.GetPortfolioListUseCase;
+import org.sopt.snappinserver.global.s3.S3Service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,16 +20,24 @@ public class GetPortfolioListService implements GetPortfolioListUseCase {
     private static final int PAGE_SIZE = 30;
 
     private final PortfolioRepositoryCustom portfolioRepositoryCustom;
+    private final S3Service s3Service;
 
     @Override
     public GetPortfolioListResult getPortfolioList(GetPortfolioListQuery query) {
 
-        List<GetPortfolioCardResult> rows =
-            portfolioRepositoryCustom.findPortfolioCards(
-                query.cursor(),
-                query,
-                PAGE_SIZE
-            );
+        List<GetPortfolioCardResult> rows = portfolioRepositoryCustom
+            .findPortfolioCards(query.cursor(), query, PAGE_SIZE).stream()
+            .map(result -> {
+                String presignedUrl = (result.imageUrl() != null && !result.imageUrl().isBlank())
+                    ? s3Service.getPresignedUrl(result.imageUrl())
+                    : null;
+
+                return new GetPortfolioCardResult(
+                    result.id(),
+                    presignedUrl
+                );
+            })
+            .toList();
 
         boolean hasNext = rows.size() > PAGE_SIZE;
         List<GetPortfolioCardResult> portfolios = hasNext ? rows.subList(0, PAGE_SIZE) : rows;

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetPortfolioService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetPortfolioService.java
@@ -1,0 +1,42 @@
+package org.sopt.snappinserver.domain.portfolio.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.portfolio.repository.PortfolioRepositoryCustom;
+import org.sopt.snappinserver.domain.portfolio.service.dto.request.GetPortfolioListQuery;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioCardResult;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioListMeta;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioListResult;
+import org.sopt.snappinserver.domain.portfolio.service.usecase.GetPortfolioListUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class GetPortfolioService implements GetPortfolioListUseCase {
+
+    private static final int PAGE_SIZE = 30;
+
+    private final PortfolioRepositoryCustom portfolioRepositoryCustom;
+
+    public GetPortfolioListResult getPortfolioList(GetPortfolioListQuery query) {
+
+        List<GetPortfolioCardResult> rows =
+            portfolioRepositoryCustom.findPortfolioCards(
+                query.cursor(),
+                query,
+                PAGE_SIZE
+            );
+
+        boolean hasNext = rows.size() > PAGE_SIZE;
+        List<GetPortfolioCardResult> portfolios = hasNext ? rows.subList(0, PAGE_SIZE) : rows;
+        Long nextCursor = hasNext ? portfolios.get(portfolios.size() - 1).id() : null;
+
+        return new GetPortfolioListResult(
+            portfolios,
+            new GetPortfolioListMeta(hasNext, nextCursor)
+        );
+    }
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/request/GetPortfolioListQuery.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/request/GetPortfolioListQuery.java
@@ -1,6 +1,5 @@
 package org.sopt.snappinserver.domain.portfolio.service.dto.request;
 
-import java.time.LocalDate;
 import java.util.List;
 import org.sopt.snappinserver.global.enums.SnapCategory;
 
@@ -10,8 +9,6 @@ public record GetPortfolioListQuery(
     Long photographerId,
     SnapCategory snapCategory,
     Long placeId,
-    LocalDate date,
-    Integer peopleCount,
     Long cursor
 ) {
 

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/request/GetPortfolioListQuery.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/request/GetPortfolioListQuery.java
@@ -1,0 +1,18 @@
+package org.sopt.snappinserver.domain.portfolio.service.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.sopt.snappinserver.global.enums.SnapCategory;
+
+public record GetPortfolioListQuery(
+    List<Long> moodIds,
+    Long productId,
+    Long photographerId,
+    SnapCategory snapCategory,
+    Long placeId,
+    LocalDate date,
+    Integer peopleCount,
+    Long cursor
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPortfolioCardResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPortfolioCardResult.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.portfolio.service.dto.response;
+
+public record GetPortfolioCardResult(
+    Long id,
+    String imageUrl
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPortfolioListMeta.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPortfolioListMeta.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.portfolio.service.dto.response;
+
+public record GetPortfolioListMeta(
+    Boolean hasNext,
+    Long nextCursor
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPortfolioListResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPortfolioListResult.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public record GetPortfolioListResult(
     List<GetPortfolioCardResult> portfolios,
-    GetPortfolioListMeta getPortfolioListMeta
+    GetPortfolioListMeta meta
 ) {
 
 }

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPortfolioListResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPortfolioListResult.java
@@ -1,0 +1,10 @@
+package org.sopt.snappinserver.domain.portfolio.service.dto.response;
+
+import java.util.List;
+
+public record GetPortfolioListResult(
+    List<GetPortfolioCardResult> portfolios,
+    GetPortfolioListMeta getPortfolioListMeta
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/usecase/GetPortfolioListUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/usecase/GetPortfolioListUseCase.java
@@ -1,0 +1,9 @@
+package org.sopt.snappinserver.domain.portfolio.service.usecase;
+
+import org.sopt.snappinserver.domain.portfolio.service.dto.request.GetPortfolioListQuery;
+import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioListResult;
+
+public interface GetPortfolioListUseCase {
+
+    GetPortfolioListResult getPortfolioList(GetPortfolioListQuery query);
+}

--- a/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
 
         "/api/v1/photographers/**",
         "/api/v1/places/**",
+        "/api/v1/portfolios",
         "/api/v1/portfolios/*",
         "/api/v1/products/**"
     };


### PR DESCRIPTION
## 👀 Summary

- close #131


## 🖇️ Tasks

- 포트폴리오 목록 조회 API (GET /api/v1/portfolios) 구현
- 커서 기반 페이지네이션 적용
- portfolio.id 기준 내림차순 정렬
- limit + 1 조회로 hasNext, nextCursor 계산
- 검색 조건(Query Parameter) 기반 필터링 지원
- 비로그인 사용자도 접근 가능하도록 Security 설정 반영

## 🔍 To Reviewer

본 API는 탐색/조회 전용 API로, 리스트 응답을 최대한 얇게 유지하는 것을 목표로 했습니다. 무한 스크롤 안정성을 위해 OFFSET 기반 페이지네이션은 사용하지 않았습니다. 포트폴리오 리스트 API를 “탐색/검색 전용 API”로 정의하고, 상세 정보, 비즈니스 로직은 포함하지 않도록 의도적으로 분리했습니다. 커서 기준은 portfolio.id DESC 기준이며, limit + 1 방식으로 hasNext를 판단합니다.

