### PR TITLE
[FIX] #189: 상품 목록 조회 소수점 오류 수정

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
@@ -104,7 +104,11 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         product.id,
                         photo.imageUrl,
                         product.title,
-                        review.rating.avg().coalesce(0.0),
+                        Expressions.numberTemplate(
+                            Double.class,
+                            "round({0}, 1)",
+                            review.rating.avg().coalesce(0.0)
+                        ),
                         review.id.countDistinct(),
                         photographer.nickname,
                         product.price

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductListService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductListService.java
@@ -15,7 +15,7 @@ import org.sopt.snappinserver.domain.product.service.dto.response.CursorMeta;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductCardResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductListResult;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductListUseCase;
-import org.sopt.snappinserver.global.s3.S3Service;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,7 +28,9 @@ public class GetProductListService implements GetProductListUseCase {
 
     private final ProductRepositoryCustom productRepository;
     private final MoodRepository moodRepository;
-    private final S3Service s3Service;
+
+    @Value("${cloud.aws.cloud-front.domain}")
+    private String cloudFrontDomain;
 
     public GetProductListResult getProductList(GetProductListQuery query) {
         Map<MoodCategory, List<Long>> moodGroupMap = groupByCategory(query.moodIds());
@@ -38,7 +40,7 @@ public class GetProductListService implements GetProductListUseCase {
             results.stream()
                 .map(result -> {
                     String presignedUrl = (result.imageUrl() != null && !result.imageUrl().isBlank())
-                        ? s3Service.getPresignedUrl(result.imageUrl())
+                        ? cloudFrontDomain + result.imageUrl()
                         : null;
 
                     return new GetProductCardResult(


### PR DESCRIPTION
## 👀 Summary

- close #189


## 🖇️ Tasks

- 상품 목록 조회 소수점 무한대로 나오는 오류를 수정했습니다.


## 🔍 To Reviewer

QueryDSL에서 Return 값 자체를 Double로 보내고 있어서 jpa 쿼리와는 다르게 double로 캐스팅하지 않아도 될 것 같습니다!
