### PR TITLE
[FIX] #232: 작가 프로필 조회 시 작가 닉네임 반환

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
@@ -94,7 +94,7 @@ public class GetUserInfoService implements GetUserInfoUseCase {
         List<String> specialties = getSpecialties(photographer);
         List<String> locations = getAvailableLocations(photographer);
         GetPhotographerInfoResult photographerInfo = new GetPhotographerInfoResult(
-            photographer.getName(),
+            photographer.getNickname(),
             photographer.getBio(),
             specialties,
             locations


### PR DESCRIPTION
## 👀 Summary

- close #232 

작가 프로필 조회 시 작가 본명이 아닌 닉네임을 반환하도록 수정했습니다.

## 🖇️ Tasks

- [x] name에서 nickname으로 변경 

## 🔍 To Reviewer

