### PR TITLE
[REFACTOR] #243: 카카오 로그인 시 응답값에 작가 프로필 보유 여부 필드 추가

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v2/auth/controller/AuthApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/auth/controller/AuthApi.java
@@ -1,6 +1,7 @@
 package org.sopt.snappinserver.api.v2.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
@@ -30,6 +31,6 @@ public interface AuthApi {
 
         @RequestHeader(value = "User-Agent", required = false) String userAgent,
 
-        HttpServletResponse httpServletResponse
+        @Parameter(hidden = true) HttpServletResponse httpServletResponse
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/v2/auth/controller/AuthApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/auth/controller/AuthApi.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import org.sopt.snappinserver.api.v2.auth.dto.request.CreateKakaoLoginRequest;
 import org.sopt.snappinserver.api.v2.auth.dto.response.CreateKakaoLoginResponse;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Tag(name = "01 - Auth", description = "인증/인가 관련 API V2")
 public interface AuthApi {
 
+    @PostMapping("/login/kakao")
     @Operation(
         summary = "카카오 로그인",
         description = "인가 코드를 받아 카카오로 소셜 로그인을 진행합니다."

--- a/src/main/java/org/sopt/snappinserver/api/v2/auth/controller/AuthApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/auth/controller/AuthApi.java
@@ -1,0 +1,33 @@
+package org.sopt.snappinserver.api.v2.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.sopt.snappinserver.api.v2.auth.dto.request.CreateKakaoLoginRequest;
+import org.sopt.snappinserver.api.v2.auth.dto.response.CreateKakaoLoginResponse;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "01 - Auth", description = "인증/인가 관련 API V2")
+public interface AuthApi {
+
+    @Operation(
+        summary = "카카오 로그인",
+        description = "인가 코드를 받아 카카오로 소셜 로그인을 진행합니다."
+    )
+    ApiResponseBody<CreateKakaoLoginResponse, Void> createKakaoLogin(
+
+        @Schema(description = "카카오에 등록할 redirect_uri 주소입니다.", example = "http://localhost:8080/api/v1/auth/login/kakao", nullable = true)
+        @RequestParam(name = "redirect_uri", required = false) String clientRedirectUri,
+
+        @Valid @RequestBody CreateKakaoLoginRequest createKakaoLoginRequest,
+
+        @RequestHeader(value = "User-Agent", required = false) String userAgent,
+
+        HttpServletResponse httpServletResponse
+    );
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/auth/controller/AuthApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/auth/controller/AuthApi.java
@@ -23,7 +23,7 @@ public interface AuthApi {
     )
     ApiResponseBody<CreateKakaoLoginResponse, Void> createKakaoLogin(
 
-        @Schema(description = "카카오에 등록할 redirect_uri 주소입니다.", example = "http://localhost:8080/api/v1/auth/login/kakao", nullable = true)
+        @Schema(description = "카카오에 등록할 redirect_uri 주소입니다.", example = "http://localhost:8080/api/v2/auth/login/kakao", nullable = true)
         @RequestParam(name = "redirect_uri", required = false) String clientRedirectUri,
 
         @Valid @RequestBody CreateKakaoLoginRequest createKakaoLoginRequest,

--- a/src/main/java/org/sopt/snappinserver/api/v2/auth/controller/AuthControllerV2.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/auth/controller/AuthControllerV2.java
@@ -1,7 +1,6 @@
 package org.sopt.snappinserver.api.v2.auth.controller;
 
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.snappinserver.api.v2.auth.dto.request.CreateKakaoLoginRequest;
@@ -13,11 +12,7 @@ import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v2/auth")
@@ -35,16 +30,15 @@ public class AuthControllerV2 implements AuthApi {
     private long refreshTokenSeconds;
 
     @Override
-    @PostMapping("/login/kakao")
     public ApiResponseBody<CreateKakaoLoginResponse, Void> createKakaoLogin(
-        @RequestParam(name = "redirect_uri", required = false) String clientRedirectUri,
-        @Valid @RequestBody CreateKakaoLoginRequest createKakaoLoginRequest,
-        @RequestHeader(value = "User-Agent", required = false) String userAgent,
+        String clientRedirectUri,
+        CreateKakaoLoginRequest createKakaoLoginRequest,
+        String userAgent,
         HttpServletResponse httpServletResponse
     ) {
         String redirectUri =
             (clientRedirectUri == null)
-                ? ("http://localhost:8080/api/v1/auth/login/kakao")
+                ? ("http://localhost:8080/api/v2/auth/login/kakao")
                 : clientRedirectUri;
         LoginWithPhotographerProfileResult loginResult = authFacade.loginWithPhotographerProfile(
             redirectUri,

--- a/src/main/java/org/sopt/snappinserver/api/v2/auth/controller/AuthControllerV2.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/auth/controller/AuthControllerV2.java
@@ -1,0 +1,72 @@
+package org.sopt.snappinserver.api.v2.auth.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.snappinserver.api.v2.auth.dto.request.CreateKakaoLoginRequest;
+import org.sopt.snappinserver.api.v2.auth.dto.response.CreateKakaoLoginResponse;
+import org.sopt.snappinserver.domain.auth.facade.AuthFacade;
+import org.sopt.snappinserver.domain.auth.service.dto.response.LoginWithPhotographerProfileResult;
+import org.sopt.snappinserver.global.response.code.auth.AuthSuccessCode;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v2/auth")
+@RequiredArgsConstructor
+@RestController
+@Slf4j
+public class AuthControllerV2 implements AuthApi {
+
+    private final AuthFacade authFacade;
+
+    @Value("${auth.cookie.secure}")
+    private boolean isSecure;
+
+    @Value("${jwt.refresh-token-ttl-seconds}")
+    private long refreshTokenSeconds;
+
+    @Override
+    @PostMapping("/login/kakao")
+    public ApiResponseBody<CreateKakaoLoginResponse, Void> createKakaoLogin(
+        @RequestParam(name = "redirect_uri", required = false) String clientRedirectUri,
+        @Valid @RequestBody CreateKakaoLoginRequest createKakaoLoginRequest,
+        @RequestHeader(value = "User-Agent", required = false) String userAgent,
+        HttpServletResponse httpServletResponse
+    ) {
+        String redirectUri =
+            (clientRedirectUri == null)
+                ? ("http://localhost:8080/api/v1/auth/login/kakao")
+                : clientRedirectUri;
+        LoginWithPhotographerProfileResult loginResult = authFacade.loginWithPhotographerProfile(
+            redirectUri,
+            createKakaoLoginRequest.code(),
+            userAgent
+        );
+        ResponseCookie refreshCookie = getResponseCookie(loginResult.refreshToken());
+        httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+
+        return ApiResponseBody.ok(
+            AuthSuccessCode.LOGIN_SUCCESS,
+            CreateKakaoLoginResponse.from(loginResult)
+        );
+    }
+
+    private ResponseCookie getResponseCookie(String refreshTokenValue) {
+        return ResponseCookie.from("refreshToken", refreshTokenValue)
+            .httpOnly(true)
+            .secure(isSecure)
+            .sameSite(isSecure ? "None" : "Lax")
+            .path("/")
+            .maxAge(refreshTokenSeconds)
+            .build();
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/auth/dto/request/CreateKakaoLoginRequest.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/auth/dto/request/CreateKakaoLoginRequest.java
@@ -1,0 +1,14 @@
+package org.sopt.snappinserver.api.v2.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "카카오 로그인 요청 DTO")
+public record CreateKakaoLoginRequest(
+
+    @Schema(description = "인가 코드", example = "il3uaRxUwljpgZy_YUYHqR_YhhyqV2WShVDq_k2m-m8TFWMDwlC-kAAAAAQKFwHPAAABm5kN17ctjdRiIM79qQ")
+    @NotBlank(message = "인가 코드는 필수입니다.")
+    String code
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/auth/dto/response/CreateKakaoLoginResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/auth/dto/response/CreateKakaoLoginResponse.java
@@ -1,0 +1,30 @@
+package org.sopt.snappinserver.api.v2.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.auth.service.dto.response.LoginWithPhotographerProfileResult;
+
+@Schema(description = "카카오 로그인 응답 DTO")
+public record CreateKakaoLoginResponse(
+
+    @Schema(description = "신규 가입 여부")
+    boolean isNew,
+
+    @Schema(description = "인증 시 필요한 accessToken입니다. refreshToken은 쿠키로 내려드립니다.")
+    String accessToken,
+
+    @Schema(description = "현재 로그인한 유저 역할")
+    String role,
+
+    @Schema(description = "작가 프로필 보유 여부")
+    boolean hasPhotographerProfile
+) {
+
+    public static CreateKakaoLoginResponse from(LoginWithPhotographerProfileResult loginResult) {
+        return new CreateKakaoLoginResponse(
+            loginResult.isNew(),
+            loginResult.accessToken(),
+            loginResult.role(),
+            loginResult.hasPhotographerProfile()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/auth/facade/AuthFacade.java
+++ b/src/main/java/org/sopt/snappinserver/domain/auth/facade/AuthFacade.java
@@ -21,10 +21,10 @@ public class AuthFacade {
         String userAgent
     ) {
         LoginResult loginResult = loginUseCase.kakaoLogin(redirectUri, accessCode, userAgent);
-        GetPhotographerExistenceResult hasPhotographerProfile = getPhotographerExistenceUseCase
+        GetPhotographerExistenceResult photographerExistence = getPhotographerExistenceUseCase
             .getHasPhotographerProfile(loginResult.userId());
 
-        return LoginWithPhotographerProfileResult.of(loginResult, hasPhotographerProfile);
+        return LoginWithPhotographerProfileResult.of(loginResult, photographerExistence);
     }
 
 }

--- a/src/main/java/org/sopt/snappinserver/domain/auth/facade/AuthFacade.java
+++ b/src/main/java/org/sopt/snappinserver/domain/auth/facade/AuthFacade.java
@@ -1,0 +1,30 @@
+package org.sopt.snappinserver.domain.auth.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.auth.service.dto.response.LoginResult;
+import org.sopt.snappinserver.domain.auth.service.dto.response.LoginWithPhotographerProfileResult;
+import org.sopt.snappinserver.domain.auth.service.usecase.LoginUseCase;
+import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerExistenceResult;
+import org.sopt.snappinserver.domain.photographer.service.usecase.GetPhotographerExistenceUseCase;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthFacade {
+
+    private final LoginUseCase loginUseCase;
+    private final GetPhotographerExistenceUseCase getPhotographerExistenceUseCase;
+
+    public LoginWithPhotographerProfileResult loginWithPhotographerProfile(
+        String redirectUri,
+        String accessCode,
+        String userAgent
+    ) {
+        LoginResult loginResult = loginUseCase.kakaoLogin(redirectUri, accessCode, userAgent);
+        GetPhotographerExistenceResult hasPhotographerProfile = getPhotographerExistenceUseCase
+            .getHasPhotographerProfile(loginResult.userId());
+
+        return LoginWithPhotographerProfileResult.of(loginResult, hasPhotographerProfile);
+    }
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/auth/service/LoginService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/auth/service/LoginService.java
@@ -35,7 +35,7 @@ public class LoginService implements LoginUseCase {
         );
         TokenPair tokenPair = authTokenManager.issueTokenPair(user, userAgent);
 
-        return LoginResult.of(isNew, tokenPair, user.getRole());
+        return LoginResult.of(isNew, tokenPair, user);
     }
 
     private KakaoUserProfile fetchKakaoUserInfo(String redirectUri, String accessCode) {

--- a/src/main/java/org/sopt/snappinserver/domain/auth/service/dto/response/LoginResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/auth/service/dto/response/LoginResult.java
@@ -1,21 +1,23 @@
 package org.sopt.snappinserver.domain.auth.service.dto.response;
 
 import org.sopt.snappinserver.domain.auth.domain.value.TokenPair;
-import org.sopt.snappinserver.domain.user.domain.enums.UserRole;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
 
 public record LoginResult(
     boolean isNew,
     String accessToken,
     String refreshToken,
-    String role
+    String role,
+    Long userId
 ) {
 
-    public static LoginResult of(boolean isNew, TokenPair tokenPair, UserRole userRole) {
+    public static LoginResult of(boolean isNew, TokenPair tokenPair, User user) {
         return new LoginResult(
             isNew,
             tokenPair.accessToken(),
             tokenPair.refreshToken(),
-            userRole.name()
+            user.getRole().name(),
+            user.getId()
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/auth/service/dto/response/LoginWithPhotographerProfileResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/auth/service/dto/response/LoginWithPhotographerProfileResult.java
@@ -1,0 +1,25 @@
+package org.sopt.snappinserver.domain.auth.service.dto.response;
+
+import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerExistenceResult;
+
+public record LoginWithPhotographerProfileResult(
+    boolean isNew,
+    String accessToken,
+    String refreshToken,
+    String role,
+    boolean hasPhotographerProfile
+) {
+
+    public static LoginWithPhotographerProfileResult of(
+        LoginResult loginResult,
+        GetPhotographerExistenceResult getPhotographerExistenceResult
+    ) {
+        return new LoginWithPhotographerProfileResult(
+            loginResult.isNew(),
+            loginResult.accessToken(),
+            loginResult.refreshToken(),
+            loginResult.role(),
+            getPhotographerExistenceResult.hasPhotographerProfile()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/repository/PhotographerRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/repository/PhotographerRepository.java
@@ -14,6 +14,8 @@ public interface PhotographerRepository extends JpaRepository<Photographer, Long
 
     boolean existsByUser(User user);
 
+    boolean existsByUserId(Long userId);
+
     @Query(
         value = """
                 SELECT *

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetPhotographerExistenceService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/GetPhotographerExistenceService.java
@@ -1,0 +1,20 @@
+package org.sopt.snappinserver.domain.photographer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.photographer.repository.PhotographerRepository;
+import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerExistenceResult;
+import org.sopt.snappinserver.domain.photographer.service.usecase.GetPhotographerExistenceUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class GetPhotographerExistenceService implements GetPhotographerExistenceUseCase {
+
+    private final PhotographerRepository photographerRepository;
+
+    public GetPhotographerExistenceResult getHasPhotographerProfile(Long userId) {
+        return new GetPhotographerExistenceResult(photographerRepository.existsByUserId(userId));
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/dto/response/GetPhotographerExistenceResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/dto/response/GetPhotographerExistenceResult.java
@@ -1,0 +1,5 @@
+package org.sopt.snappinserver.domain.photographer.service.dto.response;
+
+public record GetPhotographerExistenceResult(boolean hasPhotographerProfile) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/usecase/GetPhotographerExistenceUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/usecase/GetPhotographerExistenceUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.photographer.service.usecase;
+
+import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerExistenceResult;
+
+public interface GetPhotographerExistenceUseCase {
+
+    GetPhotographerExistenceResult getHasPhotographerProfile(Long userId);
+}

--- a/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
@@ -69,6 +69,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/v1/reviews/images").authenticated()
                 .requestMatchers(AUTHENTICATED_URLS).authenticated()
                 .requestMatchers(HttpMethod.POST, "/api/v1/auth/login/kakao").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/v2/auth/login/kakao").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/v1/auth/reissue").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/v1/photos/process").permitAll()
                 .requestMatchers(HttpMethod.GET, PUBLIC_GET_URLS).permitAll()

--- a/src/main/java/org/sopt/snappinserver/global/security/TokenAuthenticationFilter.java
+++ b/src/main/java/org/sopt/snappinserver/global/security/TokenAuthenticationFilter.java
@@ -33,7 +33,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getServletPath();
         return path.equals("/api/v1/auth/reissue") || path.equals("/api/v1/auth/login/kakao")
-            || path.equals("/api/v1/photos/process");
+            || path.equals("/api/v2/auth/login/kakao") || path.equals("/api/v1/photos/process");
     }
 
     @Override


### PR DESCRIPTION
## 👀 Summary

- close #243 


## 🖇️ Tasks

- `로그인 시 작가 프로필 응답 로직 추가`: 유저 로그인 성공 시, 해당 유저의 작가 프로필 보유 여부를 함께 반환합니다.


## 🔍 To Reviewer

### ❶ API 버저닝 적용 배경

기존 로그인/유저 조회 API(v1)는 인증 및 기본 유저 정보만 반환하는 구조였습니다. 이번 프론트 측 요구사항에서 로그인 후 전역 상태 관리에 필요한 api가 분산되어 관리가  어렵다는 문제를 바탕으로 로그인 시, 해당 유저의 작가 프로필 보유 여부를 함께 반환합니다.
이때, 기존 클라이언트에 연결된 API에 대한 영향을 최소화하고, 점진적 마이그레이션 대응을 위해 v2 API로 분리하여 대응했습니다.

### ❷ Facade(Application Layer) 도입 이유

이번 변경으로 로그인/유저 조회 시 다음과 같은 다중 도메인 조합이 필요해졌습니다.

- `Auth 도메인`: 로그인 및 토큰 발급
- `Photographer 도메인`: 작가 프로필 보유 여부 조회

기존 구조에서 이를 컨트롤러 또는 단일 서비스에 직접 결합할 경우, 도메인 간 결합도가 증가하고 책임 경계가 흐려지는 문제가 발생할 수 있었습니다. 이에 따라, 도메인 서비스는 각각의 책임에 집중할 수 있도록 하기 위해 Facade에서 유스케이스 단위로 조합하였습니다.