### PR TITLE
[FIX] #205: 신규 유저 로그인 시 profileImage nullable로 저장할 수 있도록 수정

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/user/domain/entity/User.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/domain/entity/User.java
@@ -43,7 +43,7 @@ public class User extends BaseEntity {
     @Column(nullable = false, length = MAX_NAME_LENGTH)
     private String name;
 
-    @Column(nullable = false, length = MAX_PROFILE_IMAGE_URL_LENGTH)
+    @Column(length = MAX_PROFILE_IMAGE_URL_LENGTH)
     private String profileImageUrl;
 
     @Builder(access = AccessLevel.PRIVATE)
@@ -88,17 +88,13 @@ public class User extends BaseEntity {
     }
 
     private static void validateProfileImageUrl(String profileImageUrl) {
-        validateProfileImageExists(profileImageUrl);
         validateProfileImageLength(profileImageUrl);
     }
 
-    private static void validateProfileImageExists(String profileImageUrl) {
-        if (profileImageUrl == null || profileImageUrl.isBlank()) {
-            throw new UserException(UserErrorCode.PROFILE_IMAGE_URL_REQUIRED);
-        }
-    }
-
     private static void validateProfileImageLength(String profileImageUrl) {
+        if (profileImageUrl == null || profileImageUrl.isBlank()) {
+            return;
+        }
         if (profileImageUrl.length() > MAX_PROFILE_IMAGE_URL_LENGTH) {
             throw new UserException(UserErrorCode.PROFILE_IMAGE_URL_TOO_LONG);
         }


### PR DESCRIPTION
## 👀 Summary

- close #205


## 🖇️ Tasks

- 유저 profileImage를 null로 저장하고 기본 값을 가져올 수 있도록 바꿈에 따라 profileImage를 nullable로 저장 가능하도록 수정했습니다.


## 🔍 To Reviewer

-
