### PR TITLE
[CHORE] #240: Annotatinon 관련 코드래빗 설정 변경

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -101,11 +101,29 @@ reviews:
         - 필터링/검색은 query string 사용
         
         [Annotation 위치 기준]
-        - 검증 관련 (@Valid, @NotNull 등):	인터페이스에 위치
-        - 요청 관련 (@RequestBody, @RequestParam, @PathVariable):	인터페이스에 위치
-        - 인증 관련 (@AuthenticationPrincipal): 컨트롤러 구현체에 위치
-          단, 인증 관련 어노테이션은 인터페이스에서 @parameter(hidden = true) 붙여서 스웨거에 표시되지 않는 것으로 구현
-        
+        1. Interface (계약 / 명세 계층)
+          - Swagger 관련 (@Tag, @Operation, @Schema, @Parameter): 인터페이스에 위치
+          - HTTP Mapping 관련 (@GetMapping, @PostMapping, @PutMapping, @PatchMapping, @DeleteMapping): 인터페이스에 위치
+          - 요청 관련 (@RequestBody, @RequestParam, @PathVariable, @ModelAttribute, @RequestPart, @RequestHeader, @CookieValue): 인터페이스에 위치
+          - 형식 검증 관련 (@Valid, @NotNull, @NotBlank, @NotEmpty, @Min, @Max, @Positive, @PositiveOrZero, @Size, @Pattern, @DateTimeFormat): 인터페이스에 위치
+          - 인증 파라미터 문서 숨김 (@Parameter(hidden = true)): 인터페이스에 위치
+          - 상태 코드 (@ResponseStatus), CORS 정책 (@CrossOrigin): 정책에 따라 인터페이스에 위치 가능하나 위치 일관성 유지
+
+        2. Controller (실행 / 런타임 계층)
+          - Base Path (@RequestMapping): 컨트롤러 구현체에 위치
+          - 인증 관련 (@AuthenticationPrincipal): 컨트롤러 구현체에 위치
+          - Bean 등록 (@RestController, @Controller): 컨트롤러 구현체에 위치
+          - AOP 기반 검증 활성화 (@Validated): 컨트롤러 구현체에 위치
+          - 예외 처리 (@ExceptionHandler): 컨트롤러 구현체에 위치
+          - 바인딩 제어 (@InitBinder): 컨트롤러 구현체에 위치
+          - DI / 로깅 (@RequiredArgsConstructor, @Slf4j): 컨트롤러 구현체에 위치
+          - 상태 코드 (@ResponseStatus), CORS 정책 (@CrossOrigin): 정책에 따라 컨트롤러에 위치 가능하나 위치 일관성 유지
+
+        [중복 선언 금지]
+        - 동일한 Mapping, Validation, 요청 정의 어노테이션을 Interface와 Controller에 동시에 선언하지 않음
+        - 계약은 Interface 단일 책임
+        - Controller는 실행 책임
+
         [Layer별 검증 책임]
         1. API Layer (Interface/Controller)
         - 책임: 요청 데이터의 형식(Format) 검증


### PR DESCRIPTION
## 👀 Summary

- close #240

Controller / API 인터페이스 계층에서 사용하는 Annotation 위치 기준을 명확히 정의하고, 해당 컨벤션을 `.coderabbit.yaml`에 반영했습니다.

기존에는 일부 Annotation이 계층 간에 혼재되어 있었고, 계약(Interface)과 구현체(Controller)의 책임 경계가 문서로 명확히 정의되지 않았기 때문에 구조적인 컨벤션만 정리했으며 기능 변경은 없습니다!

## 🖇️ Tasks

- Annotation 위치 기준 정립
- 계약 / 실행 계층 책임 분리 강화
- 형식 검증 / 의미 검증 책임 명확화
- 중복 선언 방지 규칙 추가
- CodeRabbit 자동 리뷰 규칙 반영

## 🔍 To Reviewer

### ❶ Annotation 위치 기준

| 구분 | 어노테이션 | 위치 |
|------|------------|------|
| Swagger 관련 | `@Tag`, `@Operation`, `@Schema`, `@Parameter` | Interface |
| HTTP Mapping | `@GetMapping`, `@PostMapping`, `@PutMapping`, `@PatchMapping`, `@DeleteMapping` | Interface |
| 요청 정의 | `@RequestBody`, `@RequestParam`, `@PathVariable`, `@ModelAttribute`, `@RequestPart`, `@RequestHeader`, `@CookieValue` | Interface |
| 형식 검증 (Bean Validation) | `@Valid`, `@NotNull`, `@NotBlank`, `@NotEmpty`, `@Min`, `@Max`, `@Positive`, `@PositiveOrZero`, `@Size`, `@Pattern`, `@DateTimeFormat` | Interface |
| 인증 파라미터 문서 숨김 | `@Parameter(hidden = true)` | Interface |
| Base Path | `@RequestMapping` (클래스 레벨) | Controller |
| 인증 처리 | `@AuthenticationPrincipal` | Controller |
| Bean 등록 | `@RestController`, `@Controller` | Controller |
| AOP 기반 검증 활성화 | `@Validated` | Controller |
| 예외 처리 | `@ExceptionHandler` | Controller |
| 바인딩 제어 | `@InitBinder` | Controller |
| DI / 로깅 | `@RequiredArgsConstructor`, `@Slf4j` | Controller |
| 상태 코드 | `@ResponseStatus` | 정책에 따라 Interface 또는 Controller (위치 일관성 유지) |
| CORS 정책 | `@CrossOrigin` | 정책에 따라 Interface 또는 Controller (위치 일관성 유지) |


### ❷ Layer별 검증 책임

**API Layer (Interface/Controller)**
- 형식(Format) 검증 담당
- Null 여부, 범위, 타입, 포맷 등
- 위반 시 400 Bad Request

**Service Layer**
- 의미(Semantic) 검증 담당
- 존재 여부, 권한, 상태, 도메인 규칙
- API 계층과 검증 중복 금지
- 위반 시 BusinessException


### ❸ 공통 원칙

> 1. 동일한 Mapping, Validation, 요청 정의 어노테이션을 Interface와 Controller에 동시에 선언하지 않음
> 2. 계약은 Interface 단일 책임
> 3. Controller는 실행 책임