### PR TITLE
[FIX] #221: 예약 목록을 updatedAt 최신순으로 조회

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepository.java
@@ -35,7 +35,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         join fetch r.user u
         where u.id = :userId
           and r.reservationStatus in :statuses
-        order by r.createdAt desc
+        order by r.updatedAt desc
     """)
     List<Reservation> findClientReservations(
         @Param("userId") Long userId,
@@ -51,7 +51,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         join fetch r.user u
         where ph.user.id = :userId
           and r.reservationStatus in :statuses
-        order by r.createdAt desc
+        order by r.updatedAt desc
     """)
     List<Reservation> findPhotographerReservations(
         @Param("userId") Long userId,


### PR DESCRIPTION
## 👀 Summary

- close #221 

예약 목록을 상태 변경 순으로 조회할 수 있도록 변경했습니다.

## 🖇️ Tasks

- [x] 예약 조회 레포지토리에서 정렬 기준을 createdAt에서 updatedAt으로 변경

## 🔍 To Reviewer

예약 취소/거절과 같은 예약 상태 변경이 목록의 맨 위에서 조회되야 하는 요구사항을 충족하고자 updatedAt을 기준으로 변경했습니다.
