### PR TITLE
[FIX] #212: 홈화면 맞춤 큐레이션 기반 포폴 조회 시 쿼리 수정

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/curation/repository/CurationRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/repository/CurationRepository.java
@@ -3,11 +3,18 @@ package org.sopt.snappinserver.domain.curation.repository;
 import java.util.List;
 import org.sopt.snappinserver.domain.curation.domain.entity.Curation;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CurationRepository extends JpaRepository<Curation, Long> {
 
-    List<Curation> findTop3ByUserOrderByRankAscCreatedAtDesc(User user);
+    @Query("""
+            select c from Curation c
+            where c.user = :user
+            order by c.createdAt desc
+        """)
+    List<Curation> findLatestByUser(User user, Pageable pageable);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetCuratedPortfolioService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetCuratedPortfolioService.java
@@ -1,6 +1,7 @@
 package org.sopt.snappinserver.domain.portfolio.service;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,7 @@ import org.sopt.snappinserver.domain.portfolio.service.usecase.GetPopularPortfol
 import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.sopt.snappinserver.domain.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,8 +54,10 @@ public class GetCuratedPortfolioService implements GetCuratedPortfolioUseCase {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new PortfolioException(PortfolioErrorCode.USER_NOT_FOUND));
 
-        List<Curation> curations = curationRepository
-            .findTop3ByUserOrderByRankAscCreatedAtDesc(user);
+        List<Curation> curations =
+            curationRepository.findLatestByUser(user, PageRequest.of(0, 3));
+
+        curations.sort(Comparator.comparing(Curation::getRank));
 
         if (curations.isEmpty()) {
             return GetCuratedPortfolioResult.from(


### PR DESCRIPTION
## 👀 Summary

- close #212


## 🖇️ Tasks

- 홈화면에서 로그인 후 맞춤 큐레이션 기반 포폴 조회 시 큐레이션 결과가 여러 개 있는 경우, 1번 순위가 중복되어 보이는 문제 해결

## 🔍 To Reviewer

### 기존

```java
 List<Curation> findTop3ByUserOrderByRankAscCreatedAtDesc(User user);
```

=> 순위 기준 오름차순 정렬 후, 같은 것이 있으면 생성일시 기준 내림차순 정렬
=> 순위가 1인 것만 여러 개 보이는 문제


### 해결

```java
    @Query("""
            select c from Curation c
            where c.user = :user
            order by c.createdAt desc
        """)
    List<Curation> findLatestByUser(User user, Pageable pageable);

----

       List<Curation> curations =
            curationRepository.findLatestByUser(user, PageRequest.of(0, 3));

        curations.sort(Comparator.comparing(Curation::getRank));
```

최신 데이터 3개를 @Query로 불러옴 -> 이후 최신 데이터 3개 결과 가져온 걸 Rank로 정렬

