### PR TITLE
[FIX] #199: 예약 겹침 로직 오류 해결

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
@@ -69,8 +69,7 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
         List<Reservation> reservations = getBlockedReservations(date, product);
         List<ProductAvailableTimeResult> results = getProductAvailableTimeResults(
             slots,
-            reservations,
-            durationMinutes
+            reservations
         );
 
         return new ProductAvailableTimesResult(date, results);
@@ -139,13 +138,12 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
     // 시간대별 예약 가능 여부 목록 생성
     private List<ProductAvailableTimeResult> getProductAvailableTimeResults(
         List<LocalTime> slots,
-        List<Reservation> reservations,
-        int durationMinutes
+        List<Reservation> reservations
     ) {
         return slots.stream()
             .map(slot -> new ProductAvailableTimeResult(
                 slot,
-                isAvailableTimeSlot(slot, reservations, durationMinutes)
+                isAvailableTimeSlot(slot, reservations)
             ))
             .toList();
     }
@@ -153,20 +151,18 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
     // 특정 시작 시간 슬롯이 예약 가능한지 판단
     private boolean isAvailableTimeSlot(
         LocalTime slot,
-        List<Reservation> reservations,
-        int durationMinutes
+        List<Reservation> reservations
     ) {
         return reservations.stream().noneMatch(
-            reservation -> isOverlapping(slot, reservation, durationMinutes)
+            reservation -> isOverlapping(slot, reservation)
         );
     }
 
     // 시간 슬롯과 예약 시간대가 겹치는지 판단
-    private boolean isOverlapping(LocalTime slot, Reservation reservation, int durationMinutes) {
+    private boolean isOverlapping(LocalTime slot, Reservation reservation) {
         LocalTime reservedStart = reservation.getReservedAt().toLocalTime();
         LocalTime reservedEnd = reservedStart.plusMinutes(reservation.getDurationTime());
 
-        return slot.isBefore(reservedEnd) && slot.plusMinutes(reservation.getDurationTime())
-            .isAfter(reservedStart);
+        return !slot.isBefore(reservedStart) && slot.isBefore(reservedEnd);
     }
 }


### PR DESCRIPTION
## 👀 Summary

- close #199 

예약 가능 시간대 조회에서 예약된 시간보다 앞선 슬롯까지 false로 내려가던 겹침 판정 로직을 수정해, 예약 시작 시각부터 예약 종료 시각까지만 정확하게 마감 처리되도록 오류를 해결했습니다.

## 🖇️ Tasks


- [x]  시간 슬롯 겹침 판정 로직 수정
- 슬롯이 예약 구간에 조금이라도 겹치면 false로 해석되어, 예약 시작 이전 슬롯까지 막히는 원인 파악
- 예약 구간 내부에 들어가는 슬롯만 false로 계산하도록 수정
- 재현 케이스(특히 상품 기본 촬영시간 90분) 기준으로 로직 검증


## 🔍 To Reviewer

### 문제 상황

예약이 `14:00`에 생성되었는데도 available-times 응답에서 `12:30`, `13:00`, `13:30` 등 예약 시작보다 앞 슬롯까지 false로 내려오는 현상이 발생했습니다. 특히 상품 기본 촬영 시간이 90분일 때 더 빈번하게 재현되었습니다.

즉, 예약 요청부터 점유되도록 상태를 포함했음에도 겹침 판정 로직이 의도한 UX와 다르게 동작하고 있었고, 결과적으로 사용자에게는 예약되지 않은 앞 시간대까지 막힌 것처럼 보이게 되는 문제가 있었습니다.

### 원인 

기존 겹침 로직은 아래처럼 슬롯이 시작할 때부터 `slot + durationMinutes` 구간이 예약 구간과 겹치면 false였고, 이 durationMinutes가 상품 기본 촬영시간(ex. 90분) 으로 들어가면서 12:30 슬롯의 가상의 촬영 구간(12:30~14:00)이 실제 예약 시작(14:00)과 경계에서 겹치는 것으로 처리되어 앞 슬롯들이 연쇄적으로 false 처리되는 구조였습니다.

available-times는 슬롯을 시작할 수 있는지를 계산할 때 현재 화면에서의 가정 촬영시간(상품 기본 촬영시간) 을 기준으로 검증했기 때문에
예약의 시작 시각 이전 슬롯까지 영향을 주는 형태가 되어버린 것입니다 (ㅠㅠ)

> 아주아주 쉽게 설명 드리자면, 예를 들어 상품 기본 촬영 시간이 1.5시간이고, 상품 예약 가능 첫 타임이 12시라고 가정할 때, 사용자가 13시에 예약을 진행한다면 로직 내부에서 "만약 첫 타임에 예약이 들어온다면 `첫 타임 + 기본 촬영 시간`인 13:30까지는 무조건 예약이 가능해야 하므로 겹칠 수 있는 상황"으로 판단하고 13시 이전의 슬롯 3개를 다 막아버린 오류가 발생한 것이라고 보시면 됩니다.

### 해결 방법

available-times에서 슬롯의 의미를  '슬롯이 예약 구간 내부에 들어가면 막힌다' (예약 시작 이후부터 예약 종료 전까지의 슬롯만 false)로 정의하고, 겹침 판정 로직을 변경했습니다.

- 이전: slot이 가상의 촬영 구간(slot~slot+durationMinutes)으로 예약 구간과 겹치면 false
- 변경: slot이 예약 시간 구간 [reservedStart, reservedEnd) 내부에 들어가면 false

> 즉, 14:00 예약이면 14:00~종료 전 슬롯만 false
> 12:30/13:00/13:30 같은 “예약 시작 이전 슬롯”은 예약 상태에 영향을 받지 않도록 처리
