### PR TITLE
[FIX] #217: 상품 상세 조회 시 이미지 순서 오류 수정

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioMoodRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioMoodRepository.java
@@ -15,6 +15,7 @@ public interface PortfolioMoodRepository extends JpaRepository<PortfolioMood, Lo
             FROM PortfolioMood pm
             JOIN FETCH pm.mood
             WHERE pm.portfolio.id IN :portfolioIds
+            ORDER BY pm.id
         """)
     List<PortfolioMood> findByPortfolioIds(
         @Param("portfolioIds") List<Long> portfolioIds

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioPhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioPhotoRepository.java
@@ -19,7 +19,7 @@ public interface PortfolioPhotoRepository extends JpaRepository<PortfolioPhoto, 
             FROM PortfolioPhoto pp
             JOIN FETCH pp.photo
             WHERE pp.portfolio.id IN :portfolioIds
-            ORDER BY pp.portfolio.id, pp.displayOrder
+            ORDER BY pp.displayOrder
         """)
     List<PortfolioPhoto> findByPortfolioIds(@Param("portfolioIds") List<Long> portfolioIds);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryCustom.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryCustom.java
@@ -24,8 +24,6 @@ public interface PortfolioRepositoryCustom {
 
     List<String> findPortfolioMoods(Long portfolioId);
 
-    List<String> findProductMoods(Long productId);
-
     String findProductThumbnailUrl(Long productId);
 
     List<SnapCategory> findPhotographerSpecialties(Long photographerId);

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -160,16 +160,7 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
             .from(portfolioMood)
             .join(portfolioMood.mood, mood)
             .where(portfolioMood.portfolio.id.eq(portfolioId))
-            .fetch();
-    }
-
-    @Override
-    public List<String> findProductMoods(Long productId) {
-        return jpaQueryFactory
-            .select(mood.name)
-            .from(productMood)
-            .join(productMood.mood, mood)
-            .where(productMood.product.id.eq(productId))
+            .orderBy(portfolioMood.id.asc())
             .fetch();
     }
 

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetPortfolioDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/GetPortfolioDetailService.java
@@ -14,6 +14,7 @@ import org.sopt.snappinserver.domain.portfolio.service.mapper.PortfolioDetailMap
 import org.sopt.snappinserver.domain.portfolio.service.usecase.GetPortfolioDetailUseCase;
 import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.sopt.snappinserver.domain.product.repository.ProductRepository;
+import org.sopt.snappinserver.domain.product.repository.ProductRepositoryCustom;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult;
 import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
 import org.sopt.snappinserver.global.enums.SnapCategory;
