### PR TITLE
[REFACTOR] #137: 로그인 시 신규 유저 컬럼 추가

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/auth/controller/AuthController.java
@@ -4,7 +4,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.sopt.snappinserver.api.v1.auth.code.AuthSuccessCode;
+import org.sopt.snappinserver.global.response.code.auth.AuthSuccessCode;
 import org.sopt.snappinserver.api.v1.auth.dto.request.CreateKakaoLoginRequest;
 import org.sopt.snappinserver.api.v1.auth.dto.response.CreateAccessTokenResponse;
 import org.sopt.snappinserver.api.v1.auth.dto.response.CreateKakaoLoginResponse;

--- a/src/main/java/org/sopt/snappinserver/api/v1/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/auth/controller/AuthController.java
@@ -57,7 +57,6 @@ public class AuthController implements AuthApi {
             (clientRedirectUri == null)
                 ? ("http://localhost:8080/api/v1/auth/login/kakao")
                 : clientRedirectUri;
-        log.info("redirectUri: {}", redirectUri);
         LoginResult loginResult = loginUseCase.kakaoLogin(
             redirectUri,
             createKakaoLoginRequest.code(),
@@ -68,7 +67,7 @@ public class AuthController implements AuthApi {
 
         return ApiResponseBody.ok(
             AuthSuccessCode.LOGIN_SUCCESS,
-            new CreateKakaoLoginResponse(loginResult.accessToken())
+            CreateKakaoLoginResponse.from(loginResult)
         );
     }
 

--- a/src/main/java/org/sopt/snappinserver/api/v1/auth/dto/response/CreateKakaoLoginResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/auth/dto/response/CreateKakaoLoginResponse.java
@@ -1,12 +1,22 @@
 package org.sopt.snappinserver.api.v1.auth.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.auth.service.dto.response.LoginResult;
 
 @Schema(description = "카카오 로그인 응답 DTO")
 public record CreateKakaoLoginResponse(
+
+    @Schema(description = "신규 가입 여부")
+    boolean isNew,
 
     @Schema(description = "인증 시 필요한 accessToken입니다. refreshToken은 쿠키로 내려드립니다.")
     String accessToken
 ) {
 
+    public static CreateKakaoLoginResponse from(LoginResult loginResult){
+        return new CreateKakaoLoginResponse(
+            loginResult.isNew(),
+            loginResult.accessToken()
+        );
+    }
 }

--- a/src/main/java/org/sopt/snappinserver/api/v1/category/controller/CategoryController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/category/controller/CategoryController.java
@@ -3,7 +3,7 @@ package org.sopt.snappinserver.api.v1.category.controller;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.api.v1.category.code.CategorySuccessCode;
+import org.sopt.snappinserver.global.response.code.category.CategorySuccessCode;
 import org.sopt.snappinserver.api.v1.category.dto.response.CategoriesResponse;
 import org.sopt.snappinserver.api.v1.category.dto.response.CategoryResponse;
 import org.sopt.snappinserver.global.enums.SnapCategory;

--- a/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationController.java
@@ -1,7 +1,7 @@
 package org.sopt.snappinserver.api.v1.curation.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.api.v1.curation.code.CurationSuccessCode;
+import org.sopt.snappinserver.global.response.code.curation.CurationSuccessCode;
 import org.sopt.snappinserver.api.v1.curation.dto.request.CreateMoodCurationRequest;
 import org.sopt.snappinserver.api.v1.curation.dto.response.CreateMoodCurationResponse;
 import org.sopt.snappinserver.api.v1.curation.dto.response.GetCurationQuestionPhotosResponse;

--- a/src/main/java/org/sopt/snappinserver/api/v1/home/controller/HomeController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/home/controller/HomeController.java
@@ -2,7 +2,7 @@ package org.sopt.snappinserver.api.v1.home.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.api.v1.home.code.HomeSuccessCode;
+import org.sopt.snappinserver.global.response.code.home.HomeSuccessCode;
 import org.sopt.snappinserver.api.v1.home.dto.response.GetPlacePhotographerRecommendationResponse;
 import org.sopt.snappinserver.domain.photographer.service.dto.response.GetRandomPhotographersResult;
 import org.sopt.snappinserver.domain.photographer.service.usecase.GetRandomPhotographersUseCase;

--- a/src/main/java/org/sopt/snappinserver/api/v1/mood/controller/MoodController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/mood/controller/MoodController.java
@@ -1,7 +1,7 @@
 package org.sopt.snappinserver.api.v1.mood.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.api.v1.mood.code.MoodSuccessCode;
+import org.sopt.snappinserver.global.response.code.mood.MoodSuccessCode;
 import org.sopt.snappinserver.api.v1.mood.dto.response.GetMoodFilterListResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.mood.service.dto.response.GetMoodFilterListResult;

--- a/src/main/java/org/sopt/snappinserver/api/v1/photo/controller/PhotoController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/photo/controller/PhotoController.java
@@ -2,7 +2,7 @@ package org.sopt.snappinserver.api.v1.photo.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.api.v1.photo.code.PhotoSuccessCode;
+import org.sopt.snappinserver.global.response.code.photo.PhotoSuccessCode;
 import org.sopt.snappinserver.api.v1.photo.dto.request.CreatePhotoMoodRequest;
 import org.sopt.snappinserver.domain.photo.service.dto.request.PhotoProcessCommand;
 import org.sopt.snappinserver.domain.photo.service.usecase.ProcessPhotoUseCase;

--- a/src/main/java/org/sopt/snappinserver/api/v1/photographer/controller/PhotographerController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/photographer/controller/PhotographerController.java
@@ -1,7 +1,7 @@
 package org.sopt.snappinserver.api.v1.photographer.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.api.v1.photographer.code.PhotographerSuccessCode;
+import org.sopt.snappinserver.global.response.code.photographer.PhotographerSuccessCode;
 import org.sopt.snappinserver.api.v1.photographer.dto.response.GetPhotographerProfileResponse;
 import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerProfileResult;
 import org.sopt.snappinserver.domain.photographer.service.usecase.GetPhotographerProfileUseCase;

--- a/src/main/java/org/sopt/snappinserver/api/v1/place/controller/PlaceController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/place/controller/PlaceController.java
@@ -1,6 +1,6 @@
 package org.sopt.snappinserver.api.v1.place.controller;
 
-import static org.sopt.snappinserver.api.v1.place.code.PlaceSuccessCode.GET_PLACE_LIST_OK;
+import static org.sopt.snappinserver.global.response.code.place.PlaceSuccessCode.GET_PLACE_LIST_OK;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.v1.place.dto.response.GetPlaceListResponse;

--- a/src/main/java/org/sopt/snappinserver/api/v1/portfolio/controller/PortfolioController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/portfolio/controller/PortfolioController.java
@@ -1,9 +1,9 @@
 package org.sopt.snappinserver.api.v1.portfolio.controller;
 
-import static org.sopt.snappinserver.api.v1.portfolio.code.PortfolioSuccessCode.GET_POPULAR_PORTFOLIOS_OK;
+import static org.sopt.snappinserver.global.response.code.portfolio.PortfolioSuccessCode.GET_POPULAR_PORTFOLIOS_OK;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.api.v1.portfolio.code.PortfolioSuccessCode;
+import org.sopt.snappinserver.global.response.code.portfolio.PortfolioSuccessCode;
 import org.sopt.snappinserver.api.v1.portfolio.dto.request.GetPortfolioListRequest;
 import org.sopt.snappinserver.api.v1.portfolio.dto.response.GetCurationResponse;
 import org.sopt.snappinserver.api.v1.portfolio.dto.response.GetPopularPortfolioListResponse;

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductController.java
@@ -3,7 +3,7 @@ package org.sopt.snappinserver.api.v1.product.controller;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.api.v1.product.code.ProductSuccessCode;
+import org.sopt.snappinserver.global.response.code.product.ProductSuccessCode;
 import org.sopt.snappinserver.api.v1.product.dto.request.ProductReservationRequest;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetProductDetailResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetProductListMeta;

--- a/src/main/java/org/sopt/snappinserver/api/v1/reservation/controller/ReservationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/reservation/controller/ReservationController.java
@@ -1,7 +1,7 @@
 package org.sopt.snappinserver.api.v1.reservation.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.api.v1.reservation.code.ReservationSuccessCode;
+import org.sopt.snappinserver.global.response.code.reservation.ReservationSuccessCode;
 import org.sopt.snappinserver.api.v1.reservation.dto.request.CreateReservationReviewRequest;
 import org.sopt.snappinserver.api.v1.reservation.dto.request.RequestPaymentReservationRequest;
 import org.sopt.snappinserver.api.v1.reservation.dto.response.CancelReservationResponse;

--- a/src/main/java/org/sopt/snappinserver/api/v1/review/controller/ReviewController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/review/controller/ReviewController.java
@@ -1,10 +1,10 @@
 package org.sopt.snappinserver.api.v1.review.controller;
 
-import static org.sopt.snappinserver.api.v1.review.code.ReviewSuccessCode.POST_PRESIGNED_URL_OK;
+import static org.sopt.snappinserver.global.response.code.review.ReviewSuccessCode.POST_PRESIGNED_URL_OK;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.api.v1.review.code.ReviewSuccessCode;
+import org.sopt.snappinserver.global.response.code.review.ReviewSuccessCode;
 import org.sopt.snappinserver.api.v1.review.dto.request.PostPresignedUrlRequest;
 import org.sopt.snappinserver.api.v1.review.dto.response.GetReviewDetailResponse;
 import org.sopt.snappinserver.api.v1.review.dto.response.PostPresignedUrlResponse;

--- a/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserController.java
@@ -1,10 +1,10 @@
 package org.sopt.snappinserver.api.v1.user.controller;
 
-import static org.sopt.snappinserver.api.v1.user.code.UserSuccessCode.SWITCH_USER_ROLE_OK;
+import static org.sopt.snappinserver.global.response.code.user.UserSuccessCode.SWITCH_USER_ROLE_OK;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.api.v1.user.code.UserSuccessCode;
+import org.sopt.snappinserver.global.response.code.user.UserSuccessCode;
 import org.sopt.snappinserver.api.v1.user.dto.response.GetSwitchedUserProfileResponse;
 import org.sopt.snappinserver.api.v1.user.dto.response.GetUserInfoResponse;
 import org.sopt.snappinserver.domain.auth.domain.exception.AuthErrorCode;

--- a/src/main/java/org/sopt/snappinserver/api/v1/wish/controller/WishController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/wish/controller/WishController.java
@@ -1,7 +1,7 @@
 package org.sopt.snappinserver.api.v1.wish.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.api.v1.wish.code.WishSuccessCode;
+import org.sopt.snappinserver.global.response.code.wish.WishSuccessCode;
 import org.sopt.snappinserver.api.v1.wish.dto.request.WishPortfolioRequest;
 import org.sopt.snappinserver.api.v1.wish.dto.request.WishProductRequest;
 import org.sopt.snappinserver.api.v1.wish.dto.response.WishPortfolioResponse;

--- a/src/main/java/org/sopt/snappinserver/domain/auth/repository/AuthProviderRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/auth/repository/AuthProviderRepository.java
@@ -11,4 +11,9 @@ public interface AuthProviderRepository extends JpaRepository<AuthProvider, Long
         SocialProvider socialProvider,
         String providerId
     );
+
+    boolean existsBySocialProviderAndProviderId(
+        SocialProvider socialProvider,
+        String providerId
+    );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/auth/service/LoginService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/auth/service/LoginService.java
@@ -7,6 +7,7 @@ import org.sopt.snappinserver.domain.auth.domain.value.TokenPair;
 import org.sopt.snappinserver.domain.auth.infra.oauth.KakaoClient;
 import org.sopt.snappinserver.domain.auth.infra.oauth.dto.response.KakaoUserProfile;
 import org.sopt.snappinserver.domain.auth.infra.oauth.dto.response.OAuthToken;
+import org.sopt.snappinserver.domain.auth.repository.AuthProviderRepository;
 import org.sopt.snappinserver.domain.auth.service.dto.response.LoginResult;
 import org.sopt.snappinserver.domain.auth.service.token.AuthTokenManager;
 import org.sopt.snappinserver.domain.auth.service.usecase.LoginUseCase;
@@ -18,12 +19,15 @@ import org.springframework.stereotype.Service;
 public class LoginService implements LoginUseCase {
 
     private final KakaoClient kakaoClient;
+    private final AuthProviderRepository authProviderRepository;
     private final GetSocialUserService getSocialUserService;
     private final AuthTokenManager authTokenManager;
 
     @Override
     public LoginResult kakaoLogin(String redirectUri, String accessCode, String userAgent) {
         KakaoUserProfile kakaoUserInfo = fetchKakaoUserInfo(redirectUri, accessCode);
+        boolean isNew = !authProviderRepository
+            .existsBySocialProviderAndProviderId(KAKAO, kakaoUserInfo.socialId());
         User user = getSocialUserService.registerOrGetUser(
             KAKAO,
             kakaoUserInfo.socialId(),
@@ -32,7 +36,7 @@ public class LoginService implements LoginUseCase {
         );
         TokenPair tokenPair = authTokenManager.issueTokenPair(user, userAgent);
 
-        return LoginResult.from(tokenPair);
+        return LoginResult.of(isNew, tokenPair);
     }
 
     private KakaoUserProfile fetchKakaoUserInfo(String redirectUri, String accessCode) {

--- a/src/main/java/org/sopt/snappinserver/domain/auth/service/dto/response/LoginResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/auth/service/dto/response/LoginResult.java
@@ -2,9 +2,9 @@ package org.sopt.snappinserver.domain.auth.service.dto.response;
 
 import org.sopt.snappinserver.domain.auth.domain.value.TokenPair;
 
-public record LoginResult(String accessToken, String refreshToken) {
+public record LoginResult(boolean isNew, String accessToken, String refreshToken) {
 
-    public static LoginResult from(TokenPair tokenPair) {
-        return new LoginResult(tokenPair.accessToken(), tokenPair.refreshToken());
+    public static LoginResult of(boolean isNew, TokenPair tokenPair) {
+        return new LoginResult(isNew, tokenPair.accessToken(), tokenPair.refreshToken());
     }
 }

--- a/src/main/java/org/sopt/snappinserver/global/response/code/auth/AuthSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/auth/AuthSuccessCode.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.api.v1.auth.code;
+package org.sopt.snappinserver.global.response.code.auth;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/snappinserver/global/response/code/category/CategorySuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/category/CategorySuccessCode.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.api.v1.category.code;
+package org.sopt.snappinserver.global.response.code.category;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/snappinserver/global/response/code/curation/CurationSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/curation/CurationSuccessCode.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.api.v1.curation.code;
+package org.sopt.snappinserver.global.response.code.curation;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/snappinserver/global/response/code/home/HomeSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/home/HomeSuccessCode.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.api.v1.home.code;
+package org.sopt.snappinserver.global.response.code.home;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/snappinserver/global/response/code/mood/MoodSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/mood/MoodSuccessCode.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.api.v1.mood.code;
+package org.sopt.snappinserver.global.response.code.mood;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/snappinserver/global/response/code/photo/PhotoSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/photo/PhotoSuccessCode.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.api.v1.photo.code;
+package org.sopt.snappinserver.global.response.code.photo;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/snappinserver/global/response/code/photographer/PhotographerSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/photographer/PhotographerSuccessCode.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.api.v1.photographer.code;
+package org.sopt.snappinserver.global.response.code.photographer;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/snappinserver/global/response/code/place/PlaceSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/place/PlaceSuccessCode.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.api.v1.place.code;
+package org.sopt.snappinserver.global.response.code.place;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/snappinserver/global/response/code/portfolio/PortfolioSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/portfolio/PortfolioSuccessCode.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.api.v1.portfolio.code;
+package org.sopt.snappinserver.global.response.code.portfolio;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/snappinserver/global/response/code/product/ProductSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/product/ProductSuccessCode.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.api.v1.product.code;
+package org.sopt.snappinserver.global.response.code.product;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/snappinserver/global/response/code/reservation/ReservationSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/reservation/ReservationSuccessCode.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.api.v1.reservation.code;
+package org.sopt.snappinserver.global.response.code.reservation;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/snappinserver/global/response/code/review/ReviewSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/review/ReviewSuccessCode.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.api.v1.review.code;
+package org.sopt.snappinserver.global.response.code.review;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/snappinserver/global/response/code/user/UserSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/user/UserSuccessCode.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.api.v1.user.code;
+package org.sopt.snappinserver.global.response.code.user;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/snappinserver/global/response/code/wish/WishSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/wish/WishSuccessCode.java
@@ -1,4 +1,4 @@
-package org.sopt.snappinserver.api.v1.wish.code;
+package org.sopt.snappinserver.global.response.code.wish;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## 👀 Summary

- close #137

## 🖇️ Tasks

-  로그인 시 신규 유저 컬럼 추가
- 기존 성공 코드 /global/response로 이동 (v1, v2 구분할 필요 x)


## 🔍 To Reviewer

로그인 시 신규 유저 여부에 따라 이동하는 페이지가 달라짐에 따라 유저를 가져오기 전에 해당 유저의 카카오 provider id로 유저 존재 여부를 확인하고 함께 반환합니다.
