### PR TITLE
[FIX] #229: 작가의 모든 상품에 대해 예약 마감 시간대 통일 #229

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductAvailableTimesService.java
@@ -68,7 +68,7 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
         }
 
         List<LocalTime> slots = createTimeSlots(workStart, lastStartTime);
-        List<Reservation> reservations = getBlockedReservations(date, product);
+        List<Reservation> reservations = getBlockedReservations(date, photographer);
         List<ProductAvailableTimeResult> results = getProductAvailableTimeResults(
             slots,
             reservations,
@@ -120,12 +120,12 @@ public class GetProductAvailableTimesService implements GetProductAvailableTimes
     }
 
     // 시간 슬롯별 예약 가능 여부 계산
-    private List<Reservation> getBlockedReservations(LocalDate date, Product product) {
+    private List<Reservation> getBlockedReservations(LocalDate date, Photographer photographer) {
         LocalDateTime startOfDay = date.atStartOfDay();
         LocalDateTime endOfDay = date.plusDays(ONE_DAY).atStartOfDay();
 
-        return reservationRepository.findAllByProductAndReservedAtBetweenAndReservationStatusIn(
-            product,
+        return reservationRepository.findBlockedReservationsByPhotographerIdAndDate(
+            photographer.getId(),
             startOfDay,
             endOfDay,
             List.of(

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/PostProductReservationService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/PostProductReservationService.java
@@ -1,8 +1,11 @@
 package org.sopt.snappinserver.domain.product.service;
 
+import static org.sopt.snappinserver.domain.photographer.domain.entity.QPhotographer.photographer;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
 import org.sopt.snappinserver.domain.place.domain.entity.Place;
 import org.sopt.snappinserver.domain.place.domain.exception.PlaceErrorCode;
 import org.sopt.snappinserver.domain.place.domain.exception.PlaceException;
@@ -43,10 +46,11 @@ public class PostProductReservationService implements PostProductReservationUseC
         ProductReservationCommand command
     ) {
         Product product = getProduct(productId);
+        Photographer photographer = product.getPhotographer();
         User user = getUser(userId);
         Place place = getPlace(command);
 
-        validateNoOverlappingReservation(product, command);
+        validateNoOverlappingReservation(photographer, command);
 
         Reservation reservation = createReservation(product, user, place, command);
         Reservation saved = reservationRepository.save(reservation);
@@ -73,15 +77,15 @@ public class PostProductReservationService implements PostProductReservationUseC
     }
 
     private void validateNoOverlappingReservation(
-        Product product,
+        Photographer photographer,
         ProductReservationCommand command
     ) {
         LocalDateTime startAt = command.reservedAt();
         LocalDateTime endAt = startAt.plusMinutes(command.durationTime());
 
         List<Reservation> reservations =
-            reservationRepository.findAllByProductAndReservationStatusIn(
-                product,
+            reservationRepository.findByPhotographerAndStatusIn(
+                photographer.getId(),
                 List.of(
                     ReservationStatus.RESERVATION_REQUESTED,
                     ReservationStatus.PHOTOGRAPHER_CHECKING,

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepository.java
@@ -2,6 +2,7 @@ package org.sopt.snappinserver.domain.reservation.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
 import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
 import org.sopt.snappinserver.domain.reservation.domain.enums.ReservationStatus;
@@ -57,4 +58,22 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         @Param("userId") Long userId,
         @Param("statuses") List<ReservationStatus> statuses
     );
+
+    // 작가의 모든 상품에 걸린 예약 목록
+    @Query("""
+    select r
+    from Reservation r
+    join r.product p
+    where p.photographer.id = :photographerId
+      and r.reservedAt >= :start
+      and r.reservedAt < :end
+      and r.reservationStatus in :statuses
+""")
+    List<Reservation> findBlockedReservationsByPhotographerIdAndDate(
+        @Param("photographerId") Long photographerId,
+        @Param("start") LocalDateTime start,
+        @Param("end") LocalDateTime end,
+        @Param("statuses") List<ReservationStatus> statuses
+    );
+
 }

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/repository/ReservationRepository.java
@@ -61,18 +61,30 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     // 작가의 모든 상품에 걸린 예약 목록
     @Query("""
-    select r
-    from Reservation r
-    join r.product p
-    where p.photographer.id = :photographerId
-      and r.reservedAt >= :start
-      and r.reservedAt < :end
-      and r.reservationStatus in :statuses
-""")
+            select r
+            from Reservation r
+            join r.product p
+            where p.photographer.id = :photographerId
+              and r.reservedAt >= :start
+              and r.reservedAt < :end
+              and r.reservationStatus in :statuses
+        """)
     List<Reservation> findBlockedReservationsByPhotographerIdAndDate(
         @Param("photographerId") Long photographerId,
         @Param("start") LocalDateTime start,
         @Param("end") LocalDateTime end,
+        @Param("statuses") List<ReservationStatus> statuses
+    );
+
+    @Query("""
+            select r
+            from Reservation r
+            join r.product p
+            where p.photographer.id = :photographerId
+              and r.reservationStatus in :statuses
+        """)
+    List<Reservation> findByPhotographerAndStatusIn(
+        @Param("photographerId") Long photographerId,
         @Param("statuses") List<ReservationStatus> statuses
     );
 


### PR DESCRIPTION
## 👀 Summary

- close #229

작가(Photographer) 단위로 예약 가능 시간/예약 충돌을 판단하도록 수정했습니다.
기존의 상품(Product) 단위 예약 확인에서 작가의 모든 상품을 하나의 스케줄로 간주하도록 변경했습니다.

조회 API(예약 가능 시간대)에서는 작가 기준으로 block 대상 예약을 비교해 시간 슬롯의 isAvailable을 계산하고,
예약 생성 API(예약하기)에서도 동일하게 작가 기준 시간 충돌 검증을 추가했습니다.


## 🖇️ Tasks

**예약 가능 시간대 조회**

- [x] 작가의 업무 시작/종료 및 상품 촬영 시간으로 슬롯 생성 범위 산정
- [x] 범위 내 30분 단위 슬롯 전체를 응답에 포함(업무시간 외 제외)
- [x] 작가 기준 block 예약과 시간 구간 겹침 여부로 isAvailable 계산
- [x] (오늘 날짜인 경우) 현재 시간 이전 슬롯은 isAvailable=false 처리

**예약 생성(예약하기)**

- [x] 예약 생성 시점에 작가 기준 시간 충돌 검증 추가
- [x] block 대상 상태(요청/확인중/결제요청/확정 등)와 시간 구간 겹침 검사로 중복 예약 방지

**Repository**

- [x] 작가 기준 예약 조회를 위한 메서드 추가/사용 (상품 기준 조회 → 작가 기준 조회로 전환)

## 🔍 To Reviewer

### ❶ 왜 작가 기준으로 바꿨는가?

기획/도메인 정책 상 작가는 물리적으로 한 명이고, 동일 시간에 여러 촬영을 수행할 수 없습니다. 따라서 특정 상품에 예약이 들어오면, 해당 작가의 다른 모든 상품도 같은 시간대가 막혀야 합니다.

기존 구현은 Product 단위로만 예약을 조회해 충돌을 판단하고 있어서, 상품 A에 예약이 있어도 상품 B에서는 같은 시간대가 예약 가능(true) 으로 노출/예약될 수 있는 정책 불일치가 존재했습니다.

이를 해소하기 위해 조회/생성 모두 Photographer 단위로 예약 충돌을 판단하도록 통일했습니다.

### ❷ 조회 API에서의 처리 흐름 (예약 가능 시간대)

예약 가능 시간 계산 시, 상품 단위가 아닌 작가 단위로 예약을 조회합니다.  조회 대상 예약은 실제로 시간대를 막아야 하는 상태만 포함합니다.

- `RESERVATION_REQUESTED`
- `PHOTOGRAPHER_CHECKING`
- `PAYMENT_REQUESTED`
- `RESERVATION_CONFIRMED`
- `SHOOT_COMPLETED`

작가의 다른 상품에 존재하는 예약도 모두 반영하여, 하나의 작가 스케줄로 시간대 충돌 여부를 판단합니다.
업무 시간 내의 모든 슬롯을 응답에 포함하고, 예약과 시간 구간이 겹치는 슬롯만 `isAvailable = false`로 처리합니다.


### ❸ 예약 생성 API 변경 사항 (예약하기)

예약 생성 시점에서도 동일하게 작가 기준 예약 시간대 겹침 여부 검증을 추가했습니다.
예약 요청 시 photographer를 기준으로 해당 작가의 모든 예약을 대상으로 시간 구간 겹침 여부를 검사합니다.

충돌 판정은 아래의 표준 구간 겹침 조건을 사용합니다.

`existingStart < endAt && existingEnd > startAt`


이 조건에 따라, 이전 예약이 09:00~09:30이고신규 예약이 09:30부터 시작하는 경우 겹치지 않는 정상 예약으로 처리됩니다.