### PR TITLE
[FIX] #149: 상품 목록 조회 시 장소, 작가 스케쥴 검색 조건 수정

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
@@ -3,8 +3,10 @@ package org.sopt.snappinserver.domain.product.repository;
 import static org.sopt.snappinserver.domain.mood.domain.entity.QMood.mood;
 import static org.sopt.snappinserver.domain.photo.domain.entity.QPhoto.photo;
 import static org.sopt.snappinserver.domain.photographer.domain.entity.QPhotographer.photographer;
+import static org.sopt.snappinserver.domain.photographer.domain.entity.QPhotographerSchedule.photographerSchedule;
+import static org.sopt.snappinserver.domain.portfolio.domain.entity.QPortfolio.portfolio;
+import static org.sopt.snappinserver.domain.portfolio.domain.entity.QPortfolioPlace.portfolioPlace;
 import static org.sopt.snappinserver.domain.product.domain.entity.QProduct.product;
-import static org.sopt.snappinserver.domain.product.domain.entity.QProductAvailableLocation.productAvailableLocation;
 import static org.sopt.snappinserver.domain.product.domain.entity.QProductMood.productMood;
 import static org.sopt.snappinserver.domain.product.domain.entity.QProductOption.productOption;
 import static org.sopt.snappinserver.domain.product.domain.entity.QProductPhoto.productPhoto;
@@ -21,6 +23,8 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +37,7 @@ import org.sopt.snappinserver.domain.product.domain.enums.ProductOptionCategory;
 import org.sopt.snappinserver.domain.product.service.dto.request.GetProductListQuery;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductCardResult;
 import org.sopt.snappinserver.global.enums.SnapCategory;
+import org.sopt.snappinserver.global.enums.WeekDay;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -118,6 +123,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                     snapCategoryEq(query.snapCategory()),
                     placeCondition(query.placeId()),
                     peopleCountCondition(query.peopleCount()),
+                    availableOnDate(query.date()),
                     moodCategoryGroupedCondition(moodGroupMap)
                 )
                 .groupBy(
@@ -174,11 +180,33 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
         return product.id.in(
             JPAExpressions
-                .select(productAvailableLocation.product.id)
-                .from(productAvailableLocation)
-                .where(productAvailableLocation.availableLocation.id.eq(placeId))
+                .select(portfolio.product.id)
+                .from(portfolio)
+                .join(portfolioPlace)
+                .on(portfolioPlace.portfolio.id.eq(portfolio.id))
+                .where(portfolioPlace.place.id.eq(placeId))
         );
     }
+
+    private BooleanExpression availableOnDate(LocalDate date) {
+        if (date == null) {
+            return null;
+        }
+
+        DayOfWeek dayOfWeek = date.getDayOfWeek();
+
+        return JPAExpressions
+            .selectOne()
+            .from(photographerSchedule)
+            .where(
+                photographerSchedule.photographer.id.eq(product.photographer.id),
+                photographerSchedule.weekDay.eq(WeekDay.from(dayOfWeek)),
+                photographerSchedule.dayOff.isTrue()
+            )
+            .notExists();
+    }
+
+
 
     private BooleanExpression peopleCountCondition(Integer peopleCount) {
         if (peopleCount == null) {
@@ -233,6 +261,10 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
         BooleanBuilder builder = new BooleanBuilder();
 
         for (Entry<MoodCategory, List<Long>> entry : moodGroupMap.entrySet()) {
+            if (entry.getValue() == null || entry.getValue().isEmpty()) {
+                continue;
+            }
+
             builder.and(
                 product.id.in(
                     JPAExpressions


### PR DESCRIPTION
## 👀 Summary

- close #149


## 🖇️ Tasks

- 상품 목록 조회 시 장소 검색 조건 수정
- 상품 목록 조회 시 작가 스케쥴 검색 조건 수정


## 🔍 To Reviewer

### ❶ 장소 검색 조건 관련
장소 검색 시, 기존 상품의 Available Location에 해당하는 Place로 검색한 결과를 반환했는데, 기획 측 요구사항에 따라 PortfolioPlace에서 해당 장소 Id와 연결된 Portfolio를 찾고, 해당 Portfolio와 연결된 Product를 찾아 보여주는 것으로 변환했습니다.


### ❷ 작가 스케쥴 검색 조건 관련
Product가 Photographer를 참조하고, Photorgrapher를 PhotographerSchuedule이 참조하고 있는 형태입니다. date를 입력받으면 PhotographerScedule에서 입력받은 date의 요일이 휴무일이 아닌 작가의 상품을 필터링 하여 보여줍니다.