### PR TITLE
[FIX] #213: 상품 상세에서 촬영시간 나누어떨어지는 경우 .0 제거해서 반환하도록 수정

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetProductInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetProductInfoResponse.java
@@ -74,9 +74,7 @@ public record GetProductInfoResponse(
                 .map(m -> m.concat("명"))
                 .orElse(null),
             getProductInfoResult.photographerCount(),
-            Optional.of(getProductInfoResult.durationTime())
-                .map(d -> String.format("%.1f시간", d))
-                .orElse(null),
+            formatDurationTime(getProductInfoResult.durationTime()),
             getProductInfoResult.provideRaw(),
             getProductInfoResult.provideOriginalJpg(),
             getProductInfoResult.originalJpgCount(),
@@ -90,5 +88,11 @@ public record GetProductInfoResponse(
             getProductInfoResult.equipment(),
             getProductInfoResult.caution()
         );
+    }
+
+    private static String formatDurationTime(double d) {
+        return Math.floor(d) == d
+            ? String.format("%.0f시간", d)
+            : String.format("%.1f시간", d);
     }
 }


### PR DESCRIPTION
## 👀 Summary

- close #213


## 🖇️ Tasks

- 상품 상세 조회 시 촬영 시간 정수로  나누어 떨어지는 경우 .0을 제거해서 반환하도록 수정했습니다.


## 🔍 To Reviewer

- 삼항연산자에서 round한 값과 이전 값이 같은 경우(= 정수인 경우) 소수점 없이 반환하고, 소수점이 있는 경우 소수점 한자리수까지 반환합니다.