### PR TITLE
[TEST] #252: 무드 큐레이션 결과 저장 시 테스트 코드 작성

### DIFF
--- a/src/test/java/org/sopt/snappinserver/domain/curation/service/CreateMoodCurationServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/curation/service/CreateMoodCurationServiceTest.java
@@ -1,0 +1,99 @@
+package org.sopt.snappinserver.domain.curation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.snappinserver.domain.curation.domain.entity.Curation;
+import org.sopt.snappinserver.domain.curation.repository.CurationRepository;
+import org.sopt.snappinserver.domain.curation.service.dto.request.CreateMoodCurationCommand;
+import org.sopt.snappinserver.domain.curation.service.dto.response.CreateMoodCurationResult;
+import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
+import org.sopt.snappinserver.domain.mood.domain.enums.MoodCategory;
+import org.sopt.snappinserver.domain.photo.domain.entity.PhotoMood;
+import org.sopt.snappinserver.domain.photo.repository.PhotoMoodRepository;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
+import org.sopt.snappinserver.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class CreateMoodCurationServiceTest {
+
+    @InjectMocks
+    private CreateMoodCurationService createMoodCurationService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PhotoMoodRepository photoMoodRepository;
+
+    @Mock
+    private CurationRepository curationRepository;
+
+    private User mockUser;
+
+    private CreateMoodCurationCommand command;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = mock(User.class);
+        command = new CreateMoodCurationCommand(
+            1L,
+            List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L)
+        );
+    }
+
+    @Test
+    @DisplayName("상위 3개 무드 추출 및 저장 성공 테스트")
+    void createMoodCuration_Success() {
+        // [Given] 테스트 시 필요한 데이터 생성
+        // 1. 임의의 상위 3개 결과 무드 생성
+        Mood moodA = Mood.create(MoodCategory.STYLE, "디지털", "설명", List.of(0.1f));
+        Mood moodB = Mood.create(MoodCategory.STYLE, "아날로그", "설명", List.of(0.2f));
+        Mood moodC = Mood.create(MoodCategory.STYLE, "Y2K", "설명", List.of(0.3f));
+
+        // 2. 위에서 만든 세 무드와 연결된 PhotoMood 리스트 임의 생성
+        List<PhotoMood> mockPhotoMoods = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, moodA, 1, 10.0f));
+        }
+        for (int i = 0; i < 5; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, moodB, 1, 5.0f));
+        }
+        for (int i = 0; i < 5; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, moodC, 1, 1.0f));
+        }
+
+        // 3. Mockito에게 행동 지시
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(mockUser));
+        when(photoMoodRepository.findAllByPhotoIdIn(anyList())).thenReturn(mockPhotoMoods);
+
+        // [When] 테스트할 서비스 메서드 호출
+        CreateMoodCurationResult result = createMoodCurationService.saveMoodCurationResult(command);
+
+        // [Then] 결과 검증
+        // 1. 결과값이 3개인지 확인
+        assertThat(result.moods()).hasSize(3);
+
+        // 2. 점수가 가장 높은 moodA가 0번째 인덱스(1위)인지 확인
+        assertThat(result.moods().get(0).name()).isEqualTo("디지털");
+
+        // 3. DB 저장이 3번 일어났는지 확인
+        verify(curationRepository, times(3)).save(any(Curation.class));
+    }
+}

--- a/src/test/java/org/sopt/snappinserver/domain/curation/service/CreateMoodCurationServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/curation/service/CreateMoodCurationServiceTest.java
@@ -1,6 +1,7 @@
 package org.sopt.snappinserver.domain.curation.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -16,13 +17,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sopt.snappinserver.domain.curation.domain.entity.Curation;
+import org.sopt.snappinserver.domain.curation.domain.exception.CurationErrorCode;
+import org.sopt.snappinserver.domain.curation.domain.exception.CurationException;
 import org.sopt.snappinserver.domain.curation.repository.CurationRepository;
 import org.sopt.snappinserver.domain.curation.service.dto.request.CreateMoodCurationCommand;
 import org.sopt.snappinserver.domain.curation.service.dto.response.CreateMoodCurationResult;
