### PR TITLE
[FIX] #223: 리뷰 평균 별점 포맷을 소수점 1자리로 고정

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/portfolio/dto/response/GetPortfolioProductInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/portfolio/dto/response/GetPortfolioProductInfoResponse.java
@@ -35,12 +35,16 @@ public record GetPortfolioProductInfoResponse(
 ) {
 
     public static GetPortfolioProductInfoResponse from(GetProductInfoResult result) {
+        BigDecimal rate = result.rate() == null
+            ? BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP)
+            : BigDecimal.valueOf(result.rate())
+                .setScale(1, RoundingMode.HALF_UP);
+
         return new GetPortfolioProductInfoResponse(
             result.id(),
             result.imageUrl(),
             result.title(),
-            BigDecimal.valueOf(result.rate())
-                .setScale(1, RoundingMode.HALF_UP),
+            rate,
             result.reviewCount(),
             result.photographer(),
             result.price(),

--- a/src/main/java/org/sopt/snappinserver/api/v1/portfolio/dto/response/GetPortfolioProductInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/portfolio/dto/response/GetPortfolioProductInfoResponse.java
@@ -1,6 +1,8 @@
 package org.sopt.snappinserver.api.v1.portfolio.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.GetProductInfoResult;
 
@@ -16,8 +18,8 @@ public record GetPortfolioProductInfoResponse(
     @Schema(description = "상품명")
     String title,
 
-    @Schema(description = "리뷰 별점 평균")
-    Double rate,
+    @Schema(description = "리뷰 평균 별점")
+    BigDecimal rate,
 
     @Schema(description = "리뷰 수")
     long reviewCount,
@@ -37,7 +39,8 @@ public record GetPortfolioProductInfoResponse(
             result.id(),
             result.imageUrl(),
             result.title(),
-            result.rate(),
+            BigDecimal.valueOf(result.rate())
+                .setScale(1, RoundingMode.HALF_UP),
             result.reviewCount(),
             result.photographer(),
             result.price(),

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetProductCardResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetProductCardResponse.java
@@ -1,6 +1,8 @@
 package org.sopt.snappinserver.api.v1.product.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductCardResult;
 
@@ -17,7 +19,7 @@ public record GetProductCardResponse(
     String title,
 
     @Schema(description = "평균 별점")
-    Double rate,
+    BigDecimal rate,
 
     @Schema(description = "리뷰 개수")
     long reviewCount,
@@ -37,7 +39,8 @@ public record GetProductCardResponse(
             result.id(),
             result.imageUrl(),
             result.title(),
-            result.rate(),
+            BigDecimal.valueOf(result.rate())
+                .setScale(1, RoundingMode.HALF_UP),
             result.reviewCount(),
             result.photographer(),
             result.price(),

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetProductCardResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetProductCardResponse.java
@@ -35,12 +35,16 @@ public record GetProductCardResponse(
 ) {
 
     public static GetProductCardResponse from(GetProductCardResult result) {
+        BigDecimal rate = result.rate() == null
+            ? BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP)
+            : BigDecimal.valueOf(result.rate())
+                .setScale(1, RoundingMode.HALF_UP);
+
         return new GetProductCardResponse(
             result.id(),
             result.imageUrl(),
             result.title(),
-            BigDecimal.valueOf(result.rate())
-                .setScale(1, RoundingMode.HALF_UP),
+            rate,
             result.reviewCount(),
             result.photographer(),
             result.price(),

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetProductDetailResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetProductDetailResponse.java
@@ -37,16 +37,18 @@ public record GetProductDetailResponse(
     GetProductInfoResponse productInfo
 ) {
 
-    public static GetProductDetailResponse from(
-        GetProductResult result
-    ) {
+    public static GetProductDetailResponse from(GetProductResult result) {
+        BigDecimal rate = result.averageRate() == null
+            ? BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP)
+            : BigDecimal.valueOf(result.averageRate())
+                .setScale(1, RoundingMode.HALF_UP);
+
         return new GetProductDetailResponse(
             result.id(),
             result.images(),
             result.title(),
             result.isLiked(),
-            BigDecimal.valueOf(result.averageRate())
-                .setScale(1, RoundingMode.HALF_UP),
+            rate,
             result.reviewCount(),
             result.price(),
             GetProductPhotographerInfoResponse.from(result.photographerInfo()),

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetProductDetailResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetProductDetailResponse.java
@@ -1,6 +1,8 @@
 package org.sopt.snappinserver.api.v1.product.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductResult;
 
@@ -20,7 +22,7 @@ public record GetProductDetailResponse(
     boolean isLiked,
 
     @Schema(description = "평균 별점")
-    Double averageRate,
+    BigDecimal averageRate,
 
     @Schema(description = "리뷰 개수")
     long reviewCount,
@@ -43,7 +45,8 @@ public record GetProductDetailResponse(
             result.images(),
             result.title(),
             result.isLiked(),
-            result.averageRate(),
+            BigDecimal.valueOf(result.averageRate())
+                .setScale(1, RoundingMode.HALF_UP),
             result.reviewCount(),
             result.price(),
             GetProductPhotographerInfoResponse.from(result.photographerInfo()),

--- a/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationDetailProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationDetailProductResponse.java
@@ -1,6 +1,8 @@
 package org.sopt.snappinserver.api.v1.reservation.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailProductResult;
 
@@ -17,7 +19,7 @@ public record ReservationDetailProductResponse(
     String title,
 
     @Schema(description = "평균 별점", example = "4.7")
-    Double rate,
+    BigDecimal rate,
 
     @Schema(description = "리뷰 개수", example = "20")
     int reviewCount,
@@ -37,7 +39,8 @@ public record ReservationDetailProductResponse(
             result.id(),
             result.imageUrl(),
             result.title(),
-            result.rate(),
+            BigDecimal.valueOf(result.rate())
+                .setScale(1, RoundingMode.HALF_UP),
             result.reviewCount(),
             result.photographer(),
             result.price(),

--- a/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationDetailProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationDetailProductResponse.java
@@ -35,12 +35,16 @@ public record ReservationDetailProductResponse(
 ) {
 
     public static ReservationDetailProductResponse from(GetReservationDetailProductResult result) {
+        BigDecimal rate = result.rate() == null
+            ? BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP)
+            : BigDecimal.valueOf(result.rate())
+                .setScale(1, RoundingMode.HALF_UP);
+
         return new ReservationDetailProductResponse(
             result.id(),
             result.imageUrl(),
             result.title(),
-            BigDecimal.valueOf(result.rate())
-                .setScale(1, RoundingMode.HALF_UP),
+            rate,
             result.reviewCount(),
             result.photographer(),
             result.price(),

--- a/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationListProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationListProductResponse.java
@@ -1,6 +1,8 @@
 package org.sopt.snappinserver.api.v1.reservation.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationListProductResult;
 
@@ -17,7 +19,7 @@ public record ReservationListProductResponse(
     String title,
 
     @Schema(description = "평균 별점", example = "4.7")
-    Double rate,
+    BigDecimal rate,
 
     @Schema(description = "리뷰 개수", example = "20")
     int reviewCount,
@@ -42,7 +44,8 @@ public record ReservationListProductResponse(
             result.id(),
             result.imageUrl(),
             result.title(),
-            result.rate(),
+            BigDecimal.valueOf(result.rate())
+                .setScale(1, RoundingMode.HALF_UP),
             result.reviewCount(),
             result.photographer(),
             result.price(),

--- a/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationListProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/reservation/dto/response/ReservationListProductResponse.java
@@ -37,15 +37,18 @@ public record ReservationListProductResponse(
     boolean isReviewed
 ) {
 
-    public static ReservationListProductResponse from(
-        GetReservationListProductResult result
-    ) {
+    public static ReservationListProductResponse from(GetReservationListProductResult result) {
+        BigDecimal rate = result.rate() == null
+            ? BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP)
+            : BigDecimal.valueOf(result.rate())
+                .setScale(1, RoundingMode.HALF_UP);
+
+
         return new ReservationListProductResponse(
             result.id(),
             result.imageUrl(),
             result.title(),
-            BigDecimal.valueOf(result.rate())
-                .setScale(1, RoundingMode.HALF_UP),
+            rate,
             result.reviewCount(),
             result.photographer(),
             result.price(),

--- a/src/main/java/org/sopt/snappinserver/api/v1/wish/dto/response/WishedProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/wish/dto/response/WishedProductResponse.java
@@ -35,12 +35,16 @@ public record WishedProductResponse(
 ) {
 
     public static WishedProductResponse from(WishedProductResult result) {
+        BigDecimal rate = result.rate() == null
+            ? BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP)
+            : BigDecimal.valueOf(result.rate())
+                .setScale(1, RoundingMode.HALF_UP);
+
         return new WishedProductResponse(
             result.id(),
             result.imageUrl(),
             result.title(),
-            BigDecimal.valueOf(result.rate())
-                .setScale(1, RoundingMode.HALF_UP),
+            rate,
             result.reviewCount(),
             result.photographer(),
             result.price(),

--- a/src/main/java/org/sopt/snappinserver/api/v1/wish/dto/response/WishedProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/wish/dto/response/WishedProductResponse.java
@@ -1,6 +1,8 @@
 package org.sopt.snappinserver.api.v1.wish.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductResult;
 
@@ -17,7 +19,7 @@ public record WishedProductResponse(
     String title,
 
     @Schema(description = "평균 별점", example = "4.8")
-    Double rate,
+    BigDecimal rate,
 
     @Schema(description = "리뷰 개수", example = "23")
     Integer reviewCount,
@@ -37,7 +39,8 @@ public record WishedProductResponse(
             result.id(),
             result.imageUrl(),
             result.title(),
-            result.rate(),
+            BigDecimal.valueOf(result.rate())
+                .setScale(1, RoundingMode.HALF_UP),
             result.reviewCount(),
             result.photographer(),
             result.price(),


### PR DESCRIPTION
## 👀 Summary

- close #223 

리뷰 평균 별점이 3, 4와 같이 나누어떨어지는 경우 3.0, 4.0 형태가 아닌 정수형으로 조회되는 문제를 해결했습니다.


## 🖇️ Tasks

- [x] 응답 DTO에서 평균 별점 타입을 BigDecimal로 변경
- [x] 응답 생성 시 setScale(1, RoundingMode.HALF_UP) 적용
- [x] 평균 별점이 정수값인 경우에도 3.0 형태로 응답되도록 수정
- [x] 기존 서비스 / 도메인 DTO 및 QueryDSL 로직은 그대로 유지


## 🔍 To Reviewer

상품 목록 조회 API에서 평균 별점 값이 3 / 3.5처럼 혼합되어 내려오던 문제를 수정했고, 모든 변경사항에 계산 로직 변경은 없습니다.

평균 별점 반올림 기준은 소수점 둘째 자리에서 반올림하여 첫째 자리까지 표시(HALF_UP)이며,  응답 DTO에서 평균 별점을 BigDecimal(scale=1)로 변환하여 항상 소수점 1자리(3.0, 3.5)로 표현되도록 보정했습니다.

비즈니스 로직, 서비스 DTO, 쿼리 로직에는 영향을 주지 않고 API 응답 DTO에서만 처리하도록 변경했습니다.