### PR TITLE
[FEAT] #188: 상품 촬영 시간 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductApi.java
@@ -14,6 +14,7 @@ import org.sopt.snappinserver.api.v1.product.dto.response.GetProductListMeta;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetProductListResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.ProductAvailableTimesResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.ProductClosedDatesResponse;
+import org.sopt.snappinserver.api.v1.product.dto.response.ProductDurationTimeResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.ProductPeopleRangeResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.ProductReservationResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.ProductReviewsMetaResponse;
@@ -57,6 +58,20 @@ public interface ProductApi {
         @Schema(description = "상품 아이디", example = "1")
         @PathVariable @NotNull Long productId
     );
+
+    @Operation(
+        summary = "촬영 시간 조회",
+        description = "예약 과정에서 상품의 촬영 시간을 조회합니다."
+    )
+    @GetMapping("/{productId}/available/duration-time")
+    ApiResponseBody<ProductDurationTimeResponse, Void> getProductDurationTime(
+        @Parameter(hidden = true)
+        CustomUserInfo principal,
+
+        @Schema(description = "상품 아이디", example = "1")
+        @PathVariable @NotNull Long productId
+    );
+
 
     @Operation(
         summary = "달별 휴무일 목록 조회",

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductController.java
@@ -3,6 +3,9 @@ package org.sopt.snappinserver.api.v1.product.controller;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.v1.product.dto.response.ProductDurationTimeResponse;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductDurationTimeResult;
+import org.sopt.snappinserver.domain.product.service.usecase.GetProductDurationTimeUseCase;
 import org.sopt.snappinserver.global.response.code.product.ProductSuccessCode;
 import org.sopt.snappinserver.api.v1.product.dto.request.ProductReservationRequest;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetProductDetailResponse;
@@ -51,6 +54,7 @@ public class ProductController implements ProductApi {
     private final PostProductReservationUseCase postProductReservationUseCase;
     private final GetProductDetailUseCase getProductDetailUseCase;
     private final GetProductListUseCase getProductListUseCase;
+    private final GetProductDurationTimeUseCase getProductDurationTimeUseCase;
 
     @Override
     public ApiResponseBody<ProductReviewsResponse, ProductReviewsMetaResponse> getProductReviews(
@@ -78,6 +82,20 @@ public class ProductController implements ProductApi {
         return ApiResponseBody.ok(
             ProductSuccessCode.GET_PRODUCT_PEOPLE_RANGE_OK,
             ProductPeopleRangeResponse.from(result)
+        );
+    }
+
+    @Override
+    public ApiResponseBody<ProductDurationTimeResponse, Void> getProductDurationTime(
+        @AuthenticationPrincipal CustomUserInfo principal,
+        Long productId
+    ) {
+        ProductDurationTimeResult result =
+            getProductDurationTimeUseCase.getProductDurationTime(productId);
+
+        return ApiResponseBody.ok(
+            ProductSuccessCode.GET_PRODUCT_DURATION_TIME_OK,
+            ProductDurationTimeResponse.from(result)
         );
     }
 

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/ProductDurationTimeResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/ProductDurationTimeResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.snappinserver.api.v1.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductDurationTimeResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductPeopleRangeResult;
+
+@Schema(description = "상품 촬영 시간 조회 응답 DTO")
+public record ProductDurationTimeResponse(
+
+    @Schema(description = "촬영 최소 시간", example = "1")
+    double minDurationTime
+) {
+
+    public static ProductDurationTimeResponse from(ProductDurationTimeResult result) {
+        return new ProductDurationTimeResponse(result.minDurationTime());
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/domain/exception/ProductErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/domain/exception/ProductErrorCode.java
@@ -35,10 +35,12 @@ public enum ProductErrorCode implements ErrorCode {
     // 404 NOT FOUND
     PRODUCT_NOT_FOUND(404, "PRODUCT_404_001", "존재하지 않는 상품입니다."),
     PRODUCT_PEOPLE_RANGE_NOT_FOUND(404, "PRODUCT_404_002", "촬영 가능 인원 정보가 존재하지 않습니다."),
+    PRODUCT_DURATION_TIME_NOT_FOUND(404, "PRODUCT_404_003", "촬영 시간 정보가 존재하지 않습니다."),
 
     // 500 SERVER ERROR
     INVALID_PRODUCT_OPTION_FORMAT(500, "PRODUCT_500_001", "상품 옵션 데이터 형식이 올바르지 않습니다."),
-    INVALID_PRODUCT_PEOPLE_RANGE(500, "PRODUCT_500_002", "최대/최소 인원 수가 유효한 값이 아닙니다.");
+    INVALID_PRODUCT_PEOPLE_RANGE(500, "PRODUCT_500_002", "최대/최소 인원 수가 유효한 값이 아닙니다."),
+    INVALID_PRODUCT_DURATION_TIME(500, "PRODUCT_500_003", "최소 촬영 시간이 유효한 값이 아닙니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductOptionRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductOptionRepository.java
@@ -20,4 +20,9 @@ public interface ProductOptionRepository extends JpaRepository<ProductOption, Lo
     );
 
     List<ProductOption> findByProduct(Product product);
+
+    Optional<ProductOption> findByProductIdAndProductOptionCategory(
+        Long productId,
+        ProductOptionCategory category
+    );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductDurationTimeService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductDurationTimeService.java
@@ -40,6 +40,14 @@ public class GetProductDurationTimeService
 
 
     private int parseDurationTime(ProductOption option) {
+        String answer = option.getAnswer();
+
+        if (answer == null || answer.isBlank()) {
+            throw new ProductException(
+                ProductErrorCode.INVALID_PRODUCT_DURATION_TIME
+            );
+        }
+
         try {
             return Integer.parseInt(option.getAnswer());
         } catch (NumberFormatException e) {

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductDurationTimeService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductDurationTimeService.java
@@ -1,0 +1,63 @@
+package org.sopt.snappinserver.domain.product.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.product.domain.entity.ProductOption;
+import org.sopt.snappinserver.domain.product.domain.enums.ProductOptionCategory;
+import org.sopt.snappinserver.domain.product.domain.exception.ProductErrorCode;
+import org.sopt.snappinserver.domain.product.domain.exception.ProductException;
+import org.sopt.snappinserver.domain.product.repository.ProductOptionRepository;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductDurationTimeResult;
+import org.sopt.snappinserver.domain.product.service.usecase.GetProductDurationTimeUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetProductDurationTimeService
+    implements GetProductDurationTimeUseCase {
+
+    private final ProductOptionRepository productOptionRepository;
+
+    @Override
+    public ProductDurationTimeResult getProductDurationTime(Long productId) {
+        ProductOption option = productOptionRepository
+            .findByProductIdAndProductOptionCategory(
+                productId,
+                ProductOptionCategory.DURATION_TIME
+            )
+            .orElseThrow(() ->
+                new ProductException(ProductErrorCode.PRODUCT_DURATION_TIME_NOT_FOUND)
+            );
+
+        int durationMinutes = parseDurationTime(option);
+        validateDurationTime(durationMinutes);
+
+        double durationHours = convertMinutesToHours(durationMinutes);
+
+        return new ProductDurationTimeResult(durationHours);
+    }
+
+
+    private int parseDurationTime(ProductOption option) {
+        try {
+            return Integer.parseInt(option.getAnswer());
+        } catch (NumberFormatException e) {
+            throw new ProductException(
+                ProductErrorCode.INVALID_PRODUCT_OPTION_FORMAT
+            );
+        }
+    }
+
+    private void validateDurationTime(int durationTime) {
+        if (durationTime <= 0) {
+            throw new ProductException(
+                ProductErrorCode.INVALID_PRODUCT_DURATION_TIME
+            );
+        }
+    }
+
+    private double convertMinutesToHours(int minutes) {
+        return minutes / 60.0;
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductDurationTimeResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductDurationTimeResult.java
@@ -1,0 +1,5 @@
+package org.sopt.snappinserver.domain.product.service.dto.response;
+
+public record ProductDurationTimeResult(double minDurationTime) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductDurationTimeUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetProductDurationTimeUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.product.service.usecase;
+
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductDurationTimeResult;
+
+public interface GetProductDurationTimeUseCase {
+    ProductDurationTimeResult getProductDurationTime(Long productId);
+
+}

--- a/src/main/java/org/sopt/snappinserver/global/response/code/product/ProductSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/product/ProductSuccessCode.java
@@ -16,6 +16,7 @@ public enum ProductSuccessCode implements SuccessCode {
     GET_PRODUCT_DETAIL_OK(200, "PRODUCT_200_005", "상품 상세 조회에 성공했습니다."),
     GET_PRODUCT_PRICE_OK(200, "PRODUCT_200_006", "상품 기본 촬영 비용 조회에 성공했습니다."),
     GET_PRODUCT_LIST_OK(200, "PRODUCT_200_007", "상품 목록 조회에 성공했습니다."),
+    GET_PRODUCT_DURATION_TIME_OK(200, "PRODUCT_200_008", "상품의 촬영 시간 조회에 성공했습니다."),
 
     // 201 CREATED
     POST_PRODUCT_RESERVATION_OK(201, "PRODUCT_201_001", "상품 예약 생성에 성공했습니다.");


### PR DESCRIPTION
## 👀 Summary

- close #188

예약 과정에서 상품의 촬영 가능 시간을 조회하는 API를 구현했습니다.

## 🖇️ Tasks

- [x]  촬영 가능 시간 조회 API 엔드포인트 추가
- [x]  상품 옵션 카테고리 기반 조회 Repository 메서드 구현
- [x]  촬영 시간 조회 UseCase / Service 분리
- [x]  도메인 결과 DTO 추가
- [x]  에러 및 성공 코드 추가


## 🔍 To Reviewer

가장 기본적인 조회 로직이라 별다른 이슈 없습니다.