### PR TITLE
[FIX] #192: 예약하기 API 시작시간 Schema 타입 변경

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/request/ProductReservationRequest.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/request/ProductReservationRequest.java
@@ -12,7 +12,7 @@ public record ProductReservationRequest(
     @Schema(description = "촬영 희망 날짜", example = "2026-03-15")
     @NotNull LocalDate date,
 
-    @Schema(description = "촬영 시작 시간", example = "10:00")
+    @Schema(description = "촬영 시작 시간", example = "10:00", type = "string", format = "time")
     @NotNull LocalTime startTime,
 
     @Schema(description = "촬영 시간 (0.5시간 단위)", example = "2.5")


### PR DESCRIPTION
## 👀 Summary

- close #192 

예약하기 API의 Request Body에서 시작시간 필드의 Schema 타입을 변경했습니다.

## 🖇️ Tasks

- [x]  예약 요청 DTO의 startTime 필드에 OpenAPI 스키마 타입 명시

## 🔍 To Reviewer

클라이언트 측에서 Swagger 스키마를 기준으로 타입을 자동 생성하는 과정에서 LocalTime 필드가 객체 형태(hour/minute/second/nano)로 노출되면서 요청 타입 불일치 문제가 발생했습니다. 실제 API에서는 "10:00"과 같은 문자열 형태로 요청을 받고 있었지만, Swagger 문서 상 표현이 이를 정확히 반영하지 못하고 있어 발생한 문제입니다!

따라서 Swagger 표현을 string (time)으로 명시하여 실제 요청 포맷과 문서/타입 정의를 일치시키는 방향으로 수정했습니다.
