### PR TITLE
[FIX] #165: 촬영 완료 / 리뷰 요청 시 작가 검증 추가

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationCompleteService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/PatchReservationCompleteService.java
@@ -13,18 +13,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class PatchReservationCompleteService
-    implements PatchReservationCompleteUseCase {
+public class PatchReservationCompleteService implements PatchReservationCompleteUseCase {
 
     private final ReservationRepository reservationRepository;
 
     @Override
     public CompleteReservationResult completeReservation(
-        Long photographerId,
+        Long userId,
         Long reservationId
     ) {
         Reservation reservation = getReservation(reservationId);
-        validateReservationPhotographer(photographerId, reservation);
+        validateReservationPhotographer(userId, reservation);
 
         reservation.completeShooting();
 
@@ -36,16 +35,14 @@ public class PatchReservationCompleteService
 
     private Reservation getReservation(Long reservationId) {
         return reservationRepository.findById(reservationId)
-            .orElseThrow(() -> new ReservationException(
-                ReservationErrorCode.RESERVATION_NOT_FOUND
-            ));
+            .orElseThrow(
+                () -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND)
+            );
     }
 
-    private void validateReservationPhotographer(Long photographerId, Reservation reservation) {
-        if (!reservation.isReservationClient(photographerId)) {
-            throw new ReservationException(
-                ReservationErrorCode.RESERVATION_USER_NOT_MATCH
-            );
+    private void validateReservationPhotographer(Long userId, Reservation reservation) {
+        if (!reservation.isReservationPhotographer(userId)) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_USER_NOT_MATCH);
         }
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/PatchReservationCompleteUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/usecase/PatchReservationCompleteUseCase.java
@@ -5,7 +5,7 @@ import org.sopt.snappinserver.domain.reservation.service.dto.response.CompleteRe
 public interface PatchReservationCompleteUseCase {
 
     CompleteReservationResult completeReservation(
-        Long photographerId,
+        Long userId,
         Long reservationId
     );
 }


### PR DESCRIPTION
## 👀 Summary

- close #165

## 🖇️ Tasks

- 촬영 완료 / 리뷰 요청 API에서 유저 ID를 받아 예약과 연결된 상품의 작가 ID와 비교하던 문제를 수정했습니다.


## 🔍 To Reviewer

- 서비스 메서드 파라미터 변경
- 예약 검증 시 Client로 비교하는 것을 Photographer로 비교하도록 변경
