### PR TITLE
[FIX] #174:  ios 이미지 확장자 허용

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/review/service/PostPresignedUrlService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/service/PostPresignedUrlService.java
@@ -18,13 +18,16 @@ import org.springframework.stereotype.Service;
 public class PostPresignedUrlService implements PostPresignedUrlUseCase {
 
     private static final List<String> ALLOWED_EXTENSIONS =
-        List.of("jpg", "jpeg", "png", "webp");
+        List.of("jpg", "jpeg", "png", "webp", "heic", "heif");
 
     private static final List<String> ALLOWED_CONTENT_TYPES =
         List.of(
             "image/jpeg",
             "image/png",
-            "image/webp"
+            "image/webp",
+            "image/heic",
+            "image/heif",
+            "application/octet-stream"
         );
 
     private final UserRepository userRepository;


### PR DESCRIPTION
## 👀 Summary

- close #174


## 🖇️ Tasks

- ios 이미지 확장자가 일반 사진 이미지 확장자와 달라 해당 확장자와 MIME TYPE을 추가했습니다.


## 🔍 To Reviewer

-
