### PR TITLE
[REFACTOR] 사용자, 무드, 장소 관련 도메인 Annotation 재정비

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/auth/controller/AuthApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/auth/controller/AuthApi.java
@@ -2,7 +2,6 @@ package org.sopt.snappinserver.api.v1.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -26,7 +25,7 @@ public interface AuthApi {
     )
     @PostMapping("/login/kakao")
     ApiResponseBody<CreateKakaoLoginResponse, Void> createKakaoLogin(
-        @Schema(description = "카카오에 등록할 redirect_uri 주소입니다.", example = "http://localhost:8080/api/v1/auth/login/kakao", nullable = true)
+        @Parameter(description = "카카오에 등록할 redirect_uri 주소입니다.", example = "http://localhost:8080/api/v1/auth/login/kakao")
         @RequestParam(name = "redirect_uri", required = false)
         String clientRedirectUri,
 
@@ -34,6 +33,7 @@ public interface AuthApi {
         @RequestBody
         CreateKakaoLoginRequest createKakaoLoginRequest,
 
+        @Parameter(description = "유저가 로그인한 기기")
         @RequestHeader(value = "User-Agent", required = false)
         String userAgent,
 
@@ -47,10 +47,11 @@ public interface AuthApi {
     )
     @PostMapping("/reissue")
     ApiResponseBody<CreateAccessTokenResponse, Void> createReissuedTokens(
-        @Schema(description = "재발급 때 사용할 refreshToken 입니다. 쿠키 설정만 해주시면 자동으로 보내집니다.")
+        @Parameter(description = "재발급 때 사용할 refreshToken 입니다. 쿠키 설정만 해주시면 자동으로 보내집니다.")
         @CookieValue(name = "refreshToken")
         String refreshToken,
 
+        @Parameter(description = "유저 로그인 기기")
         @RequestHeader(value = "User-Agent", required = false)
         String userAgent,
 
@@ -67,7 +68,7 @@ public interface AuthApi {
         @Parameter(hidden = true)
         CustomUserInfo principal,
 
-        @Schema(description = "로그아웃 시 사용할 refreshToken 입니다. 쿠키 설정만 해주시면 자동으로 보내집니다.")
+        @Parameter(description = "로그아웃 시 사용할 refreshToken 입니다. 쿠키 설정만 해주시면 자동으로 보내집니다.")
         @CookieValue(name = "refreshToken", required = false)
         String refreshToken,
 

--- a/src/main/java/org/sopt/snappinserver/api/v1/auth/controller/AuthApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/auth/controller/AuthApi.java
@@ -1,6 +1,7 @@
 package org.sopt.snappinserver.api.v1.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
@@ -10,8 +11,8 @@ import org.sopt.snappinserver.api.v1.auth.dto.response.CreateAccessTokenResponse
 import org.sopt.snappinserver.api.v1.auth.dto.response.CreateKakaoLoginResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,15 +24,20 @@ public interface AuthApi {
         summary = "카카오 로그인",
         description = "인가 코드를 받아 카카오로 소셜 로그인을 진행합니다."
     )
+    @PostMapping("/login/kakao")
     ApiResponseBody<CreateKakaoLoginResponse, Void> createKakaoLogin(
-
         @Schema(description = "카카오에 등록할 redirect_uri 주소입니다.", example = "http://localhost:8080/api/v1/auth/login/kakao", nullable = true)
-        @RequestParam(name = "redirect_uri", required = false) String clientRedirectUri,
+        @RequestParam(name = "redirect_uri", required = false)
+        String clientRedirectUri,
 
-        @Valid @RequestBody CreateKakaoLoginRequest createKakaoLoginRequest,
+        @Valid
+        @RequestBody
+        CreateKakaoLoginRequest createKakaoLoginRequest,
 
-        @RequestHeader(value = "User-Agent", required = false) String userAgent,
+        @RequestHeader(value = "User-Agent", required = false)
+        String userAgent,
 
+        @Parameter(hidden = true)
         HttpServletResponse httpServletResponse
     );
 
@@ -39,13 +45,16 @@ public interface AuthApi {
         summary = "토큰 재발급",
         description = "accessToken 만료 시, 기존 Refresh Token 으로 새로운 accessToken 을 반환하고, 새로운 refreshToken 으로 쿠키를 교체합니다."
     )
+    @PostMapping("/reissue")
     ApiResponseBody<CreateAccessTokenResponse, Void> createReissuedTokens(
-
         @Schema(description = "재발급 때 사용할 refreshToken 입니다. 쿠키 설정만 해주시면 자동으로 보내집니다.")
-        @CookieValue(name = "refreshToken") String refreshToken,
+        @CookieValue(name = "refreshToken")
+        String refreshToken,
 
-        @RequestHeader(value = "User-Agent", required = false) String userAgent,
+        @RequestHeader(value = "User-Agent", required = false)
+        String userAgent,
 
+        @Parameter(hidden = true)
         HttpServletResponse httpServletResponse
     );
 
@@ -53,14 +62,16 @@ public interface AuthApi {
         summary = "로그아웃",
         description = "accessToken 으로 인증된 사용자를 기준으로 refreshToken 을 무효화하여 사용자를 로그아웃 처리합니다."
     )
+    @PostMapping("/logout")
     ApiResponseBody<Void, Void> logout(
-
-        @Schema(description = "인증이 필요합니다.")
-        @AuthenticationPrincipal CustomUserInfo principal,
+        @Parameter(hidden = true)
+        CustomUserInfo principal,
 
         @Schema(description = "로그아웃 시 사용할 refreshToken 입니다. 쿠키 설정만 해주시면 자동으로 보내집니다.")
-        @CookieValue(name = "refreshToken", required = false) String refreshToken,
+        @CookieValue(name = "refreshToken", required = false)
+        String refreshToken,
 
+        @Parameter(hidden = true)
         HttpServletResponse response
     );
 

--- a/src/main/java/org/sopt/snappinserver/api/v1/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/auth/controller/AuthController.java
@@ -1,10 +1,8 @@
 package org.sopt.snappinserver.api.v1.auth.controller;
 
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.sopt.snappinserver.global.response.code.auth.AuthSuccessCode;
 import org.sopt.snappinserver.api.v1.auth.dto.request.CreateKakaoLoginRequest;
 import org.sopt.snappinserver.api.v1.auth.dto.response.CreateAccessTokenResponse;
 import org.sopt.snappinserver.api.v1.auth.dto.response.CreateKakaoLoginResponse;
@@ -16,17 +14,13 @@ import org.sopt.snappinserver.domain.auth.service.dto.response.ReissueTokenResul
 import org.sopt.snappinserver.domain.auth.service.usecase.LoginUseCase;
 import org.sopt.snappinserver.domain.auth.service.usecase.LogoutUseCase;
 import org.sopt.snappinserver.domain.auth.service.usecase.ReissueTokenUseCase;
+import org.sopt.snappinserver.global.response.code.auth.AuthSuccessCode;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/auth")
@@ -46,11 +40,10 @@ public class AuthController implements AuthApi {
     private long refreshTokenSeconds;
 
     @Override
-    @PostMapping("/login/kakao")
     public ApiResponseBody<CreateKakaoLoginResponse, Void> createKakaoLogin(
-        @RequestParam(name = "redirect_uri", required = false) String clientRedirectUri,
-        @Valid @RequestBody CreateKakaoLoginRequest createKakaoLoginRequest,
-        @RequestHeader(value = "User-Agent", required = false) String userAgent,
+        String clientRedirectUri,
+        CreateKakaoLoginRequest createKakaoLoginRequest,
+        String userAgent,
         HttpServletResponse httpServletResponse
     ) {
         String redirectUri =
@@ -72,10 +65,9 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    @PostMapping("/reissue")
     public ApiResponseBody<CreateAccessTokenResponse, Void> createReissuedTokens(
-        @CookieValue(name = "refreshToken", required = false) String refreshToken,
-        @RequestHeader(value = "User-Agent", required = false) String userAgent,
+        String refreshToken,
+        String userAgent,
         HttpServletResponse httpServletResponse
     ) {
         validateCookieExists(refreshToken);
@@ -96,10 +88,9 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    @PostMapping("/logout")
     public ApiResponseBody<Void, Void> logout(
         @AuthenticationPrincipal CustomUserInfo principal,
-        @CookieValue(name = "refreshToken", required = false) String refreshToken,
+        String refreshToken,
         HttpServletResponse httpServletResponse
     ) {
         logoutUseCase.logout(principal.userId(), refreshToken);

--- a/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationApi.java
@@ -5,6 +5,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import org.sopt.snappinserver.api.v1.curation.dto.request.CreateMoodCurationRequest;
 import org.sopt.snappinserver.api.v1.curation.dto.response.CreateMoodCurationResponse;
 import org.sopt.snappinserver.api.v1.curation.dto.response.GetAllCurationQuestionsResponse;
@@ -31,6 +34,9 @@ public interface CurationApi {
         CustomUserInfo userInfo,
 
         @Schema(description = "조회할 단계", example = "1")
+        @NotNull(message = "단계는 필수입니다.")
+        @Min(value = 1, message = "단계는 1 이상이어야 합니다.")
+        @Max(value = 5, message = "단계는 5 이하여야 합니다.")
         @RequestParam
         Integer step
     );

--- a/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationApi.java
@@ -2,7 +2,6 @@ package org.sopt.snappinserver.api.v1.curation.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -33,7 +32,7 @@ public interface CurationApi {
         @Parameter(hidden = true)
         CustomUserInfo userInfo,
 
-        @Schema(description = "조회할 단계", example = "1")
+        @Parameter(description = "조회할 단계", example = "1")
         @NotNull(message = "단계는 필수입니다.")
         @Min(value = 1, message = "단계는 1 이상이어야 합니다.")
         @Max(value = 5, message = "단계는 5 이하여야 합니다.")

--- a/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationApi.java
@@ -5,9 +5,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import org.sopt.snappinserver.api.v1.curation.dto.request.CreateMoodCurationRequest;
 import org.sopt.snappinserver.api.v1.curation.dto.response.CreateMoodCurationResponse;
 import org.sopt.snappinserver.api.v1.curation.dto.response.GetAllCurationQuestionsResponse;
@@ -34,9 +31,6 @@ public interface CurationApi {
         CustomUserInfo userInfo,
 
         @Schema(description = "조회할 단계", example = "1")
-        @NotNull(message = "단계는 필수입니다.")
-        @Min(value = 1, message = "단계는 1 이상이어야 합니다.")
-        @Max(value = 5, message = "단계는 5 이하여야 합니다.")
         @RequestParam
         Integer step
     );

--- a/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationApi.java
@@ -15,6 +15,8 @@ import org.sopt.snappinserver.api.v1.curation.dto.response.GetCurationQuestionPh
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -26,8 +28,8 @@ public interface CurationApi {
         summary = "큐레이션 단계별 질문/사진 조회 API",
         description = "로그인한 사용자가 큐레이션 별로 질문 / 사진을 조회할 수 있도록 합니다."
     )
+    @GetMapping
     ApiResponseBody<GetCurationQuestionPhotosResponse, Void> getCurationQuestion(
-
         @Parameter(hidden = true)
         CustomUserInfo userInfo,
 
@@ -35,24 +37,29 @@ public interface CurationApi {
         @NotNull(message = "단계는 필수입니다.")
         @Min(value = 1, message = "단계는 1 이상이어야 합니다.")
         @Max(value = 5, message = "단계는 5 이하여야 합니다.")
-        @RequestParam Integer step
+        @RequestParam
+        Integer step
     );
 
     @Operation(
         summary = "무드 큐레이션 결과 저장 및 결과 반환 API",
         description = "사용자가 선택한 사진에 대해 무드 큐레이션 결과를 저장하고, 결과를 반환합니다."
     )
+    @PostMapping
     ApiResponseBody<CreateMoodCurationResponse, Void> createMoodCuration(
         @Parameter(hidden = true)
         CustomUserInfo userInfo,
 
-        @Valid @RequestBody CreateMoodCurationRequest request
+        @Valid
+        @RequestBody
+        CreateMoodCurationRequest request
     );
 
     @Operation(
         summary = "큐레이션 전체 질문/사진 조회",
         description = "로그인한 사용자가 전체 큐레이션 질문과 각 질문 별 사진을 한꺼번에 조회할 수 있습니다."
     )
+    @GetMapping("/all")
     ApiResponseBody<GetAllCurationQuestionsResponse, Void> getAllCurationQuestions(
         @Parameter(hidden = true)
         CustomUserInfo userInfo

--- a/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationController.java
@@ -1,5 +1,8 @@
 package org.sopt.snappinserver.api.v1.curation.controller;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.v1.curation.dto.request.CreateMoodCurationRequest;
 import org.sopt.snappinserver.api.v1.curation.dto.response.CreateMoodCurationResponse;
@@ -31,6 +34,10 @@ public class CurationController implements CurationApi {
     @Override
     public ApiResponseBody<GetCurationQuestionPhotosResponse, Void> getCurationQuestion(
         @AuthenticationPrincipal CustomUserInfo userInfo,
+
+        @NotNull(message = "단계는 필수입니다.")
+        @Min(value = 1, message = "단계는 1 이상이어야 합니다.")
+        @Max(value = 5, message = "단계는 5 이하여야 합니다.")
         Integer step
     ) {
         GetCurationQuestionResult result = getCurationQuestionUseCase.retrieveCurationQuestionPhotos(

--- a/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationController.java
@@ -1,8 +1,5 @@
 package org.sopt.snappinserver.api.v1.curation.controller;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.v1.curation.dto.request.CreateMoodCurationRequest;
 import org.sopt.snappinserver.api.v1.curation.dto.response.CreateMoodCurationResponse;
@@ -34,10 +31,6 @@ public class CurationController implements CurationApi {
     @Override
     public ApiResponseBody<GetCurationQuestionPhotosResponse, Void> getCurationQuestion(
         @AuthenticationPrincipal CustomUserInfo userInfo,
-
-        @NotNull(message = "단계는 필수입니다.")
-        @Min(value = 1, message = "단계는 1 이상이어야 합니다.")
-        @Max(value = 5, message = "단계는 5 이하여야 합니다.")
         Integer step
     ) {
         GetCurationQuestionResult result = getCurationQuestionUseCase.retrieveCurationQuestionPhotos(

--- a/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/curation/controller/CurationController.java
@@ -16,8 +16,6 @@ import org.sopt.snappinserver.domain.curation.service.usecase.GetCurationQuestio
 import org.sopt.snappinserver.global.response.code.curation.CurationSuccessCode;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,7 +29,6 @@ public class CurationController implements CurationApi {
     private final GetAllCurationQuestionUseCase getAllCurationQuestionUseCase;
 
     @Override
-    @GetMapping
     public ApiResponseBody<GetCurationQuestionPhotosResponse, Void> getCurationQuestion(
         @AuthenticationPrincipal CustomUserInfo userInfo,
         Integer step
@@ -46,7 +43,6 @@ public class CurationController implements CurationApi {
     }
 
     @Override
-    @PostMapping
     public ApiResponseBody<CreateMoodCurationResponse, Void> createMoodCuration(
         @AuthenticationPrincipal CustomUserInfo userInfo,
         CreateMoodCurationRequest request
@@ -62,7 +58,6 @@ public class CurationController implements CurationApi {
     }
 
     @Override
-    @GetMapping("/all")
     public ApiResponseBody<GetAllCurationQuestionsResponse, Void> getAllCurationQuestions(
         @AuthenticationPrincipal CustomUserInfo userInfo
     ) {

--- a/src/main/java/org/sopt/snappinserver/api/v1/home/controller/HomeApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/home/controller/HomeApi.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sopt.snappinserver.api.v1.home.dto.response.GetPlacePhotographerRecommendationResponse;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @Tag(name = "04 - Home", description = "홈 화면에서 사용되는 API")
 public interface HomeApi {
@@ -12,6 +13,7 @@ public interface HomeApi {
         summary = "스냅 명소 및 작가 추천 목록 조회 API",
         description = "최근 1개월 간 예약 건수가 가장 많은 장소 5곳과 랜덤으로 작가 5명을 추천합니다."
     )
+    @GetMapping("/recommendation")
     ApiResponseBody<GetPlacePhotographerRecommendationResponse, Void> getRecommendation();
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/v1/home/controller/HomeController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/home/controller/HomeController.java
@@ -2,14 +2,13 @@ package org.sopt.snappinserver.api.v1.home.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.global.response.code.home.HomeSuccessCode;
 import org.sopt.snappinserver.api.v1.home.dto.response.GetPlacePhotographerRecommendationResponse;
 import org.sopt.snappinserver.domain.photographer.service.dto.response.GetRandomPhotographersResult;
 import org.sopt.snappinserver.domain.photographer.service.usecase.GetRandomPhotographersUseCase;
 import org.sopt.snappinserver.domain.place.service.dto.response.GetRecommendationPlaceResult;
 import org.sopt.snappinserver.domain.place.service.usecase.GetRecommendationPlaceUseCase;
+import org.sopt.snappinserver.global.response.code.home.HomeSuccessCode;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,7 +21,6 @@ public class HomeController implements HomeApi {
     private final GetRandomPhotographersUseCase getRandomPhotographersUseCase;
 
     @Override
-    @GetMapping("/recommendation")
     public ApiResponseBody<GetPlacePhotographerRecommendationResponse, Void> getRecommendation() {
         List<GetRecommendationPlaceResult> placeResult = getRecommendationPlaceUseCase
             .getPlaceRecommendation();

--- a/src/main/java/org/sopt/snappinserver/api/v1/mood/controller/MoodApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/mood/controller/MoodApi.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sopt.snappinserver.api.v1.mood.dto.response.GetMoodFilterListResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @Tag(name = "05 - Mood", description = "무드 관련 API")
 public interface MoodApi {
@@ -14,6 +15,7 @@ public interface MoodApi {
         summary = "전체 무드 필터 값 조회 API",
         description = "전체 무드 필터 값을 해당 무드 카테고리, 사용자 큐레이션 진행 여부와 함께 반환합니다."
     )
+    @GetMapping
     ApiResponseBody<GetMoodFilterListResponse, Void> getAllMoodFilters(
         @Parameter(hidden = true)
         CustomUserInfo userInfo

--- a/src/main/java/org/sopt/snappinserver/api/v1/mood/controller/MoodController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/mood/controller/MoodController.java
@@ -1,14 +1,13 @@
 package org.sopt.snappinserver.api.v1.mood.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.global.response.code.mood.MoodSuccessCode;
 import org.sopt.snappinserver.api.v1.mood.dto.response.GetMoodFilterListResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.mood.service.dto.response.GetMoodFilterListResult;
 import org.sopt.snappinserver.domain.mood.service.usecase.GetMoodFilterListUseCase;
+import org.sopt.snappinserver.global.response.code.mood.MoodSuccessCode;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,7 +19,6 @@ public class MoodController implements MoodApi {
     private final GetMoodFilterListUseCase getMoodFilterListUseCase;
 
     @Override
-    @GetMapping
     public ApiResponseBody<GetMoodFilterListResponse, Void> getAllMoodFilters(
         @AuthenticationPrincipal CustomUserInfo userInfo
     ) {

--- a/src/main/java/org/sopt/snappinserver/api/v1/photo/controller/PhotoApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/photo/controller/PhotoApi.java
@@ -2,8 +2,10 @@ package org.sopt.snappinserver.api.v1.photo.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.sopt.snappinserver.api.v1.photo.dto.request.CreatePhotoMoodRequest;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "06 - Photo", description = "사진 관련 API")
@@ -13,7 +15,10 @@ public interface PhotoApi {
         summary = "사진 <-> 무드 태그 연결",
         description = "람다에서 벡터로 변환된 사진과 무드 태그를 연결합니다. 웹에서 연결하는 API가 아닙니다! 람다 전용 API입니다."
     )
+    @PostMapping("/process")
     ApiResponseBody<Void, Void> createPhotoMoodConnection(
-        @RequestBody CreatePhotoMoodRequest createPhotoMoodRequest
+        @Valid
+        @RequestBody
+        CreatePhotoMoodRequest createPhotoMoodRequest
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/v1/photo/controller/PhotoController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/photo/controller/PhotoController.java
@@ -1,14 +1,11 @@
 package org.sopt.snappinserver.api.v1.photo.controller;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.global.response.code.photo.PhotoSuccessCode;
 import org.sopt.snappinserver.api.v1.photo.dto.request.CreatePhotoMoodRequest;
 import org.sopt.snappinserver.domain.photo.service.dto.request.PhotoProcessCommand;
 import org.sopt.snappinserver.domain.photo.service.usecase.ProcessPhotoUseCase;
+import org.sopt.snappinserver.global.response.code.photo.PhotoSuccessCode;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,9 +17,8 @@ public class PhotoController implements PhotoApi {
     private final ProcessPhotoUseCase processPhotoUseCase;
 
     @Override
-    @PostMapping("/process")
     public ApiResponseBody<Void, Void> createPhotoMoodConnection(
-        @Valid @RequestBody CreatePhotoMoodRequest createPhotoMoodRequest
+        CreatePhotoMoodRequest createPhotoMoodRequest
     ) {
         PhotoProcessCommand photoProcessCommand = PhotoProcessCommand.from(createPhotoMoodRequest);
         processPhotoUseCase.linkPhotoWithMoodTags(photoProcessCommand);

--- a/src/main/java/org/sopt/snappinserver/api/v1/photographer/controller/PhotographerApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/photographer/controller/PhotographerApi.java
@@ -1,7 +1,7 @@
 package org.sopt.snappinserver.api.v1.photographer.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -21,7 +21,7 @@ public interface PhotographerApi {
     )
     @GetMapping("/{photographerId}")
     ApiResponseBody<GetPhotographerProfileResponse, Void> getPhotographerProfile(
-        @Schema(description = "조회할 작가 ID")
+        @Parameter(description = "조회할 작가 ID")
         @NotNull(message = "작가 ID는 필수입니다.")
         @Positive(message = "작가 ID는 양수여야 합니다.")
         @PathVariable

--- a/src/main/java/org/sopt/snappinserver/api/v1/photographer/controller/PhotographerApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/photographer/controller/PhotographerApi.java
@@ -3,11 +3,10 @@ package org.sopt.snappinserver.api.v1.photographer.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import org.sopt.snappinserver.api.v1.photographer.dto.response.GetPhotographerProfileResponse;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "02 - Photographer", description = "스냅 작가 관련 API")
@@ -18,10 +17,10 @@ public interface PhotographerApi {
         summary = "작가 상세 조회 API",
         description = "입력받은 photographerId로 해당 작가의 프로필을 조회합니다."
     )
+    @GetMapping("/{photographerId}")
     ApiResponseBody<GetPhotographerProfileResponse, Void> getPhotographerProfile(
         @Schema(description = "조회할 작가 ID")
-        @NotNull(message = "작가 ID는 필수입니다.")
-        @Positive(message = "작가 ID는 양수여야 합니다.")
-        @PathVariable Long photographerId
+        @PathVariable
+        Long photographerId
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/v1/photographer/controller/PhotographerApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/photographer/controller/PhotographerApi.java
@@ -3,6 +3,8 @@ package org.sopt.snappinserver.api.v1.photographer.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import org.sopt.snappinserver.api.v1.photographer.dto.response.GetPhotographerProfileResponse;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.validation.annotation.Validated;
@@ -20,6 +22,8 @@ public interface PhotographerApi {
     @GetMapping("/{photographerId}")
     ApiResponseBody<GetPhotographerProfileResponse, Void> getPhotographerProfile(
         @Schema(description = "조회할 작가 ID")
+        @NotNull(message = "작가 ID는 필수입니다.")
+        @Positive(message = "작가 ID는 양수여야 합니다.")
         @PathVariable
         Long photographerId
     );

--- a/src/main/java/org/sopt/snappinserver/api/v1/photographer/controller/PhotographerController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/photographer/controller/PhotographerController.java
@@ -1,7 +1,5 @@
 package org.sopt.snappinserver.api.v1.photographer.controller;
 
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.v1.photographer.dto.response.GetPhotographerProfileResponse;
 import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerProfileResult;
@@ -20,8 +18,6 @@ public class PhotographerController implements PhotographerApi {
 
     @Override
     public ApiResponseBody<GetPhotographerProfileResponse, Void> getPhotographerProfile(
-        @NotNull(message = "작가 ID는 필수입니다.")
-        @Positive(message = "작가 ID는 양수여야 합니다.")
         Long photographerId
     ) {
         GetPhotographerProfileResult result = getPhotographerProfileUseCase

--- a/src/main/java/org/sopt/snappinserver/api/v1/photographer/controller/PhotographerController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/photographer/controller/PhotographerController.java
@@ -1,12 +1,13 @@
 package org.sopt.snappinserver.api.v1.photographer.controller;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
-import org.sopt.snappinserver.global.response.code.photographer.PhotographerSuccessCode;
 import org.sopt.snappinserver.api.v1.photographer.dto.response.GetPhotographerProfileResponse;
 import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerProfileResult;
 import org.sopt.snappinserver.domain.photographer.service.usecase.GetPhotographerProfileUseCase;
+import org.sopt.snappinserver.global.response.code.photographer.PhotographerSuccessCode;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,8 +19,9 @@ public class PhotographerController implements PhotographerApi {
     private final GetPhotographerProfileUseCase getPhotographerProfileUseCase;
 
     @Override
-    @GetMapping("/{photographerId}")
     public ApiResponseBody<GetPhotographerProfileResponse, Void> getPhotographerProfile(
+        @NotNull(message = "작가 ID는 필수입니다.")
+        @Positive(message = "작가 ID는 양수여야 합니다.")
         Long photographerId
     ) {
         GetPhotographerProfileResult result = getPhotographerProfileUseCase

--- a/src/main/java/org/sopt/snappinserver/api/v1/place/controller/PlaceApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/place/controller/PlaceApi.java
@@ -1,11 +1,11 @@
 package org.sopt.snappinserver.api.v1.place.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.NotBlank;
-import org.hibernate.validator.constraints.Length;
 import org.sopt.snappinserver.api.v1.place.dto.response.GetPlaceListResponse;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "05 - Place", description = "장소 관련 API")
@@ -15,9 +15,9 @@ public interface PlaceApi {
         summary = "촬영 장소 검색 API",
         description = "입력받은 키워드로 촬영 장소를 검색합니다."
     )
+    @GetMapping
     ApiResponseBody<GetPlaceListResponse, Void> getPlaces(
-        @NotBlank(message = "검색 키워드는 필수입니다.")
-        @Length(max = 32, message = "검색 키워드는 최대 32자까지 입력할 수 있습니다.")
+        @Schema(description = "장소 검색어")
         @RequestParam String keyword
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/v1/place/controller/PlaceApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/place/controller/PlaceApi.java
@@ -1,7 +1,7 @@
 package org.sopt.snappinserver.api.v1.place.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
 import org.hibernate.validator.constraints.Length;
@@ -19,7 +19,7 @@ public interface PlaceApi {
     )
     @GetMapping
     ApiResponseBody<GetPlaceListResponse, Void> getPlaces(
-        @Schema(description = "장소 검색어")
+        @Parameter(description = "장소 검색어")
         @NotBlank(message = "검색 키워드는 필수입니다.")
         @Length(max = 32, message = "검색 키워드는 최대 32자까지 입력할 수 있습니다.")
         @RequestParam String keyword

--- a/src/main/java/org/sopt/snappinserver/api/v1/place/controller/PlaceApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/place/controller/PlaceApi.java
@@ -3,6 +3,8 @@ package org.sopt.snappinserver.api.v1.place.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Length;
 import org.sopt.snappinserver.api.v1.place.dto.response.GetPlaceListResponse;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +20,8 @@ public interface PlaceApi {
     @GetMapping
     ApiResponseBody<GetPlaceListResponse, Void> getPlaces(
         @Schema(description = "장소 검색어")
+        @NotBlank(message = "검색 키워드는 필수입니다.")
+        @Length(max = 32, message = "검색 키워드는 최대 32자까지 입력할 수 있습니다.")
         @RequestParam String keyword
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/v1/place/controller/PlaceController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/place/controller/PlaceController.java
@@ -2,12 +2,13 @@ package org.sopt.snappinserver.api.v1.place.controller;
 
 import static org.sopt.snappinserver.global.response.code.place.PlaceSuccessCode.GET_PLACE_LIST_OK;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 import org.sopt.snappinserver.api.v1.place.dto.response.GetPlaceListResponse;
 import org.sopt.snappinserver.domain.place.service.dto.response.GetPlaceListResult;
 import org.sopt.snappinserver.domain.place.service.usecase.GetPlaceListUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,8 +20,9 @@ public class PlaceController implements PlaceApi {
     private final GetPlaceListUseCase getPlaceListUseCase;
 
     @Override
-    @GetMapping()
     public ApiResponseBody<GetPlaceListResponse, Void> getPlaces(
+        @NotBlank(message = "검색 키워드는 필수입니다.")
+        @Length(max = 32, message = "검색 키워드는 최대 32자까지 입력할 수 있습니다.")
         String keyword
     ) {
         GetPlaceListResult result = getPlaceListUseCase.getPlaceList(keyword);

--- a/src/main/java/org/sopt/snappinserver/api/v1/place/controller/PlaceController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/place/controller/PlaceController.java
@@ -2,9 +2,7 @@ package org.sopt.snappinserver.api.v1.place.controller;
 
 import static org.sopt.snappinserver.global.response.code.place.PlaceSuccessCode.GET_PLACE_LIST_OK;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.validator.constraints.Length;
 import org.sopt.snappinserver.api.v1.place.dto.response.GetPlaceListResponse;
 import org.sopt.snappinserver.domain.place.service.dto.response.GetPlaceListResult;
 import org.sopt.snappinserver.domain.place.service.usecase.GetPlaceListUseCase;
@@ -21,8 +19,6 @@ public class PlaceController implements PlaceApi {
 
     @Override
     public ApiResponseBody<GetPlaceListResponse, Void> getPlaces(
-        @NotBlank(message = "검색 키워드는 필수입니다.")
-        @Length(max = 32, message = "검색 키워드는 최대 32자까지 입력할 수 있습니다.")
         String keyword
     ) {
         GetPlaceListResult result = getPlaceListUseCase.getPlaceList(keyword);

--- a/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserApi.java
@@ -8,6 +8,8 @@ import org.sopt.snappinserver.api.v1.user.dto.response.GetSwitchedUserProfileRes
 import org.sopt.snappinserver.api.v1.user.dto.response.GetUserInfoResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "01 - User", description = "사용자 관련 API")
@@ -17,6 +19,7 @@ public interface UserApi {
         summary = "유저 정보 조회 API",
         description = "현재 로그인한 사용자의 역할을 기반으로 사용자 정보를 조회합니다."
     )
+    @GetMapping("/me")
     ApiResponseBody<GetUserInfoResponse, Void> getUserInfo(
         @Parameter(hidden = true)
         CustomUserInfo userInfo
@@ -26,12 +29,15 @@ public interface UserApi {
         summary = "유저 프로필 전환 API",
         description = "현재 로그인한 사용자가 유저 프로필 전환이 가능한 경우, 사용자 역할을 전환하여 accessCode를 재발급합니다."
     )
+    @PatchMapping("/role")
     ApiResponseBody<GetSwitchedUserProfileResponse, Void> patchUserRole(
         @Parameter(hidden = true)
         CustomUserInfo userInfo,
 
-        @RequestHeader(value = "User-Agent", required = false) String userAgent,
+        @RequestHeader(value = "User-Agent", required = false)
+        String userAgent,
 
+        @Parameter(hidden = true)
         HttpServletResponse httpServletResponse
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserApi.java
@@ -34,6 +34,7 @@ public interface UserApi {
         @Parameter(hidden = true)
         CustomUserInfo userInfo,
 
+        @Parameter(description = "유저가 로그인한 기기")
         @RequestHeader(value = "User-Agent", required = false)
         String userAgent,
 

--- a/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserController.java
@@ -18,9 +18,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -39,7 +36,6 @@ public class UserController implements UserApi {
     private long refreshTokenSeconds;
 
     @Override
-    @GetMapping("/me")
     public ApiResponseBody<GetUserInfoResponse, Void> getUserInfo(
         @AuthenticationPrincipal CustomUserInfo userInfo
     ) {
@@ -50,10 +46,9 @@ public class UserController implements UserApi {
     }
 
     @Override
-    @PatchMapping("/role")
     public ApiResponseBody<GetSwitchedUserProfileResponse, Void> patchUserRole(
         @AuthenticationPrincipal CustomUserInfo userInfo,
-        @RequestHeader(value = "User-Agent", required = false) String userAgent,
+        String userAgent,
         HttpServletResponse httpServletResponse
     ) {
         SwitchUserRoleCommand command = getCommand(userInfo, userAgent);

--- a/src/main/java/org/sopt/snappinserver/api/v2/auth/controller/AuthApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/auth/controller/AuthApi.java
@@ -17,20 +17,24 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Tag(name = "01 - Auth", description = "인증/인가 관련 API V2")
 public interface AuthApi {
 
-    @PostMapping("/login/kakao")
     @Operation(
         summary = "카카오 로그인",
         description = "인가 코드를 받아 카카오로 소셜 로그인을 진행합니다."
     )
+    @PostMapping("/login/kakao")
     ApiResponseBody<CreateKakaoLoginResponse, Void> createKakaoLogin(
-
         @Schema(description = "카카오에 등록할 redirect_uri 주소입니다.", example = "http://localhost:8080/api/v2/auth/login/kakao", nullable = true)
-        @RequestParam(name = "redirect_uri", required = false) String clientRedirectUri,
+        @RequestParam(name = "redirect_uri", required = false)
+        String clientRedirectUri,
 
-        @Valid @RequestBody CreateKakaoLoginRequest createKakaoLoginRequest,
+        @Valid
+        @RequestBody
+        CreateKakaoLoginRequest createKakaoLoginRequest,
 
-        @RequestHeader(value = "User-Agent", required = false) String userAgent,
+        @RequestHeader(value = "User-Agent", required = false)
+        String userAgent,
 
-        @Parameter(hidden = true) HttpServletResponse httpServletResponse
+        @Parameter(hidden = true)
+        HttpServletResponse httpServletResponse
     );
 }


### PR DESCRIPTION
## 👀 Summary

- close #249


## 🖇️ Tasks

- [x] auth 도메인 annotation 재정비
- [x] curation 도메인 annotation 재정비
- [x] home 도메인 annotation 재정비
- [x] mood 도메인 annotation 재정비
- [x] photo 도메인 annotation 재정비
- [x] photographer 도메인 annotation 재정비
- [x] place 도메인 annotation 재정비
- [x] user 도메인 annotation 재정비


## 🔍 To Reviewer

### ❶ 가독성에 관한 고민
컨벤션을 다시 정하면서 API 인터페이스 쪽에 많은 어노테이션이 붙습니다. 하나의 파라미터에 대해 여러 어노테이션이 붙는 경우가 많고, 여러 파라미터가 있어 인터페이스 측에서는 한 줄 당 하나의 어노테이션만 붙였습니다. 또한, 파라미터 간 개행으로 파라미터를 조금 더 명확하게 작성하기 위해 노력했습니다.

반면, 컨트롤러 구현체에서는 인증 어노테이션을 제외하면 거의 모든 어노테이션이 붙지 않기 때문에 파라미터 간에 개행을 하지 않았고, 각 파라미터에 들어가는 어노테이션은 파라미터와 함께 한 줄에 작성했습니다. 
