### PR TITLE
[FIX] #209: 상품 상세 조회 시 촬영 시간 단위 오류 수정

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetProductInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetProductInfoResponse.java
@@ -74,8 +74,8 @@ public record GetProductInfoResponse(
                 .map(m -> m.concat("명"))
                 .orElse(null),
             getProductInfoResult.photographerCount(),
-            Optional.ofNullable(getProductInfoResult.durationTime())
-                .map(d -> d.concat("시간"))
+            Optional.of(getProductInfoResult.durationTime())
+                .map(d -> String.format("%.1f시간", d))
                 .orElse(null),
             getProductInfoResult.provideRaw(),
             getProductInfoResult.provideOriginalJpg(),

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetProductInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetProductInfoResult.java
@@ -15,7 +15,7 @@ public record GetProductInfoResult(
     List<String> moods,
     String maxPeople,
     String photographerCount,
-    String durationTime,
+    double durationTime,
     String provideRaw,
     String provideOriginalJpg,
     String originalJpgCount,
@@ -48,7 +48,9 @@ public record GetProductInfoResult(
                 .toList(),
             options.get(ProductOptionCategory.MAX_PEOPLE),
             options.get(ProductOptionCategory.PHOTOGRAPHER_COUNT),
-            options.get(ProductOptionCategory.DURATION_TIME),
+            Math.round(Double.parseDouble(
+                options.get(ProductOptionCategory.DURATION_TIME)) / 60d * 10
+            ) / 10d,
             options.get(ProductOptionCategory.PROVIDE_RAW),
             options.get(ProductOptionCategory.PROVIDE_ORIGINAL_JPG),
             options.get(ProductOptionCategory.ORIGINAL_JPG_COUNT),


### PR DESCRIPTION
## 👀 Summary

- close #209


## 🖇️ Tasks

- 상품 상세 조회 시 120시간으로 잘못 내려가는 문제를 2.5시간으로 단위 변환하여 수정했습니다. 이때, durationTime이 필수값이기 때문에 Double이 아닌 double로 반환합니다.


## 🔍 To Reviewer

-