### PR TITLE
[FIX] #197: 상수화 및 기본 프로필 이미지 조회 시 cloudFront 도메인 빠진 부분 추가

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetRandomPhotographersService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetRandomPhotographersService.java
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class GetRandomPhotographersService implements GetRandomPhotographersUseCase {
 
-    private static final String baseProfileImageKey = "profile/basic_profile.png";
+    private static final String BASE_PROFILE_IMAGE_KEY = "profile/basic_profile.png";
 
     private final PhotographerRepository photographerRepository;
     private final PhotographerSpecialtyRepository photographerSpecialtyRepository;
@@ -30,7 +30,7 @@ public class GetRandomPhotographersService implements GetRandomPhotographersUseC
         return photographers.stream()
             .map(photographer -> {
                 String profileImageUrl = (photographer.getUser().getProfileImageUrl() == null)
-                    ? cloudFrontDomain + baseProfileImageKey
+                    ? cloudFrontDomain + BASE_PROFILE_IMAGE_KEY
                     : cloudFrontDomain + photographer.getUser().getProfileImageUrl();
                 List<PhotographerSpecialty> specialties = photographerSpecialtyRepository
                     .findAllByPhotographer(photographer);

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
@@ -26,7 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class GetUserInfoService implements GetUserInfoUseCase {
 
-    private static final String basicProfileImageKey = "profile/basic_profile.png";
+    private static final String BASIC_PROFILE_IMAGE_KEY = "profile/basic_profile.png";
 
     private final UserRepository userRepository;
     private final PhotographerRepository photographerRepository;
@@ -59,8 +59,8 @@ public class GetUserInfoService implements GetUserInfoUseCase {
     ) {
         String profileImageUrl =
             (user.getProfileImageUrl() == null || user.getProfileImageUrl().isBlank())
-                ? cloudFrontDomain + basicProfileImageKey
-                : user.getProfileImageUrl();
+                ? cloudFrontDomain + BASIC_PROFILE_IMAGE_KEY
+                : cloudFrontDomain + user.getProfileImageUrl();
         boolean hasPhotographerProfile = photographerRepository.existsByUser(user);
         List<Long> moodIds = curationRepository.findTop3MoodIdsByUserId(user.getId());
         List<String> moodNames = getMoodNames(moodIds);
@@ -88,7 +88,7 @@ public class GetUserInfoService implements GetUserInfoUseCase {
     ) {
         String profileImageUrl =
             (user.getProfileImageUrl() == null || user.getProfileImageUrl().isBlank())
-                ? cloudFrontDomain + basicProfileImageKey
+                ? cloudFrontDomain + BASIC_PROFILE_IMAGE_KEY
                 : cloudFrontDomain + user.getProfileImageUrl();
         boolean hasPhotographerProfile = photographerRepository.existsByUser(user);
         List<String> specialties = getSpecialties(photographer);


### PR DESCRIPTION
## 👀 Summary

- close #197


## 🖇️ Tasks

- 상수 네이밍 컨벤션에 맞게 변경
- cloudFront 도메인 누락 추가


## 🔍 To Reviewer

-
