### PR TITLE
[FIX] #215: 장소 목록 조회 시 키워드로 시작하는 이름 검색

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/place/repository/PlaceRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
 
-    List<Place> findTop4ByNameContainingOrderByNameAsc(String name);
+    List<Place> findTop4ByNameStartingWithOrderByNameAsc(String name);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/place/service/GetPlaceListService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/place/service/GetPlaceListService.java
@@ -17,7 +17,7 @@ public class GetPlaceListService implements GetPlaceListUseCase {
     private final PlaceRepository placeRepository;
 
     public GetPlaceListResult getPlaceList(String keyword) {
-        List<Place> places = placeRepository.findTop4ByNameContainingOrderByNameAsc(keyword);
+        List<Place> places = placeRepository.findTop4ByNameStartingWithOrderByNameAsc(keyword);
 
         return GetPlaceListResult.from(places);
     }


### PR DESCRIPTION
## 👀 Summary

- close #215


## 🖇️ Tasks

- 장소 목록 조회 시 키워드를 포함하는 장소 대신 키워드로 시작하는 이름으로 검색하도록 수정
- 이름 기준 오름차순으로 정렬


## 🔍 To Reviewer

