### PR TITLE
[FEAT] #125: 예약 상세 내역 조회 시 권한 검증 및 상태 변경 로직 추가

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
@@ -250,4 +250,11 @@ public class Reservation extends BaseEntity {
         this.reservationStatus = ReservationStatus.SHOOT_COMPLETED;
     }
 
+    public void PhotographerCheck() {
+        if (this.reservationStatus != ReservationStatus.RESERVATION_REQUESTED) {
+            return;
+        }
+        this.reservationStatus = ReservationStatus.PHOTOGRAPHER_CHECKING;
+    }
+
 }

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/domain/entity/Reservation.java
@@ -250,7 +250,7 @@ public class Reservation extends BaseEntity {
         this.reservationStatus = ReservationStatus.SHOOT_COMPLETED;
     }
 
-    public void PhotographerCheck() {
+    public void photographerCheck() {
         if (this.reservationStatus != ReservationStatus.RESERVATION_REQUESTED) {
             return;
         }

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
@@ -90,7 +90,7 @@ public class GetReservationDetailService implements GetReservationDetailUseCase 
             return;
         }
 
-        reservation.PhotographerCheck();
+        reservation.photographerCheck();
     }
 
 

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class GetReservationDetailService implements GetReservationDetailUseCase {
 
     private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
@@ -65,12 +65,34 @@ public class GetReservationDetailService implements GetReservationDetailUseCase 
         Reservation reservation = reservationRepository.findById(reservationId)
             .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
 
-        if (!reservation.isReservationClient(userId)) {
-            throw new ReservationException(ReservationErrorCode.RESERVATION_USER_NOT_MATCH);
-        }
+        validateAccessPermission(reservation, userId);
+        updateStatus(reservation, userId);
 
         return reservation;
     }
+
+    private void validateAccessPermission(Reservation reservation, Long loginUserId) {
+        if (reservation.isReservationClient(loginUserId)) {
+            return;
+        }
+
+        if (reservation.isReservationPhotographer(loginUserId)) {
+            return;
+        }
+
+        throw new ReservationException(
+            ReservationErrorCode.RESERVATION_USER_NOT_MATCH
+        );
+    }
+
+    private void updateStatus(Reservation reservation, Long loginUserId) {
+        if (!reservation.isReservationPhotographer(loginUserId)) {
+            return;
+        }
+
+        reservation.PhotographerCheck();
+    }
+
 
     private String getThumbnail(Product product) {
         return productPhotoRepository.findFirstByProductOrderByDisplayOrderAsc(product)


### PR DESCRIPTION
## 👀 Summary

- close #112 
- close #125 

예약 상세 및 촬영 내역 조회 API에서 접근 권한 검증 로직을 추가하고, 작가가 최초로 예약 상세를 조회하는 경우 예약 상태가 변경되도록 하는 로직을 추가했습니다.

## 🖇️ Tasks

- [x]  예약 상세/촬영 내역 조회 시 로그인 사용자 기준 권한 검증 로직 추가
- [x]  작가가 최초로 예약 상세 조회 시 예약 상태 변경 로직 추가


## 🔍 To Reviewer

### ❶ 예약 상세/촬영 내역 조회 시 권한 검증 로직 흐름

예약 상세 및 촬영 내역 조회 시, 해당 예약과 직접적인 관계가 있는 사용자만 조회 가능하도록 처리했습니다.

- 클라이언트: 본인이 예약한 예약만 조회 가능
- 작가: 해당 예약 상품의 작가인 경우에만 조회 가능

예약과 무관한 사용자가 접근할 경우 예외를 발생시키도록 구현했습니다.



### ❷ 작가 최초 조회 시 예약 상태 변경 로직 흐름

작가가 예약 상세를 최초로 조회하는 경우, 예약 상태가 `RESERVATION_REQUESTED`일 때만 PHOTOGRAPHER_CHECKING 상태로 변경되도록 처리했습니다.

상태 변경 규칙은 Reservation 엔티티에, 상태 변경 호출 조건은 Service에서 판단하도록 책임을 분리했습니다.

