### PR TITLE
[FIX] #127: 예약 목록 및 상세 조회 시 오류 해결

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationDetailInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationDetailInfoResponse.java
@@ -10,7 +10,7 @@ public record ReservationDetailInfoResponse(
     @Schema(description = "예약자명", example = "홍길동")
     String client,
 
-    @Schema(description = "예약 생성 일시", example = "2026-02-18 10:05:44")
+    @Schema(description = "예약 생성 일시", example = "2026-02-18 10:05")
     String createdAt,
 
     @Schema(description = "촬영 희망 날짜", example = "2026-03-15")
@@ -32,7 +32,7 @@ public record ReservationDetailInfoResponse(
     String requestNote
 ) {
     private static final DateTimeFormatter CREATED_AT_FORMATTER =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
     public static ReservationDetailInfoResponse from(GetReservationDetailInfoResult result) {
         return new ReservationDetailInfoResponse(

--- a/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationDetailInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationDetailInfoResponse.java
@@ -20,7 +20,7 @@ public record ReservationDetailInfoResponse(
     String startTime,
 
     @Schema(description = "촬영 시간", example = "1.5")
-    double durationTime,
+    Double durationTime,
 
     @Schema(description = "촬영 장소", example = "건국대")
     String place,

--- a/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationDetailProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationDetailProductResponse.java
@@ -17,7 +17,7 @@ public record ReservationDetailProductResponse(
     String title,
 
     @Schema(description = "평균 별점", example = "4.7")
-    double rate,
+    Double rate,
 
     @Schema(description = "리뷰 개수", example = "20")
     int reviewCount,

--- a/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationListItemResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationListItemResponse.java
@@ -15,7 +15,7 @@ public record ReservationListItemResponse(
     @Schema(description = "예약자명", example = "홍길동")
     String client,
 
-    @Schema(description = "예약 생성 일시", example = "2026-01-12 15:00:02")
+    @Schema(description = "예약 생성 일시", example = "2026-01-12 15:00")
     String createdAt,
 
     @Schema(description = "예약 상품 정보")

--- a/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationListProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationListProductResponse.java
@@ -17,7 +17,7 @@ public record ReservationListProductResponse(
     String title,
 
     @Schema(description = "평균 별점", example = "4.7")
-    double rate,
+    Double rate,
 
     @Schema(description = "리뷰 개수", example = "20")
     int reviewCount,

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
@@ -95,6 +95,17 @@ public class GetReservationDetailService implements GetReservationDetailUseCase 
         );
     }
 
+    private Double resolveAverageRating(ProductReviewStatsResult stats) {
+        if (stats == null || stats.reviewCount() == 0) {
+            return null;
+        }
+        return stats.averageRating();
+    }
+
+    private int resolveReviewCount(ProductReviewStatsResult stats) {
+        return stats == null ? 0 : Math.toIntExact(stats.reviewCount());
+    }
+
     private List<String> getMoodNames(Product product) {
         return productMoodRepository.findAllByProduct(product).stream()
             .map(pm -> pm.getMood().getName())

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
@@ -24,6 +24,7 @@ import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationD
 import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
 import org.sopt.snappinserver.domain.review.repository.ReviewPhotoRepository;
 import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
+import org.sopt.snappinserver.global.s3.S3Service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,6 +40,7 @@ public class GetReservationDetailService implements GetReservationDetailUseCase 
     private final ReviewRepository reviewRepository;
     private final ReviewPhotoRepository reviewPhotoRepository;
     private final ReservationAdditionalPaymentRepository reservationAdditionalPaymentRepository;
+    private final S3Service s3Service;
 
     @Override
     public GetReservationDetailResult getReservationDetail(Long userId, Long reservationId) {
@@ -72,7 +74,7 @@ public class GetReservationDetailService implements GetReservationDetailUseCase 
 
     private String getThumbnail(Product product) {
         return productPhotoRepository.findFirstByProductOrderByDisplayOrderAsc(product)
-            .map(pp -> pp.getPhoto().getImageUrl())
+            .map(pp -> pp.getPhoto().getImageUrl()).map(s3Service::getPresignedUrl)
             .orElse(null);
     }
 
@@ -87,8 +89,8 @@ public class GetReservationDetailService implements GetReservationDetailUseCase 
             product.getId(),
             getThumbnail(product),
             product.getTitle(),
-            stats != null ? stats.averageRating() : 0.0,
-            stats != null ? Math.toIntExact(stats.reviewCount()) : 0,
+            resolveAverageRating(stats),
+            resolveReviewCount(stats),
             product.getPhotographer().getName(),
             product.getPrice(),
             getMoodNames(product)
@@ -156,7 +158,9 @@ public class GetReservationDetailService implements GetReservationDetailUseCase 
                     reservation.getUser().getName(),
                     review.getRating(),
                     LocalDate.ofInstant(review.getCreatedAt(), KOREA_ZONE),
-                    photos.stream().map(rp -> rp.getPhoto().getImageUrl()).toList(),
+                    photos.stream().map(rp -> rp.getPhoto().getImageUrl())
+                        .map(s3Service::getPresignedUrl)
+                        .toList(),
                     review.getContent()
                 );
             })

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
@@ -31,7 +31,7 @@ public class GetReservationListService implements GetReservationListUseCase {
 
     private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter FORMATTER =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
     private final ReservationRepository reservationRepository;
     private final ReviewRepository reviewRepository;

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationDetailProductResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationDetailProductResult.java
@@ -6,7 +6,7 @@ public record GetReservationDetailProductResult(
     Long id,
     String imageUrl,
     String title,
-    double rate,
+    Double rate,
     int reviewCount,
     String photographer,
     int price,

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationListProductResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/dto/response/GetReservationListProductResult.java
@@ -6,7 +6,7 @@ public record GetReservationListProductResult(
     Long id,
     String imageUrl,
     String title,
-    double rate,
+    Double rate,
     int reviewCount,
     String photographer,
     int price,


### PR DESCRIPTION
## 👀 Summary

- close #127


## 🖇️ Tasks

- [x] 예약 목록 조회 시 예약 생성 시간 초 단위 제거
- [x] 예약 상세 / 촬영 내역 리뷰 조회 시 NPE 발생 오류 해결
- [x] 예약 상세 조회 시 예약 생성 시간 초 단위 제거
- [x] 예약 상세 조회 시 presigned url 적용

## 🔍 To Reviewer
### 예약 상세 조회 시 NPE 해결 과정
#### 문제 원인
상품 리뷰 통계 조회 시(AVG(rating)), 리뷰가 없는 경우 평균 평점이 null로 반환되고 있었고, 해당 값을 API 응답 DTO에서 double 타입으로 처리하면서 Double → double 자동 언박싱 과정에서 NPE가 발생했습니다.
기존 로직에서는 통계 객체(stats)의 null 여부만 확인하고 있어, 리뷰가 없는 경우(`reviewCount = 0`이면서 `averageRating = null`)를 고려하지 못하고 있었습니다.

#### 해결
리뷰 없음과 평점 0점을 의미적으로 구분하기 위해 평균 평점 타입을 Double로 유지했습니다. Service 계층에서 리뷰 stats 결과의 의미를 해석하도록 전용 변환 메서드를 추가했습니다. 리뷰 개수가 0인 경우 평균 평점을 null로 명시적으로 반환하도록 처리했습니다.

추가적으로 API 응답 DTO에서도 평균 평점 필드를 double에서 Double로 변경하여, null 값을 안전하게 표현할 수 있도록 수정했습니다.
