### PR TITLE
[FIX] #207: 포폴 목록 조회 시 무드 필터 AND 조건 누락 수정

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryCustom.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryCustom.java
@@ -1,8 +1,10 @@
 package org.sopt.snappinserver.domain.portfolio.repository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.sopt.snappinserver.domain.mood.domain.enums.MoodCategory;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
 import org.sopt.snappinserver.domain.portfolio.service.dto.request.GetPortfolioListQuery;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioCardResult;
@@ -40,6 +42,7 @@ public interface PortfolioRepositoryCustom {
     List<GetPortfolioCardResult> findPortfolioCards(
         Long cursor,
         GetPortfolioListQuery query,
+        Map<MoodCategory, List<Long>> moodGroupMap,
         int size
     );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -16,6 +16,8 @@ import static org.sopt.snappinserver.domain.product.domain.entity.QProductMood.p
 import static org.sopt.snappinserver.domain.product.domain.entity.QProductPhoto.productPhoto;
 import static org.sopt.snappinserver.domain.wish.domain.entity.QWishPortfolio.wishPortfolio;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -23,9 +25,12 @@ import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.mood.domain.enums.MoodCategory;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
 import org.sopt.snappinserver.domain.portfolio.service.dto.request.GetPortfolioListQuery;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioCardResult;
@@ -242,6 +247,7 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
     public List<GetPortfolioCardResult> findPortfolioCards(
         Long cursor,
         GetPortfolioListQuery query,
+        Map<MoodCategory, List<Long>> moodGroupMap,
         int size
     ) {
         return jpaQueryFactory
@@ -264,7 +270,7 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
             .leftJoin(portfolioMood).on(portfolioMood.portfolio.id.eq(portfolio.id))
             .where(
                 cursorLt(cursor),
-                moodIn(query.moodIds()),
+                moodCategoryGroupedCondition(moodGroupMap),
                 productIdEq(query.productId()),
                 photographerIdEq(query.photographerId()),
                 snapCategoryEq(query.snapCategory()),
@@ -280,11 +286,35 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
         return cursor == null ? null : portfolio.id.lt(cursor);
     }
 
-    private BooleanExpression moodIn(List<Long> moodIds) {
-        if (moodIds == null || moodIds.isEmpty()) {
+    private Predicate moodCategoryGroupedCondition(
+        Map<MoodCategory, List<Long>> moodGroupMap
+    ) {
+        if (moodGroupMap == null || moodGroupMap.isEmpty()) {
             return null;
         }
-        return portfolioMood.mood.id.in(moodIds);
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        for (Entry<MoodCategory, List<Long>> entry : moodGroupMap.entrySet()) {
+            if (entry.getValue() == null || entry.getValue().isEmpty()) {
+                continue;
+            }
+
+            builder.and(
+                portfolio.id.in(
+                    JPAExpressions
+                        .select(portfolioMood.portfolio.id)
+                        .from(portfolioMood)
+                        .join(portfolioMood.mood, mood)
+                        .where(
+                            mood.category.eq(entry.getKey()),
+                            mood.id.in(entry.getValue())
+                        )
+                )
+            );
+        }
+
+        return builder;
     }
 
     private BooleanExpression productIdEq(Long productId) {

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetPortfolioListService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetPortfolioListService.java
@@ -1,7 +1,14 @@
 package org.sopt.snappinserver.domain.portfolio.service;
 
+import static java.util.stream.Collectors.toList;
+
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
+import org.sopt.snappinserver.domain.mood.domain.enums.MoodCategory;
+import org.sopt.snappinserver.domain.mood.repository.MoodRepository;
 import org.sopt.snappinserver.domain.portfolio.repository.PortfolioRepositoryCustom;
 import org.sopt.snappinserver.domain.portfolio.service.dto.request.GetPortfolioListQuery;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetPortfolioCardResult;
@@ -19,6 +26,7 @@ public class GetPortfolioListService implements GetPortfolioListUseCase {
 
     private static final int PAGE_SIZE = 30;
 
+    private final MoodRepository moodRepository;
     private final PortfolioRepositoryCustom portfolioRepositoryCustom;
 
     @Value("${cloud.aws.cloud-front.domain}")
@@ -26,8 +34,9 @@ public class GetPortfolioListService implements GetPortfolioListUseCase {
 
     @Override
     public GetPortfolioListResult getPortfolioList(GetPortfolioListQuery query) {
+        Map<MoodCategory, List<Long>> moodGroupMap = groupByCategory(query.moodIds());
         List<GetPortfolioCardResult> rows = portfolioRepositoryCustom
-            .findPortfolioCards(query.cursor(), query, PAGE_SIZE).stream()
+            .findPortfolioCards(query.cursor(), query, moodGroupMap, PAGE_SIZE).stream()
             .map(result -> {
                 String presignedUrl = (result.imageUrl() != null && !result.imageUrl().isBlank())
                     ? cloudFrontDomain + result.imageUrl()
@@ -48,6 +57,23 @@ public class GetPortfolioListService implements GetPortfolioListUseCase {
             portfolios,
             new GetPortfolioListMeta(hasNext, nextCursor)
         );
+    }
+
+    private Map<MoodCategory, List<Long>> groupByCategory(List<Long> moodIds) {
+        if (moodIds == null || moodIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return moodRepository.findAllById(moodIds).stream()
+            .collect(
+                Collectors.groupingBy(
+                    Mood::getCategory,
+                    Collectors.mapping(
+                        Mood::getId,
+                        toList()
+                    )
+                )
+            );
     }
 
 }


### PR DESCRIPTION
## 👀 Summary

- close #207


## 🖇️ Tasks

- 포트폴리오 목록 조회 시, 무드 필터 그룹 간 AND 조건이 누락된 채 조회되는 부분이 있어 조회 시 해당 조건이 누락된 부분을 다시 추가했습니다.


## 🔍 To Reviewer

-
