### PR TITLE
[FIX] #214: 포트폴리오 BaseEntity 상속받도록 수정, 목록 조회 시 조회 순서 수정

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/domain/entity/Portfolio.java
@@ -19,12 +19,13 @@ import lombok.NoArgsConstructor;
 import org.sopt.snappinserver.domain.portfolio.domain.exception.PortfolioErrorCode;
 import org.sopt.snappinserver.domain.portfolio.domain.exception.PortfolioException;
 import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.global.entity.BaseEntity;
 import org.sopt.snappinserver.global.enums.SnapCategory;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Portfolio {
+public class Portfolio extends BaseEntity {
 
     private static final int MAX_DESCRIPTION_LENGTH = 1024;
 

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/domain/entity/Portfolio.java
@@ -19,13 +19,12 @@ import lombok.NoArgsConstructor;
 import org.sopt.snappinserver.domain.portfolio.domain.exception.PortfolioErrorCode;
 import org.sopt.snappinserver.domain.portfolio.domain.exception.PortfolioException;
 import org.sopt.snappinserver.domain.product.domain.entity.Product;
-import org.sopt.snappinserver.global.entity.BaseEntity;
 import org.sopt.snappinserver.global.enums.SnapCategory;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Portfolio extends BaseEntity {
+public class Portfolio {
 
     private static final int MAX_DESCRIPTION_LENGTH = 1024;
 

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -274,7 +274,7 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
                 snapCategoryEq(query.snapCategory()),
                 placeExists(query.placeId())
             )
-            .orderBy(portfolio.createdAt.desc())
+            .orderBy(portfolio.id.desc())
             .limit(size + 1)
             .fetch();
     }

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -266,18 +266,15 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
                     .and(portfolioPhoto.displayOrder.eq(1))
             )
             .join(portfolioPhoto.photo, photo)
-            .leftJoin(portfolioPlace).on(portfolioPlace.portfolio.id.eq(portfolio.id))
-            .leftJoin(portfolioMood).on(portfolioMood.portfolio.id.eq(portfolio.id))
             .where(
                 cursorLt(cursor),
                 moodCategoryGroupedCondition(moodGroupMap),
                 productIdEq(query.productId()),
                 photographerIdEq(query.photographerId()),
                 snapCategoryEq(query.snapCategory()),
-                placeEq(query.placeId())
+                placeExists(query.placeId())
             )
-            .distinct()
-            .orderBy(portfolio.id.desc())
+            .orderBy(portfolio.createdAt.desc())
             .limit(size + 1)
             .fetch();
     }
@@ -329,8 +326,18 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
         return category == null ? null : portfolio.snapCategory.eq(category);
     }
 
-    private BooleanExpression placeEq(Long placeId) {
-        return placeId == null ? null : portfolioPlace.place.id.eq(placeId);
+    private BooleanExpression placeExists(Long placeId) {
+        if (placeId == null) return null;
+
+        return JPAExpressions
+            .selectOne()
+            .from(portfolioPlace)
+            .where(
+                portfolioPlace.portfolio.id.eq(portfolio.id),
+                portfolioPlace.place.id.eq(placeId)
+            )
+            .exists();
     }
+
 
 }


### PR DESCRIPTION
## 👀 Summary

- close #214


## 🖇️ Tasks

- 포트폴리오 BaseEntity 상속받도록 수정
- 목록 조회 시 조회 순서 수정


## 🔍 To Reviewer
