### PR TITLE
[FIX] #196: 위시 목록 최신순 정렬

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishPortfolioRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishPortfolioRepository.java
@@ -13,5 +13,5 @@ public interface WishPortfolioRepository extends JpaRepository<WishPortfolio, Lo
 
     Optional<WishPortfolio> findByUserAndPortfolio(User user, Portfolio portfolio);
 
-    List<WishPortfolio> findAllByUser(User user);
+    List<WishPortfolio> findAllByUserOrderByCreatedAtDesc(User user);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishProductRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishProductRepository.java
@@ -16,11 +16,14 @@ public interface WishProductRepository extends JpaRepository<WishProduct, Long> 
     Optional<WishProduct> findByUserAndProduct(User user, Product product);
 
     @Query("""
-        select wp
-        from WishProduct wp
-        join fetch wp.product p
-        join fetch p.photographer
-        where wp.user = :user
-    """)
-    List<WishProduct> findAllByUserWithProduct(@Param("user") User user);
+            select wp
+            from WishProduct wp
+            join fetch wp.product p
+            join fetch p.photographer
+            where wp.user = :user
+            order by wp.createdAt desc
+        """)
+    List<WishProduct> findAllByUserWithProductOrderByCreatedAtDesc(
+        @Param("user") User user
+    );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
@@ -45,7 +45,7 @@ public class GetWishedPortfoliosService implements GetWishedPortfoliosUseCase {
 
     private List<WishedPortfolioResult> getWishedPortfolioResults(User user) {
         return wishPortfolioRepository
-            .findAllByUser(user)
+            .findAllByUserOrderByCreatedAtDesc(user)
             .stream()
             .map(WishPortfolio::getPortfolio)
             .map(this::mapToWishedPortfolioResult)

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsService.java
@@ -50,7 +50,7 @@ public class GetWishedProductsService implements GetWishedProductsUseCase {
 
     private List<WishedProductResult> getWishedProductResults(User user) {
         return wishProductRepository
-            .findAllByUserWithProduct(user)
+            .findAllByUserWithProductOrderByCreatedAtDesc(user)
             .stream()
             .map(WishProduct::getProduct)
             .map(this::mapToWishedProductResult)


### PR DESCRIPTION
## 👀 Summary

- close #196

위시 상품/포트폴리오 목록을 좋아요한 최신순으로 정렬하도록 조회 로직을 추가했습니다.


## 🖇️ Tasks

- [x] 포트폴리오 위시 목록 최신순(createdAt DESC) 정렬 적용
- [x] 상품 위시 목록 최신순(createdAt DESC) 정렬 적용

## 🔍 To Reviewer

위시 목록은 포트폴리오/상품 자체의 생성 시점이 아닌 사용자의 '좋아요’ 시점이 의미를 갖는 도메인인이기 때문에  WishPortfolio, WishProduct의 createdAt을 기준으로 최신순 정렬하도록 수정했습니다.

정렬 책임은 Repository 계층에 두고, Service에서는 정렬 로직 없이 조회 결과 변환만 수행하도록 했습니다.
