### PR TITLE
[FIX] #158: 예약 목록 상품 이미지 중복 오류 해결

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
@@ -19,7 +19,11 @@ public interface ProductPhotoRepository extends JpaRepository<ProductPhoto, Long
             from ProductPhoto pp
             join fetch pp.photo ph
             where pp.product.id in :productIds
-              and pp.displayOrder = 1
+              and pp.displayOrder = (
+                  select min(pp2.displayOrder)
+                  from ProductPhoto pp2
+                  where pp2.product.id = pp.product.id
+              )
         """)
     List<ProductPhoto> findThumbnails(@Param("productIds") List<Long> productIds);
 


### PR DESCRIPTION
## 👀 Summary

- close #158 

예약 목록 조회 시 상품별 대표 이미지가 올바르게 매핑되지 않던 문제를 수정했습니다.

## 🖇️ Tasks

- [x] 상품별 썸네일 조회 쿼리 수정


## 🔍 To Reviewer
### 문제 원인
기존 썸네일 조회 쿼리는 `displayOrder = 1 `조건만으로 productIds에 해당하는 ProductPhoto들을 조회하고 있었는데, 이 방식은 상품별 대표 이미지 1장을 보장하는 쿼리가 아니라 단순히 displayOrder 값이 1인 값을 모두 가져오는 형태였습니다.

```java
@Query("""
    select pp
    from ProductPhoto pp
    join fetch pp.photo ph
    where pp.product.id in :productIds
      and pp.displayOrder = 1
""")
List<ProductPhoto> findThumbnails(@Param("productIds") List<Long> productIds);

```

그래서 예약 목록 조회에서 조회된 ProductPhoto 리스트를 `Map<productId, imageUrl>`로 변환하는 과정에서 하나의 상품에 대해 `displayOrder = 1`인 레코드가 여러 개 존재하거나 데이터가 누적/중복되면서 상품별 대표 이미지 조건이 깨진 경우 쿼리 결과가 상품 단위로 1장만 내려오지 않아 Map 변환 시 동일 이미지가 여러 상품에 매핑되는 문제가 발생했습니다.

### 해결

썸네일 조회 쿼리를 '상품별 대표 이미지 1장'이라는 의미를 충족하도록 수정했습니다. 구체적으로는 각 상품에 대해 최소 displayOrder를 갖는 사진만 조회하도록 서브쿼리를 추가하여, productIds를 조회하더라도 상품별로 대표 이미지가 1장만 반환되도록 했습니다.

```java
@Query("""
    select pp
    from ProductPhoto pp
    join fetch pp.photo ph
    where pp.product.id in :productIds
      and pp.displayOrder = (
          select min(pp2.displayOrder)
          from ProductPhoto pp2
          where pp2.product.id = pp.product.id
      )
""")
List<ProductPhoto> findThumbnails(@Param("productIds") List<Long> productIds);
```
이렇게 Repository 레벨에서 썸네일(대표 이미지)를 처리하고, Service 계층에서는 기존과 동일하게 `Map<productId, imageUrl>`로 변환하고 presigned url을 적용하는 흐름을 유지했습니다.
