### PR TITLE
[FIX] #197: 프로필 이미지 기본 이미지로 변경, 유저 조회 시 작가 프로필 보유 여부 오류 수정

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/auth/service/GetSocialUserService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/auth/service/GetSocialUserService.java
@@ -23,16 +23,15 @@ public class GetSocialUserService {
     public User registerOrGetUser(
         SocialProvider socialProvider,
         String providerId,
-        String name,
-        String profileImage
+        String name
     ) {
         return authProviderRepository.findBySocialProviderAndProviderId(socialProvider, providerId)
             .map(AuthProvider::getUser)
-            .orElseGet(() -> createUser(providerId, name, profileImage));
+            .orElseGet(() -> createUser(providerId, name));
     }
 
-    private User createUser(String providerId, String name, String profileImage) {
-        User user = userRepository.save(User.create(UserRole.CLIENT, name, profileImage));
+    private User createUser(String providerId, String name) {
+        User user = userRepository.save(User.create(UserRole.CLIENT, name, null));
         authProviderRepository.save(AuthProvider.create(user, KAKAO, providerId));
 
         return user;

--- a/src/main/java/org/sopt/snappinserver/domain/auth/service/LoginService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/auth/service/LoginService.java
@@ -31,8 +31,7 @@ public class LoginService implements LoginUseCase {
         User user = getSocialUserService.registerOrGetUser(
             KAKAO,
             kakaoUserInfo.socialId(),
-            kakaoUserInfo.nickname(),
-            kakaoUserInfo.profileImage()
+            kakaoUserInfo.nickname()
         );
         TokenPair tokenPair = authTokenManager.issueTokenPair(user, userAgent);
 

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetRandomPhotographersService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetRandomPhotographersService.java
@@ -31,7 +31,7 @@ public class GetRandomPhotographersService implements GetRandomPhotographersUseC
             .map(photographer -> {
                 String profileImageUrl = (photographer.getUser().getProfileImageUrl() == null)
                     ? cloudFrontDomain + baseProfileImageKey
-                    : photographer.getUser().getProfileImageUrl();
+                    : cloudFrontDomain + photographer.getUser().getProfileImageUrl();
                 List<PhotographerSpecialty> specialties = photographerSpecialtyRepository
                     .findAllByPhotographer(photographer);
 

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetRandomPhotographersService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetRandomPhotographersService.java
@@ -8,6 +8,7 @@ import org.sopt.snappinserver.domain.photographer.repository.PhotographerReposit
 import org.sopt.snappinserver.domain.photographer.repository.PhotographerSpecialtyRepository;
 import org.sopt.snappinserver.domain.photographer.service.dto.response.GetRandomPhotographersResult;
 import org.sopt.snappinserver.domain.photographer.service.usecase.GetRandomPhotographersUseCase;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,17 +17,25 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class GetRandomPhotographersService implements GetRandomPhotographersUseCase {
 
+    private static final String baseProfileImageKey = "profile/basic_profile.png";
+
     private final PhotographerRepository photographerRepository;
     private final PhotographerSpecialtyRepository photographerSpecialtyRepository;
+
+    @Value("${cloud.aws.cloud-front.domain}")
+    private String cloudFrontDomain;
 
     public List<GetRandomPhotographersResult> getRandomPhotographersResult() {
         List<Photographer> photographers = photographerRepository.findRandom(5);
         return photographers.stream()
             .map(photographer -> {
+                String profileImageUrl = (photographer.getUser().getProfileImageUrl() == null)
+                    ? cloudFrontDomain + baseProfileImageKey
+                    : photographer.getUser().getProfileImageUrl();
                 List<PhotographerSpecialty> specialties = photographerSpecialtyRepository
                     .findAllByPhotographer(photographer);
 
-                return GetRandomPhotographersResult.of(photographer, specialties);
+                return GetRandomPhotographersResult.of(photographer, profileImageUrl, specialties);
             })
             .toList();
     }

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/dto/response/GetRandomPhotographersResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/dto/response/GetRandomPhotographersResult.java
@@ -16,12 +16,13 @@ public record GetRandomPhotographersResult(
 
     public static GetRandomPhotographersResult of(
         Photographer photographer,
+        String profileImageUrl,
         List<PhotographerSpecialty> specialties
     ) {
         return new GetRandomPhotographersResult(
             photographer.getId(),
             photographer.getNickname(),
-            photographer.getUser().getProfileImageUrl(),
+            profileImageUrl,
             photographer.isNewPhotographer(),
             photographer.getBio(),
             specialties.stream()

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
@@ -89,7 +89,7 @@ public class GetUserInfoService implements GetUserInfoUseCase {
         String profileImageUrl =
             (user.getProfileImageUrl() == null || user.getProfileImageUrl().isBlank())
                 ? cloudFrontDomain + basicProfileImageKey
-                : user.getProfileImageUrl();
+                : cloudFrontDomain + user.getProfileImageUrl();
         boolean hasPhotographerProfile = photographerRepository.existsByUser(user);
         List<String> specialties = getSpecialties(photographer);
         List<String> locations = getAvailableLocations(photographer);

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
@@ -57,14 +57,22 @@ public class GetUserInfoService implements GetUserInfoUseCase {
     private GetUserInfoResult getClientInfo(
         User user
     ) {
-        String profileImageUrl = (user.getProfileImageUrl() == null)
-            ? cloudFrontDomain + basicProfileImageKey
-            : user.getProfileImageUrl();
+        String profileImageUrl =
+            (user.getProfileImageUrl() == null || user.getProfileImageUrl().isBlank())
+                ? cloudFrontDomain + basicProfileImageKey
+                : user.getProfileImageUrl();
+        boolean hasPhotographerProfile = photographerRepository.existsByUser(user);
         List<Long> moodIds = curationRepository.findTop3MoodIdsByUserId(user.getId());
         List<String> moodNames = getMoodNames(moodIds);
         GetClientInfoResult clientInfo = new GetClientInfoResult(user.getName(), moodNames);
 
-        return GetUserInfoResult.of(user, profileImageUrl, null, clientInfo, null);
+        return GetUserInfoResult.of(
+            user,
+            profileImageUrl,
+            hasPhotographerProfile,
+            clientInfo,
+            null
+        );
     }
 
     private List<String> getMoodNames(List<Long> moodIds) {
@@ -78,9 +86,11 @@ public class GetUserInfoService implements GetUserInfoUseCase {
         User user,
         Photographer photographer
     ) {
-        String profileImageUrl = (user.getProfileImageUrl() == null)
-            ? cloudFrontDomain + basicProfileImageKey
-            : user.getProfileImageUrl();
+        String profileImageUrl =
+            (user.getProfileImageUrl() == null || user.getProfileImageUrl().isBlank())
+                ? cloudFrontDomain + basicProfileImageKey
+                : user.getProfileImageUrl();
+        boolean hasPhotographerProfile = photographerRepository.existsByUser(user);
         List<String> specialties = getSpecialties(photographer);
         List<String> locations = getAvailableLocations(photographer);
         GetPhotographerInfoResult photographerInfo = new GetPhotographerInfoResult(
@@ -90,7 +100,13 @@ public class GetUserInfoService implements GetUserInfoUseCase {
             locations
         );
 
-        return GetUserInfoResult.of(user, profileImageUrl, photographer, null, photographerInfo);
+        return GetUserInfoResult.of(
+            user,
+            profileImageUrl,
+            hasPhotographerProfile,
+            null,
+            photographerInfo
+        );
     }
 
     private List<String> getSpecialties(Photographer photographer) {

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
@@ -17,6 +17,7 @@ import org.sopt.snappinserver.domain.user.service.dto.response.GetClientInfoResu
 import org.sopt.snappinserver.domain.user.service.dto.response.GetPhotographerInfoResult;
 import org.sopt.snappinserver.domain.user.service.dto.response.GetUserInfoResult;
 import org.sopt.snappinserver.domain.user.service.usecase.GetUserInfoUseCase;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,12 +26,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class GetUserInfoService implements GetUserInfoUseCase {
 
+    private static final String basicProfileImageKey = "profile/basic_profile.png";
+
     private final UserRepository userRepository;
     private final PhotographerRepository photographerRepository;
     private final MoodRepository moodRepository;
     private final CurationRepositoryCustom curationRepository;
     private final PhotographerSpecialtyRepository specialtyRepository;
     private final PhotographerAvailableLocationRepository locationRepository;
+
+    @Value("${cloud.aws.cloud-front.domain}")
+    private String cloudFrontDomain;
 
     @Override
     public GetUserInfoResult getUserInfo(Long userId) {
@@ -51,11 +57,14 @@ public class GetUserInfoService implements GetUserInfoUseCase {
     private GetUserInfoResult getClientInfo(
         User user
     ) {
+        String profileImageUrl = (user.getProfileImageUrl() == null)
+            ? cloudFrontDomain + basicProfileImageKey
+            : user.getProfileImageUrl();
         List<Long> moodIds = curationRepository.findTop3MoodIdsByUserId(user.getId());
         List<String> moodNames = getMoodNames(moodIds);
         GetClientInfoResult clientInfo = new GetClientInfoResult(user.getName(), moodNames);
 
-        return GetUserInfoResult.of(user, null, clientInfo, null);
+        return GetUserInfoResult.of(user, profileImageUrl, null, clientInfo, null);
     }
 
     private List<String> getMoodNames(List<Long> moodIds) {
@@ -69,6 +78,9 @@ public class GetUserInfoService implements GetUserInfoUseCase {
         User user,
         Photographer photographer
     ) {
+        String profileImageUrl = (user.getProfileImageUrl() == null)
+            ? cloudFrontDomain + basicProfileImageKey
+            : user.getProfileImageUrl();
         List<String> specialties = getSpecialties(photographer);
         List<String> locations = getAvailableLocations(photographer);
         GetPhotographerInfoResult photographerInfo = new GetPhotographerInfoResult(
@@ -78,7 +90,7 @@ public class GetUserInfoService implements GetUserInfoUseCase {
             locations
         );
 
-        return GetUserInfoResult.of(user, photographer, null, photographerInfo);
+        return GetUserInfoResult.of(user, profileImageUrl, photographer, null, photographerInfo);
     }
 
     private List<String> getSpecialties(Photographer photographer) {

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetUserInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetUserInfoResult.java
@@ -13,6 +13,7 @@ public record GetUserInfoResult(
 ) {
     public static GetUserInfoResult of(
         User user,
+        String profileImageUrl,
         Photographer photographer,
         GetClientInfoResult clientInfo,
         GetPhotographerInfoResult photographerInfo
@@ -20,7 +21,7 @@ public record GetUserInfoResult(
         return new GetUserInfoResult(
             user.getId(),
             user.getRole().name(),
-            user.getProfileImageUrl(),
+            profileImageUrl,
             photographer != null,
             clientInfo,
             photographerInfo

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetUserInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetUserInfoResult.java
@@ -1,6 +1,5 @@
 package org.sopt.snappinserver.domain.user.service.dto.response;
 
-import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
 
 public record GetUserInfoResult(
@@ -11,10 +10,11 @@ public record GetUserInfoResult(
     GetClientInfoResult clientInfo,
     GetPhotographerInfoResult photographerInfo
 ) {
+
     public static GetUserInfoResult of(
         User user,
         String profileImageUrl,
-        Photographer photographer,
+        boolean hasPhotographerProfile,
         GetClientInfoResult clientInfo,
         GetPhotographerInfoResult photographerInfo
     ) {
@@ -22,7 +22,7 @@ public record GetUserInfoResult(
             user.getId(),
             user.getRole().name(),
             profileImageUrl,
-            photographer != null,
+            hasPhotographerProfile,
             clientInfo,
             photographerInfo
         );


### PR DESCRIPTION
## 👀 Summary

- close #197

## 🖇️ Tasks

- 회원가입 시 카카오 프로필 저장하지 않도록 변경
- 프로젝트 내부 전체 프로필 조회 시 기본 프로필 이미지 사용하도록 변경
- 유저 조회 시 작가 프로필 보유 여부 오류 수정


## 🔍 To Reviewer

### ❶ 유저 프로필 이미지 변경 내역

기존에는 신규 유저 저장 시 해당 유저의 카카오 프로필 이미지 URL을 그대로 DB에 저장했습니다. 기획 / 디자인 측의 요구사항에 맞추어 신규 유저 저장 시 해당 유저의 카카오 프로필 이미지를 아예 저장하지 않고, null 로 들어가게 바꾸었습니다. 이에 따라, 해당 이미지를 사용하는 부분에서는 유저의 프로필이 있으면 해당 프로필을 cloudFront에서 조회할 수 있도록 변경하고, 다른 부분은 기본 프로필 이미지를 상수화하여 조회하도록 변경했습니다.


### ❷ 유저 조회 시 작가 프로필 보유 여부 오류 수정

유저 조회 시 작가 로그인 여부와 상관없이 작가 프로필을 보유하고 있는지에 대한 여부를 보내주어야 하는데, 작가 로그인 여부로 잘못 보내주는 오류가 있었습니다. 이를 해당 유저에 대해서 PhotographerRepository에 작가 프로필이 있는지 여부로 바꾸어 변환하도록 했습니다.
