### PR TITLE
[PERF] #175: AI 무드 큐레이션 이미지 캐싱

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/GetAllCurationQuestionService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/GetAllCurationQuestionService.java
@@ -17,7 +17,7 @@ import org.sopt.snappinserver.domain.question.domain.enums.QuestionDomain;
 import org.sopt.snappinserver.domain.question.repository.QuestionPhotoRepository;
 import org.sopt.snappinserver.domain.question.repository.QuestionRepository;
 import org.sopt.snappinserver.domain.user.repository.UserRepository;
-import org.sopt.snappinserver.global.s3.S3Service;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +29,9 @@ public class GetAllCurationQuestionService implements GetAllCurationQuestionUseC
     private final UserRepository userRepository;
     private final QuestionRepository questionRepository;
     private final QuestionPhotoRepository questionPhotoRepository;
-    private final S3Service s3Service;
+
+    @Value("${cloud.aws.cloud-front.domain}")
+    private String cloudFrontDomain;
 
     @Override
     public GetAllCurationQuestionResult getAllCurationQuestions(Long userId) {
@@ -79,10 +81,9 @@ public class GetAllCurationQuestionService implements GetAllCurationQuestionUseC
         return questionPhotos.stream()
             .map(questionPhoto -> {
                 Photo photo = questionPhoto.getPhoto();
-                String presignedUrl = s3Service.getPresignedUrl(photo.getImageUrl());
                 return new GetPhotoResult(
                     photo.getId(),
-                    presignedUrl,
+                    cloudFrontDomain.concat(photo.getImageUrl()),
                     questionPhoto.getDisplayOrder()
                 );
             })

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -45,3 +45,5 @@ cloud:
       static: ${AWS_REGION}
     s3:
       bucket: ${S3_BUCKET}
+    cloud-front:
+      domain: ${CLOUD_FRONT_DOMAIN}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -45,3 +45,5 @@ cloud:
       static: ${AWS_REGION}
     s3:
       bucket: ${S3_BUCKET}
+    cloud-front:
+      domain: ${CLOUD_FRONT_DOMAIN}


### PR DESCRIPTION
## 👀 Summary

- close #175


## 🖇️ Tasks

- cloudFront S3와 연결
- 기존 presigned URL 로 반환되는 사진 URL을 CloudFront 도메인 + S3 Key 값 구조로 변경

## 🔍 To Reviewer

## 📄 Tasks

### AI Curation 이미지 성능 최적화

### 기존: Step 별 이미지 개별 요청

> 각 step 진입 시 서버로부터 해당 step의 이미지를 요청
> step 이동 시마다 네트워크 요청 발생 

`평균 이미지 로드 속도 = 934ms`

<img width="1007" height="85" alt="스크린샷 2026-01-20 오후 4 33 23" src="https://github.com/user-attachments/assets/086ea344-f0ba-4301-985b-9f2c3f2431d5" />

### 1차 개선 = 약 18% 성능 개선

```
웹 & 서버) 이미지 일괄 요청 + Prefetch 적용

최초 진입 시 모든 step 이미지 한 번에 요청 (step 전환 시 추가 네트워크 요청 제거)
-> step 이동 시 네트워크 대기 제거
```

`평균 이미지 로드 속도 = 767ms`

<img width="1009" height="89" alt="스크린샷 2026-01-20 오후 4 27 13" src="https://github.com/user-attachments/assets/c5bf9882-e646-4e99-a05f-26bd174b5392" />

### 2차 = 약 24.6% 성능 개선

`웹) Image 태그에 priority, unoptimized 추가`

```
<Image
  src={imageUrl}
  priority
  unoptimized
  ...
/>
```

`평균 이미지 로드 속도 = 702.5ms`

### priority + unoptimized 조합을 적용한 이유

AI Curation 화면의 이미지들은 UX 관점에서 즉시 노출되어야 하는 핵심 콘텐츠이지만, Next.js의 기본 이미지 최적화 파이프라인과는 성격이 맞지 않는 특성을 가지고 있습니다.

이미지 컴포넌트는 기본적으로 lazy loading이 적용되기 때문에, step 진입 시 이미지 로딩 지연이 발생할 수 있어 priority 옵션을 통해 지연 로딩을 비활성화하고 preload 되도록 처리했습니다.

또한 해당 이미지들은 이미 CDN을 통해 최적화된 외부 이미지이므로, 
Next.js Image Optimization 서버를 거칠 경우

- 추가 네트워크 홉 발생
- 불필요한 리사이징 / 포맷 변환 비용 증가

로 인해 step 전환 UX에 오히려 지연이 발생할 수 있다고 판단했습니다.

이에 따라 unoptimized 옵션을 적용하여 Next.js 이미지 최적화 파이프라인을 우회하고, CDN → 브라우저로 직접 전달되도록 하여 네트워크 비용, 서버 부담을 최소화했습니다.

<img width="1000" height="88" alt="스크린샷 2026-01-20 오후 4 41 11" src="https://github.com/user-attachments/assets/8f5d212f-d6b6-4664-8058-b32eb58f3bef" />

### 3차  = 90.0% 개선

`서버) presigned URL 대신 CloudFront 도메인 + S3 Key로 이미지 캐싱`

기존에는 이미지 조회 시 presigned URL 로 조회하여 이미지 조회 시 클라이언트 - 서버 - DB 간의 소통이 줄어든다는 특성이 있었습니다. 하지만 presigend URL로 보낼 경우, 쿼리 파라미터가 매번 달라져서 캐싱이 되지 않는 문제가 있습니다. 따라서 CloudFront를 사용하여 전세계 엣지 로케이션에서 바로 이미지를 내려줄 수 있고, S3 -> CloudFront 캐시 히트 시 S3 Get, 네트워크 비용이 줄어든다는 장점을 적용할 수 있도록 했습니다.

<img width="886" height="85" alt="스크린샷 2026-01-20 오후 6 07 22" src="https://github.com/user-attachments/assets/6d2153c2-f9a6-4b93-86ea-ba1b6a1d2a95" />

`평균 이미지 로드 속도 = 9ms`