### PR TITLE
[FIX] #199: 예약 불가능 상태 변경

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
@@ -66,7 +66,7 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
         }
 
         List<LocalTime> slots = createTimeSlots(workStart, lastStartTime);
-        List<Reservation> reservations = getConfirmedReservations(date, product);
+        List<Reservation> reservations = getBlockedReservations(date, product);
         List<ProductAvailableTimeResult> results = getProductAvailableTimeResults(
             slots,
             reservations,
@@ -118,7 +118,7 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
     }
 
     // 시간 슬롯별 예약 가능 여부 계산
-    private List<Reservation> getConfirmedReservations(LocalDate date, Product product) {
+    private List<Reservation> getBlockedReservations(LocalDate date, Product product) {
         LocalDateTime startOfDay = date.atStartOfDay();
         LocalDateTime endOfDay = date.plusDays(ONE_DAY).atStartOfDay();
 
@@ -126,7 +126,13 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
             product,
             startOfDay,
             endOfDay,
-            List.of(ReservationStatus.RESERVATION_CONFIRMED, ReservationStatus.SHOOT_COMPLETED)
+            List.of(
+                ReservationStatus.RESERVATION_REQUESTED,
+                ReservationStatus.PHOTOGRAPHER_CHECKING,
+                ReservationStatus.PAYMENT_REQUESTED,
+                ReservationStatus.RESERVATION_CONFIRMED,
+                ReservationStatus.SHOOT_COMPLETED
+            )
         );
     }
 


### PR DESCRIPTION
## 👀 Summary

- close #199 

예약 요청이 발생한 시점부터 해당 시간대를 예약 가능 시간 목록에서 즉시 예약 마감(불가능) 상태로 처리하도록 수정했습니다.


## 🖇️ Tasks

- [x] 예약 요청(RESERVATION_REQUESTED) 상태부터 시간대 점유 처리
- [x]  예약 가능 시간 조회 API에서 예약 가능 상태 필터링 기준 수정


## 🔍 To Reviewer

### 문제

예약하기 버튼을 누르기 전에 available-times API를 통해 특정 시간대가 가능하다고 판단하는 동시에  다른 사용자가 동일 시간대에 예약 요청을 보내는 경우 중복 예약이 발생할 수 있는 에러가 발생했습니다.

따라서 예약 생성 시점에 서버에서 한 번 더 시간대 충돌을 검증해야 한다고 판단했는데, 검토 과정에서 확인해보니 예약 요청 시점부터 시간대를 점유하고 있긴 했지만 available-times API에서는 해당 예약 상태를 고려하지 않아 이미 예약된 시간대가 다시 노출되는 문제가 있었습니다.

- 예약 생성 시점에는 시간대를 점유하고 있음
-  예약 가능 시간 조회에서는 RESERVATION_CONFIRMED 상태만 기준으로 필터링

### 해결

#### 예약 생성 시점

예약 생성 전에 서버 단에서 기존 예약과 시간 구간이 겹치는지 검증하고, 겹치는 경우 예외(409 CONFLICT)를 발생시킵니다.

#### 예약 가능 시간 조회 시점

예약 불가능 시간대를 판단하는 예약 상태를 아래 값들로 확장했습니다.

- `RESERVATION_REQUESTED`
- `PHOTOGRAPHER_CHECKING`
- `PAYMENT_REQUESTED`
- `RESERVATION_CONFIRMED`
- `SHOOT_COMPLETED`

예약 요청이 들어온 순간부터 해당 시간대는 더 이상 예약 가능 슬롯으로 노출되지 않도록 했습니다.

### SHOOT_COMPLETED 상태 포함

SHOOT_COMPLETED는 대부분 과거 예약이지만 '이 시간대는 실제로 예약되었던 시간대'라는 의미를 명확히 하고 ,예약 기준을 상태 기반으로 일관되게 유지하기 위해 예약 가능 시간대 계산 시 기준으로 포함하도록 했습니다. 

다만, 앞서 언급했다시피 과거의 예약에 해당하기 때문에 로직이나 기능적으로는 영향이 없다고 판단했으니 이 점 참고 부탁드립니다.