@@ -25,26 +26,27 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class GetPortfolioDetailService implements GetPortfolioDetailUseCase {
 
-    private final PortfolioRepositoryCustom queryRepository;
+    private final PortfolioRepositoryCustom portfolioRepositoryCustom;
     private final ProductRepository productRepository;
     private final ReviewRepository reviewRepository;
     private final PortfolioDetailMapper mapper;
     private final PortfolioRepository portfolioRepository;
+    private final ProductRepositoryCustom productRepositoryCustom;
 
     @Override
     public GetPortfolioDetailResult findPortfolioDetail(Long userId, Long portfolioId) {
         validateExistsPortfolio(portfolioId);
-        PortfolioDetailProjection portfolioProjection = queryRepository.findDetail(portfolioId);
-        LikeStatusProjection likeStatus = queryRepository.findLikeStatus(portfolioId, userId);
+        PortfolioDetailProjection portfolioProjection = portfolioRepositoryCustom.findDetail(portfolioId);
+        LikeStatusProjection likeStatus = portfolioRepositoryCustom.findLikeStatus(portfolioId, userId);
 
-        List<String> portfolioImages = queryRepository.findPortfolioImageUrls(portfolioId);
-        List<String> portfolioMoods = queryRepository.findPortfolioMoods(portfolioId);
-        List<String> photographerSpecialties = queryRepository
+        List<String> portfolioImages = portfolioRepositoryCustom.findPortfolioImageUrls(portfolioId);
+        List<String> portfolioMoods = portfolioRepositoryCustom.findPortfolioMoods(portfolioId);
+        List<String> photographerSpecialties = portfolioRepositoryCustom
             .findPhotographerSpecialties(portfolioProjection.photographerId())
             .stream()
             .map(SnapCategory::getCategory)
             .toList();
-        List<String> photographerLocations = queryRepository.findPhotographerAvailableLocations(
+        List<String> photographerLocations = portfolioRepositoryCustom.findPhotographerAvailableLocations(
             portfolioProjection.photographerId()
         );
 
@@ -53,8 +55,8 @@ public class GetPortfolioDetailService implements GetPortfolioDetailUseCase {
         ProductReviewStatsResult reviewStats = reviewRepository.findReviewStatsByProductId(
             product.getId()
         );
-        String productThumbnail = queryRepository.findProductThumbnailUrl(product.getId());
-        List<String> productMoods = queryRepository.findProductMoods(product.getId());
+        String productThumbnail = portfolioRepositoryCustom.findProductThumbnailUrl(product.getId());
+        List<String> productMoods = productRepositoryCustom.findProductMoods(product.getId());
 
         return mapper.toResult(
             portfolioProjection,

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductMoodRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductMoodRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductMoodRepository extends JpaRepository<ProductMood, Long> {
 
-    List<ProductMood> findAllByProduct(Product product);
+    List<ProductMood> findAllByProductOrderById(Product product);
 
     List<ProductMood> findAllByProductIdIn(List<Long> productIds);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductPhotoRepository.java
@@ -28,6 +28,6 @@ public interface ProductPhotoRepository extends JpaRepository<ProductPhoto, Long
     List<ProductPhoto> findThumbnails(@Param("productIds") List<Long> productIds);
 
 
-    List<ProductPhoto> findByProduct(Product product);
+    List<ProductPhoto> findByProductOrderByDisplayOrderAsc(Product product);
 
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryCustom.java
@@ -15,4 +15,7 @@ public interface ProductRepositoryCustom {
         GetProductListQuery query,
         Map<MoodCategory, List<Long>> moodGroupMap
     );
+
+    List<String> findProductMoods(Long productId);
+
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
@@ -165,6 +165,17 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
             .toList();
     }
 
+    @Override
+    public List<String> findProductMoods(Long productId) {
+        return jpaQueryFactory
+            .select(mood.name)
+            .from(productMood)
+            .join(productMood.mood, mood)
+            .where(productMood.product.id.eq(productId))
+            .orderBy(productMood.id.asc())
+            .fetch();
+    }
+
     private BooleanExpression cursorLt(Long cursor) {
         return cursor == null ? null : product.id.lt(cursor);
     }
@@ -293,6 +304,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
             .from(productMood)
             .join(mood).on(productMood.mood.id.eq(mood.id))
             .where(productMood.product.id.in(productIds))
+            .orderBy(productMood.id.asc())
             .fetch()) {
             String s = tuple.get(mood.name);
             map.computeIfAbsent(tuple.get(productMood.product.id), k -> new ArrayList<>()).add(s);

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductDetailService.java
@@ -63,7 +63,7 @@ public class GetProductDetailService implements GetProductDetailUseCase {
 
         List<ProductAvailableLocation> availableLocations = productAvailableLocationRepository
             .findByProduct(product);
-        List<ProductMood> productMoods = productMoodRepository.findAllByProduct(product);
+        List<ProductMood> productMoods = productMoodRepository.findAllByProductOrderById(product);
 
         Photographer photographer = product.getPhotographer();
         List<String> specialties = getSpecialties(photographer);
@@ -100,7 +100,7 @@ public class GetProductDetailService implements GetProductDetailUseCase {
     }
 
     private List<String> getProductPhotos(Product product) {
-        return productPhotoRepository.findByProduct(product).stream()
+        return productPhotoRepository.findByProductOrderByDisplayOrderAsc(product).stream()
             .map(ProductPhoto::getPhoto)
             .filter(photo ->
                 photo != null && photo.getImageUrl() != null && !photo.getImageUrl().isBlank()

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
@@ -135,7 +135,7 @@ public class GetReservationDetailService implements GetReservationDetailUseCase 
     }
 
     private List<String> getMoodNames(Product product) {
-        return productMoodRepository.findAllByProduct(product).stream()
+        return productMoodRepository.findAllByProductOrderById(product).stream()
             .map(pm -> pm.getMood().getName())
             .toList();
     }

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsService.java
@@ -87,7 +87,7 @@ public class GetWishedProductsService implements GetWishedProductsUseCase {
 
     private List<String> findMoodNames(Product product) {
         return productMoodRepository
-            .findAllByProduct(product)
+            .findAllByProductOrderById(product)
             .stream()
             .map(productMood -> productMood.getMood().getName())
             .toList();


### PR DESCRIPTION
## 👀 Summary

- close #217


## 🖇️ Tasks

- 상품 상세 조회 시 이미지 순서 오류 수정 (displayOrder로 Order By 하는 것 누락된 부분 모두 추가
- 상품 상세 조회 시 무드 순서 불일치 문제 해결을 위해 모든 무드 조회 시 해당 테이블 id 오름차순으로 조회할 수 있도록 수정했습니다.


## 🔍 To Reviewer

-