### PR TITLE
[FIX] #234: 포트폴리오, 상품 상세 조회 시 작가 프로필 이미지 누락 해결

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/portfolio/dto/response/GetPortfolioPhotographerInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/portfolio/dto/response/GetPortfolioPhotographerInfoResponse.java
@@ -13,6 +13,9 @@ public record GetPortfolioPhotographerInfoResponse(
     @Schema(description = "작가명")
     String name,
 
+    @Schema(description = "작가 프로필 이미지")
+    String imageUrl,
+
     @Schema(description = "작가 한줄 소개")
     String bio,
 
@@ -29,6 +32,7 @@ public record GetPortfolioPhotographerInfoResponse(
         return new GetPortfolioPhotographerInfoResponse(
             result.id(),
             result.name(),
+            result.imageUrl(),
             result.bio(),
             result.specialties(),
             result.locations()

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetProductPhotographerInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetProductPhotographerInfoResponse.java
@@ -13,6 +13,9 @@ public record GetProductPhotographerInfoResponse(
     @Schema(description = "작가 이름")
     String name,
 
+    @Schema(description = "프로필 이미지 URL")
+    String profileImageUrl,
+
     @Schema(description = "한줄 소개")
     String bio,
 
@@ -27,6 +30,7 @@ public record GetProductPhotographerInfoResponse(
         return new GetProductPhotographerInfoResponse(
             result.id(),
             result.name(),
+            result.profileImageUrl(),
             result.bio(),
             result.specialties(),
             result.locations()

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPhotographerInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/dto/response/GetPhotographerInfoResult.java
@@ -6,6 +6,7 @@ import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
 public record GetPhotographerInfoResult(
     Long id,
     String name,
+    String imageUrl,
     String bio,
     List<String> specialties,
     List<String> locations
@@ -13,12 +14,14 @@ public record GetPhotographerInfoResult(
 
     public static GetPhotographerInfoResult of(
         Photographer photographer,
+        String profileImageUrl,
         List<String> photographerSpecialties,
         List<String> photographerAvailableLocations
     ) {
         return new GetPhotographerInfoResult(
             photographer.getId(),
             photographer.getNickname(),
+            profileImageUrl,
             photographer.getBio(),
             photographerSpecialties,
             photographerAvailableLocations

--- a/src/main/java/org/sopt/snappinserver/domain/portfolio/service/mapper/PortfolioDetailMapper.java
+++ b/src/main/java/org/sopt/snappinserver/domain/portfolio/service/mapper/PortfolioDetailMapper.java
@@ -56,6 +56,7 @@ public class PortfolioDetailMapper {
             portfolioMoods,
             GetPhotographerInfoResult.of(
                 photographer,
+                cloudFrontDomain + photographer.getUser().getProfileImageUrl(),
                 photographerSpecialties,
                 photographerLocations
             ),

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductDetailService.java
@@ -71,9 +71,11 @@ public class GetProductDetailService implements GetProductDetailUseCase {
 
         List<ProductOption> productOptions = productOptionRepository.findByProduct(product);
         Map<ProductOptionCategory, String> optionMap = getProductOptions(productOptions);
+        String profileImageUrl = cloudFrontDomain + photographer.getUser().getProfileImageUrl();
 
         GetPhotographerInfoResult photographerInfoResult = getPhotographerInfoResult(
             photographer,
+            profileImageUrl,
             specialties,
             locations
         );
@@ -144,10 +146,15 @@ public class GetProductDetailService implements GetProductDetailUseCase {
             .toList();
     }
 
-    private static GetPhotographerInfoResult getPhotographerInfoResult(Photographer photographer,
-        List<String> specialties, List<String> locations) {
+    private static GetPhotographerInfoResult getPhotographerInfoResult(
+        Photographer photographer,
+        String photographerImageUrl,
+        List<String> specialties,
+        List<String> locations
+    ) {
         return GetPhotographerInfoResult.of(
             photographer,
+            photographerImageUrl,
             specialties,
             locations
         );

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetPhotographerInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetPhotographerInfoResult.java
@@ -6,6 +6,7 @@ import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
 public record GetPhotographerInfoResult(
     Long id,
     String name,
+    String profileImageUrl,
     String bio,
     List<String> specialties,
     List<String> locations
@@ -13,12 +14,14 @@ public record GetPhotographerInfoResult(
 
     public static GetPhotographerInfoResult of(
         Photographer photographer,
+        String profileImageUrl,
         List<String> specialties,
         List<String> locations
     ) {
         return new GetPhotographerInfoResult(
             photographer.getId(),
             photographer.getNickname(),
+            profileImageUrl,
             photographer.getBio(),
             specialties,
             locations


### PR DESCRIPTION
## 👀 Summary

- close #234


## 🖇️ Tasks

- 포트폴리오 상세 조회 시 작가 프로필 이미지 누락된 부분을 응답에 추가했습니다.
- 상품 상세 조회 시 작가 프로필 이미지 누락된 부분을 응답에 추가했습니다.

## 🔍 To Reviewer

-
