### PR TITLE
[FIX] #184: 예약 가능 시간대 조회 API 응답 스펙 변경

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/ProductAvailableTimeSectionResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/ProductAvailableTimeSectionResponse.java
@@ -1,0 +1,14 @@
+package org.sopt.snappinserver.api.v1.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "오전/오후 시간대 섹션 DTO")
+public record ProductAvailableTimeSectionResponse(
+
+    @Schema(description = "시간대 구분", example = "am")
+    String label,
+
+    @Schema(description = "해당 시간대 슬롯 목록")
+    List<ProductAvailableTimeResponse> slots
+) {}

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/ProductAvailableTimesResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/ProductAvailableTimesResponse.java
@@ -1,27 +1,45 @@
 package org.sopt.snappinserver.api.v1.product.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductAvailableTimesResult;
 
-@Schema(description = "상품 예약 가능 시간대 목록 응답 DTO")
+@Schema(description = "상품 예약 가능 시간대 응답 DTO")
 public record ProductAvailableTimesResponse(
 
     @Schema(description = "조회 기준 날짜", example = "2026-03-15")
     String date,
 
-    @Schema(description = "시간대별 예약 가능 여부 목록")
-    List<ProductAvailableTimeResponse> times
+    @Schema(description = "오전/오후 시간대 목록")
+    List<ProductAvailableTimeSectionResponse> sections
 ) {
 
     public static ProductAvailableTimesResponse from(
         ProductAvailableTimesResult result
     ) {
-        return new ProductAvailableTimesResponse(
-            result.date().toString(),
+        Map<Boolean, List<ProductAvailableTimeResponse>> partitioned =
             result.times().stream()
                 .map(ProductAvailableTimeResponse::from)
-                .toList()
+                .collect(
+                    java.util.stream.Collectors.partitioningBy(
+                        slot -> LocalTime.parse(slot.time()).isBefore(LocalTime.NOON)
+                    )
+                );
+
+        return new ProductAvailableTimesResponse(
+            result.date().toString(),
+            List.of(
+                new ProductAvailableTimeSectionResponse(
+                    "am",
+                    partitioned.getOrDefault(true, List.of())
+                ),
+                new ProductAvailableTimeSectionResponse(
+                    "pm",
+                    partitioned.getOrDefault(false, List.of())
+                )
+            )
         );
     }
 }


### PR DESCRIPTION
## 👀 Summary

- close #184 

촬영 가능 시간대 조회 API 응답 스펙을 변경했습니다.


## 🖇️ Tasks

- [x] 예약 가능 시간대 조회 응답 DTO 구조 변경
- [x] 예약 가능 시간대 조회 오전/오후 섹션 DTO 추가

## 🔍 To Reviewer
### ❶ Response 변경사항
프론트(TimePicker) 요구사항에 맞춰 예약 가능 시간대 응답 구조를 변경했습니다.

```java
{
  "date": "2026-03-15",
  "sections": [
    {
      "label": "am",
      "slots": [{ "time": "09:00", "isAvailable": true }]
    },
    {
      "label": "pm",
      "slots": [{ "time": "13:30", "isAvailable": false }]
    }
  ]
}

```

- "am" / "pm" 고정 값
- 작가 업무 시간 내의 모든 30분 단위 슬롯을 포함
- 예약이 존재하는 시간대만 isAvailable = false
- 업무 시간 밖 슬롯은 아예 응답에 포함하지 않음

도메인 로직은 그대로 유지하고, 응답 계층(API DTO)에서만 구조를 변환했습니다.


### ❷ 시간대 판단 로직 관련

time 필드는 예약 시작 시각을 의미합니다.
상품의 촬영 시간(DURATION_TIME)을 고려하여 `촬영 종료 시각 ≤ 작가 업무 종료 시각` 인 경우에만 슬롯을 생성하고, 겹침 판단은 시작 시간이 아닌 ‘시간 구간 단위’로 처리합니다.

> 09:00 ~ 09:30 예약이 있는 경우, 09:30 슬롯은 예약 가능(true)
끝나는 시각과 시작 시각이 맞닿는 경우는 겹치는 경우로 치지 않으니 이 점 참고해주세요!

### ❸ 타임존 이슈 정리

기존 더미 데이터가 +00:00(UTC) 기준으로 들어가 있어
날짜/시간 비교가 어긋나는 문제가 있었습니다.


더미 데이터 및 조회 기준을 LocalDateTime (KST 기준) 으로 통일


date.atStartOfDay()

date.plusDays(1).atStartOfDay()
로 하루 범위 정확히 조회

추후 타임존 확장이 필요해질 경우에만
ZonedDateTime 또는 UTC 통합을 검토하는 방향이 적절하다고 판단했습니다.