+import org.sopt.snappinserver.domain.curation.service.dto.response.CreateMoodResult;
 import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
 import org.sopt.snappinserver.domain.mood.domain.enums.MoodCategory;
 import org.sopt.snappinserver.domain.photo.domain.entity.PhotoMood;
@@ -59,15 +64,13 @@ public class CreateMoodCurationServiceTest {
     }
 
     @Test
-    @DisplayName("상위 3개 무드 추출 및 저장 성공 테스트")
-    void createMoodCuration_Success() {
-        // [Given] 테스트 시 필요한 데이터 생성
-        // 1. 임의의 상위 3개 결과 무드 생성
+    @DisplayName("무드 순위(1~3위)가 총점 내림차순으로 올바르게 정렬되며 3번 저장되는 테스트")
+    void createMoodCuration_OrderedByScoreAndSaved() {
+        // [Given] 총점이 다른 3개 무드 생성 (moodA: 50점, moodB: 25점, moodC: 5점)
         Mood moodA = Mood.create(MoodCategory.STYLE, "디지털", "설명", List.of(0.1f));
         Mood moodB = Mood.create(MoodCategory.STYLE, "아날로그", "설명", List.of(0.2f));
         Mood moodC = Mood.create(MoodCategory.STYLE, "Y2K", "설명", List.of(0.3f));
 
-        // 2. 위에서 만든 세 무드와 연결된 PhotoMood 리스트 임의 생성
         List<PhotoMood> mockPhotoMoods = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
             mockPhotoMoods.add(PhotoMood.create(null, moodA, 1, 10.0f));
@@ -79,21 +82,203 @@ public class CreateMoodCurationServiceTest {
             mockPhotoMoods.add(PhotoMood.create(null, moodC, 1, 1.0f));
         }
 
-        // 3. Mockito에게 행동 지시
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(mockUser));
         when(photoMoodRepository.findAllByPhotoIdIn(anyList())).thenReturn(mockPhotoMoods);
 
-        // [When] 테스트할 서비스 메서드 호출
+        // [When]
         CreateMoodCurationResult result = createMoodCurationService.saveMoodCurationResult(command);
 
-        // [Then] 결과 검증
-        // 1. 결과값이 3개인지 확인
+        // [Then] 결과 3개, 점수 내림차순 정렬, DB 저장 3회 확인
         assertThat(result.moods()).hasSize(3);
-
-        // 2. 점수가 가장 높은 moodA가 0번째 인덱스(1위)인지 확인
         assertThat(result.moods().get(0).name()).isEqualTo("디지털");
-
-        // 3. DB 저장이 3번 일어났는지 확인
+        assertThat(result.moods().get(1).name()).isEqualTo("아날로그");
+        assertThat(result.moods().get(2).name()).isEqualTo("Y2K");
         verify(curationRepository, times(3)).save(any(Curation.class));
+    }
+
+    @Test
+    @DisplayName("큐레이션 저장 시 rank 값이 1, 2, 3으로 순서대로 저장되는 테스트")
+    void createMoodCuration_SavesWithCorrectRank() {
+        // [Given] 임의의 3개 무드 생성
+        Mood moodA = Mood.create(MoodCategory.STYLE, "디지털", "설명", List.of(0.1f));
+        Mood moodB = Mood.create(MoodCategory.STYLE, "아날로그", "설명", List.of(0.2f));
+        Mood moodC = Mood.create(MoodCategory.STYLE, "Y2K", "설명", List.of(0.3f));
+
+        List<PhotoMood> mockPhotoMoods = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, moodA, 1, 10.0f));
+        }
+        for (int i = 0; i < 5; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, moodB, 1, 5.0f));
+        }
+        for (int i = 0; i < 5; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, moodC, 1, 1.0f));
+        }
+
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(mockUser));
+        when(photoMoodRepository.findAllByPhotoIdIn(anyList())).thenReturn(mockPhotoMoods);
+
+        ArgumentCaptor<Curation> curationCaptor = ArgumentCaptor.forClass(Curation.class);
+
+        // [When]
+        createMoodCurationService.saveMoodCurationResult(command);
+
+        // [Then] 저장된 Curation의 rank 값이 1, 2, 3인지 순서대로 확인
+        verify(curationRepository, times(3)).save(curationCaptor.capture());
+        List<Curation> savedCurations = curationCaptor.getAllValues();
+        assertThat(savedCurations.get(0).getRank()).isEqualTo(1);
+        assertThat(savedCurations.get(1).getRank()).isEqualTo(2);
+        assertThat(savedCurations.get(2).getRank()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("저장된 Curation에 올바른 User와 Mood가 포함되는 테스트")
+    void createMoodCuration_SavesWithCorrectUserAndMood() {
+        // [Given] 임의의 3개 무드 생성
+        Mood moodA = Mood.create(MoodCategory.STYLE, "디지털", "설명", List.of(0.1f));
+        Mood moodB = Mood.create(MoodCategory.STYLE, "아날로그", "설명", List.of(0.2f));
+        Mood moodC = Mood.create(MoodCategory.STYLE, "Y2K", "설명", List.of(0.3f));
+
+        List<PhotoMood> mockPhotoMoods = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, moodA, 1, 10.0f));
+        }
+        for (int i = 0; i < 5; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, moodB, 1, 5.0f));
+        }
+        for (int i = 0; i < 5; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, moodC, 1, 1.0f));
+        }
+
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(mockUser));
+        when(photoMoodRepository.findAllByPhotoIdIn(anyList())).thenReturn(mockPhotoMoods);
+
+        ArgumentCaptor<Curation> curationCaptor = ArgumentCaptor.forClass(Curation.class);
+
+        // [When]
+        createMoodCurationService.saveMoodCurationResult(command);
+
+        // [Then] 저장된 Curation의 user, mood 필드 검증
+        verify(curationRepository, times(3)).save(curationCaptor.capture());
+        List<Curation> savedCurations = curationCaptor.getAllValues();
+        assertThat(savedCurations.get(0).getUser()).isEqualTo(mockUser);
+        assertThat(savedCurations.get(0).getMood()).isEqualTo(moodA);
+        assertThat(savedCurations.get(1).getMood()).isEqualTo(moodB);
+        assertThat(savedCurations.get(2).getMood()).isEqualTo(moodC);
+    }
+
+    @Test
+    @DisplayName("distinct 무드가 3개 미만이면 해당 개수만큼만 저장되는 테스트")
+    void createMoodCuration_LessThan3DistinctMoods_SavesOnlyAvailable() {
+        // [Given] PhotoMood는 15개이지만 distinct 무드가 2개뿐인 상황 생성
+        Mood moodA = Mood.create(MoodCategory.STYLE, "디지털", "설명", List.of(0.1f));
+        Mood moodB = Mood.create(MoodCategory.STYLE, "아날로그", "설명", List.of(0.2f));
+
+        List<PhotoMood> mockPhotoMoods = new ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, moodA, 1, 10.0f));
+        }
+        for (int i = 0; i < 7; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, moodB, 1, 5.0f));
+        }
+
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(mockUser));
+        when(photoMoodRepository.findAllByPhotoIdIn(anyList())).thenReturn(mockPhotoMoods);
+
+        // [When]
+        CreateMoodCurationResult result = createMoodCurationService.saveMoodCurationResult(command);
+
+        // [Then] 결과값이 2개이며 DB 저장도 2번만 일어났는지 확인
+        assertThat(result.moods()).hasSize(2);
+        verify(curationRepository, times(2)).save(any(Curation.class));
+    }
+
+    @Test
+    @DisplayName("distinct 무드가 3개 초과이면 상위 3개만 저장되는 테스트")
+    void createMoodCuration_MoreThan3DistinctMoods_SavesOnlyTop3() {
+        // [Given] 총점이 다른 4개 무드 생성 (moodA: 50, moodB: 40, moodC: 30, moodD: 15)
+        Mood moodA = Mood.create(MoodCategory.STYLE, "디지털", "설명", List.of(0.1f));
+        Mood moodB = Mood.create(MoodCategory.STYLE, "아날로그", "설명", List.of(0.2f));
+        Mood moodC = Mood.create(MoodCategory.STYLE, "Y2K", "설명", List.of(0.3f));
+        Mood moodD = Mood.create(MoodCategory.STYLE, "빈티지", "설명", List.of(0.4f));
+
+        // 4개 무드로 합계 15개 PhotoMood 구성 (5+4+3+3=15)
+        List<PhotoMood> mockPhotoMoods = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, moodA, 1, 10.0f));
+        }
+        for (int i = 0; i < 4; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, moodB, 1, 10.0f));
+        }
+        for (int i = 0; i < 3; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, moodC, 1, 10.0f));
+        }
+        for (int i = 0; i < 3; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, moodD, 1, 5.0f));
+        }
+
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(mockUser));
+        when(photoMoodRepository.findAllByPhotoIdIn(anyList())).thenReturn(mockPhotoMoods);
+
+        // [When]
+        CreateMoodCurationResult result = createMoodCurationService.saveMoodCurationResult(command);
+
+        // [Then] 결과값이 3개이며, 최하위 moodD는 포함되지 않는지 확인
+        assertThat(result.moods()).hasSize(3);
+        assertThat(result.moods().stream().map(CreateMoodResult::name))
+            .doesNotContain("빈티지");
+        verify(curationRepository, times(3)).save(any(Curation.class));
+    }
+
+    @Test
+    @DisplayName("결과에 사용자 이름이 올바르게 포함되는 테스트")
+    void createMoodCuration_ResultContainsUserName() {
+        // [Given]
+        Mood mood = Mood.create(MoodCategory.STYLE, "디지털", "설명", List.of(0.1f));
+        List<PhotoMood> mockPhotoMoods = new ArrayList<>();
+        for (int i = 0; i < 15; i++) {
+            mockPhotoMoods.add(PhotoMood.create(null, mood, 1, 10.0f));
+        }
+
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(mockUser));
+        when(photoMoodRepository.findAllByPhotoIdIn(anyList())).thenReturn(mockPhotoMoods);
+        when(mockUser.getName()).thenReturn("테스트유저");
+
+        // [When]
+        CreateMoodCurationResult result = createMoodCurationService.saveMoodCurationResult(command);
+
+        // [Then] result.name이 user 이름과 일치하는지 확인
+        assertThat(result.name()).isEqualTo("테스트유저");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 ID로 요청 시 실패 테스트")
+    void createMoodCuration_Fail_UserNotFound() {
+        // [Given] 존재하지 않는 userId로 요청
+        when(userRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // [When & Then] USER_NOT_FOUND 예외 발생 확인
+        assertThatThrownBy(() -> createMoodCurationService.saveMoodCurationResult(command))
+            .isInstanceOf(CurationException.class)
+            .hasMessage(CurationErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("반환된 PhotoMood 수가 15개가 아닌 경우 실패 테스트")
+    void createMoodCuration_Fail_PhotoIdNotFound() {
+        // [Given] 15개 photoId를 요청했지만 일부가 DB에 없어 12개만 반환된 상황 생성
+        Mood mood = Mood.create(MoodCategory.STYLE, "디지털", "설명", List.of(0.1f));
+        List<PhotoMood> incompletePhotoMoods = new ArrayList<>();
+        for (int i = 0; i < 12; i++) {
+            incompletePhotoMoods.add(PhotoMood.create(null, mood, 1, 10.0f));
+        }
+
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(mockUser));
+        when(photoMoodRepository.findAllByPhotoIdIn(anyList())).thenReturn(incompletePhotoMoods);
+
+        // [When & Then] PHOTO_ID_NOT_FOUND 예외 발생 확인
+        assertThatThrownBy(() -> createMoodCurationService.saveMoodCurationResult(command))
+            .isInstanceOf(CurationException.class)
+            .hasMessage(CurationErrorCode.PHOTO_ID_NOT_FOUND.getMessage());
     }
 }


### PR DESCRIPTION
## 👀 Summary

- close #252


## 🖇️ Tasks

- [x] happy-path(성공 케이스) 테스트 코드 작성
- [x] 사용자가 사진을 5개 선택하지 않은 경우, (= PhotoMood 조회한 결과 리스트의 요소 개수가 15개가 아닌 경우) 실패 테스트 코드 작성
- [x] 존재하지 않는 사용자의 요청인 경우, 실패 테스트 코드 작성
- [x] 사용자가 요청한 사진이 존재하지 않는 사진일 경우, 실패 테스트 코드 작성

## 🔍 To Reviewer

> 아직 모든 케이스에 대한 테스트 코드 작성이 완료되지 않았으나, 성하님 코드 작성하실 때 도움이 되었으면 해서 우선 PR부터 올립니다. 실패 테스트 코드도 작성될 때마다 push 할게요!

### ❶ 기본 테스트 코드 문법 관련
우선, 저번 회의에서 의논한 내용대로 컨트롤러, 서비스, 리포지토리 중 실제 비즈니스 로직을 다루는 계층인 서비스 계층의 단위 테스트부터 작성했습니다. 이때, "비즈니스 로직"이 정상적으로 작동하는지의 여부를 테스트하기 때문에 DB에서 실제 데이터를 가져오거나, 실제로 저장하지 않습니다. 즉, DB와 상호작용하는 리포지토리 계층에서 호출되는 메서드의 실제 동작이 중요한 것이 아니기 때문에 해당 비즈니스 로직에서 사용하는 데이터나, 리포지토리 객체는 가짜 객체인 Mock으로 만듭니다.

Mock과 관련된 라이브러리는 mockito에 있습니다. mockito 라이브러리에서 사용되는 관련 문법은 아래와 같아요. 

- `@ExtendWith(MockitoExtension.class)`: 해당 어노테이션은 클래스 단에 붙어서 해당 테스트 클래스에서 mockito 라이브러리에서 사용하는 기능을 활성화할 수 있도록 합니다. 이 어노테이션으로 `@RequiredArgsConstructor`처럼 필요한 객체를 자동으로 주입해줍니다.
- `@InjectMocks`: 위에서 만든 가짜 객체(@Mock)들을 테스트 대상이 되는 서비스 객체에 자동으로 주입해 줍니다.
- `when(...).thenReturn(...)`: 이 메서드가 호출되면, 어떤 가짜 데이터를 반환해야 하는지 미리 정의합니다.
- `verify(...)`: 실제로 특정 메서드가 몇 번 호출되었는지, 어떤 인자가 넘어갔는지 검증합니다. 특히 void를 반환하는 저장 로직 등을 확인할 때 유용합니다.

### ❷ Given-When-Then 패턴 (BDD, Behavior-Driven-Development)

테스트 코드가 길어질수록 읽기 힘들다는 단점이 있어서 저는 Given-When-Then 구조로 작성했습니다.  실제 코드에서는 주석 사용을 지양했으나, 테스트 코드의 경우 BDD 패턴을 주로 사용해서 given, when, then 별로 주석을 함께 작성하는 경우가 많습니다. 각 부분의 역할은 아래와 같아요. 

- Given: 테스트에 필요한 환경과 데이터 세팅
- When: 실제 테스트할 메서드 실행
- Then: 결과값 검증 및 상태 확인

이떄, When과 Then의 경우, 실패 케이스 검증하는 테스트 코드에서는 함께 작성하는 경우가 많습니다! 상황에 따라서 작성해주세요.


