### PR TITLE
[FIX] #216: 이미 지난 시간대의 타임 슬롯 비활성화 처리

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
@@ -3,6 +3,7 @@ package org.sopt.snappinserver.domain.product.service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,7 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
 
     private static final int ONE_DAY = 1;
     private static final int TIME_SLOT_INTERVAL_MINUTES = 30;
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
     private final ProductRepository productRepository;
     private final ProductOptionRepository productOptionRepository;
@@ -142,8 +144,8 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
         List<Reservation> reservations,
         LocalDate date
     ) {
-        LocalDate today = LocalDate.now();
-        LocalTime now = LocalTime.now();
+        LocalDate today = LocalDate.now(KOREA_ZONE);
+        LocalTime now = LocalTime.now(KOREA_ZONE);
 
         return slots.stream()
             .map(slot -> {

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
@@ -69,7 +69,8 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
         List<Reservation> reservations = getBlockedReservations(date, product);
         List<ProductAvailableTimeResult> results = getProductAvailableTimeResults(
             slots,
-            reservations
+            reservations,
+            date
         );
 
         return new ProductAvailableTimesResult(date, results);
@@ -138,13 +139,22 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
     // 시간대별 예약 가능 여부 목록 생성
     private List<ProductAvailableTimeResult> getProductAvailableTimeResults(
         List<LocalTime> slots,
-        List<Reservation> reservations
+        List<Reservation> reservations,
+        LocalDate date
     ) {
+        LocalDate today = LocalDate.now();
+        LocalTime now = LocalTime.now();
+
         return slots.stream()
-            .map(slot -> new ProductAvailableTimeResult(
-                slot,
-                isAvailableTimeSlot(slot, reservations)
-            ))
+            .map(slot -> {
+                boolean isAvailable = isAvailableTimeSlot(slot, reservations);
+
+                if (date.isEqual(today) && slot.isBefore(now)) {
+                    isAvailable = false;
+                }
+
+                return new ProductAvailableTimeResult(slot, isAvailable);
+            })
             .toList();
     }
 


### PR DESCRIPTION
## 👀 Summary

- close #216 

오늘 일자의 이미 지난 시간대 타임 슬롯이 활성화되는 오류를 해결했습니다.

## 🖇️ Tasks

- [x] 예약 날짜/시간과 현재 날짜/시간 비교
- [x] 지난 시간대의 isAvailable 값을 false로 처리

## 🔍 To Reviewer

슬롯 생성 자체는 기존과 동일하게 업무 시간 범위 내 전체 슬롯을 생성하고, 예약 충돌 여부 + 현재 시각 기준을 함께 고려해 최종 isAvailable 값을 결정합니다.