### PR TITLE
[FIX] #186: 프로필 전환 시 리프레시 토큰 required = false 추가

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserController.java
@@ -56,7 +56,7 @@ public class UserController implements UserApi {
     @PatchMapping("/role")
     public ApiResponseBody<GetSwitchedUserProfileResponse, Void> patchUserRole(
         @AuthenticationPrincipal CustomUserInfo userInfo,
-        @CookieValue(name = "refreshToken") String refreshToken,
+        @CookieValue(name = "refreshToken", required = false) String refreshToken,
         @RequestHeader(value = "User-Agent", required = false) String userAgent,
         HttpServletResponse httpServletResponse
     ) {


### PR DESCRIPTION
## 👀 Summary

- close #186


## 🖇️ Tasks

- 프로필 전환 시 리프레시 토큰 nullable을 추가했습니다.

## 🔍 To Reviewer

-
