### PR TITLE
[TEST] #254: 상품 위시 좋아요/취소 테스트 코드 작성

### DIFF
--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
@@ -181,7 +181,6 @@ class PostWishProductServiceTest {
             assertThat(ex).isNotNull();
 
             // 3. 에러 코드가 PRODUCT_NOT_FOUND인지 확인
-            // WishException에 getErrorCode()가 없으면 이 줄은 컴파일 에러가 날 수 있음(확실하지 않음)
             assertThat(ex.getErrorCode()).isEqualTo(WishErrorCode.PRODUCT_NOT_FOUND);
 
             // 4. 상품이 없으면 위시 조회/저장/삭제가 수행되지 않았는지 확인

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
@@ -129,9 +129,7 @@ class PostWishProductServiceTest {
             // 2-1. 유저 조회 실패(존재하지 않음)
             when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-            // [When] 테스트할 서비스 메서드 호출
-
-            // [Then] 결과 검증
+            // [When/Then] 테스트할 서비스 메서드 호출 및 결과 검증
             // 1. 예외가 발생하는지 확인
             WishException ex = catchThrowableOfType(
                 () -> postWishProductService.toggleProductWish(userId, productId),

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
@@ -41,64 +41,105 @@ class PostWishProductServiceTest {
         @Test
         @DisplayName("기존 위시가 없으면 위시를 생성하고 liked=true를 반환한다")
         void like_whenNotExists() {
+            // [Given] 테스트 시 필요한 데이터 생성
+            // 1. 요청 파라미터 준비
             Long userId = 1L;
             Long productId = 10L;
 
+            // 2. 유저/상품 Mock 객체 준비
             User user = mock(User.class);
             Product product = mock(Product.class);
 
+            // 3. Mockito에게 행동 지시
+            // 3-1. 유저 조회 성공
             when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            // 3-2. 상품 조회 성공
             when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            // 3-3. 기존 위시가 없다고 가정
             when(wishProductRepository.findByUserAndProduct(user, product)).thenReturn(Optional.empty());
 
+            // [When] 테스트할 서비스 메서드 호출
             WishProductResult result = postWishProductService.toggleProductWish(userId, productId);
 
+            // [Then] 결과 검증
+            // 1. 결과 객체가 null이 아닌지 확인
             assertThat(result).isNotNull();
+            // 2. 결과 productId가 요청 productId와 동일한지 확인
             assertThat(result.productId()).isEqualTo(productId);
+            // 3. 위시 생성이므로 liked=true인지 확인
             assertThat(result.liked()).isTrue();
+            // 4. 저장이 1번 호출되었는지 확인
             verify(wishProductRepository, times(1)).save(any(WishProduct.class));
+            // 5. 삭제는 호출되지 않았는지 확인
             verify(wishProductRepository, never()).delete(any(WishProduct.class));
         }
 
         @Test
         @DisplayName("기존 위시가 있으면 위시를 삭제하고 liked=false를 반환한다")
         void cancel_whenExists() {
+            // [Given] 테스트 시 필요한 데이터 생성
+            // 1. 요청 파라미터 준비
             Long userId = 1L;
             Long productId = 10L;
 
+            // 2. 유저/상품/기존 위시 Mock 객체 준비
             User user = mock(User.class);
             Product product = mock(Product.class);
             WishProduct existingWish = mock(WishProduct.class);
 
+            // 3. Mockito에게 행동 지시
+            // 3-1. 유저 조회 성공
             when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            // 3-2. 상품 조회 성공
             when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            // 3-3. 기존 위시가 존재한다고 가정
             when(wishProductRepository.findByUserAndProduct(user, product)).thenReturn(Optional.of(existingWish));
 
+            // [When] 테스트할 서비스 메서드 호출
             WishProductResult result = postWishProductService.toggleProductWish(userId, productId);
 
+            // [Then] 결과 검증
+            // 1. 결과 객체가 null이 아닌지 확인
             assertThat(result).isNotNull();
+            // 2. 결과 productId가 요청 productId와 동일한지 확인
             assertThat(result.productId()).isEqualTo(productId);
+            // 3. 위시 취소이므로 liked=false인지 확인
             assertThat(result.liked()).isFalse();
+            // 4. 삭제가 1번 호출되었는지 확인
             verify(wishProductRepository, times(1)).delete(existingWish);
+            // 5. 저장은 호출되지 않았는지 확인
             verify(wishProductRepository, never()).save(any(WishProduct.class));
         }
 
         @Test
         @DisplayName("유저가 없으면 USER_NOT_FOUND 예외를 던진다")
         void throw_whenUserNotFound() {
+            // [Given] 테스트 시 필요한 데이터 생성
+            // 1. 요청 파라미터 준비
             Long userId = 1L;
             Long productId = 10L;
 
+            // 2. Mockito에게 행동 지시
+            // 2-1. 유저 조회 실패(존재하지 않음)
             when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
+            // [When] 테스트할 서비스 메서드 호출
+
+            // [Then] 결과 검증
+            // 1. 예외가 발생하는지 확인
             WishException ex = catchThrowableOfType(
                 () -> postWishProductService.toggleProductWish(userId, productId),
                 WishException.class
             );
 
+            // 2. 예외 객체가 null이 아닌지 확인
             assertThat(ex).isNotNull();
+
+            // 3. 에러 코드가 USER_NOT_FOUND인지 확인
+            // WishException에 getErrorCode()가 없으면 이 줄은 컴파일 에러가 날 수 있음(확실하지 않음)
             assertThat(ex.getErrorCode()).isEqualTo(WishErrorCode.USER_NOT_FOUND);
 
+            // 4. 유저가 없으면 이후 로직이 수행되지 않았는지 확인
             verify(productRepository, never()).findById(anyLong());
             verify(wishProductRepository, never()).findByUserAndProduct(any(), any());
             verify(wishProductRepository, never()).save(any());
@@ -106,24 +147,39 @@ class PostWishProductServiceTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 상품일 경우 PRODUCT_NOT_FOUND 예외를 던진다")
+        @DisplayName("상품이 없으면 PRODUCT_NOT_FOUND 예외를 던진다")
         void throw_whenProductNotFound() {
+            // [Given] 테스트 시 필요한 데이터 생성
+            // 1. 요청 파라미터 준비
             Long userId = 1L;
             Long productId = 10L;
 
+            // 2. 유저 Mock 객체 준비
             User user = mock(User.class);
 
+            // 3. Mockito에게 행동 지시
+            // 3-1. 유저 조회 성공
             when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            // 3-2. 상품 조회 실패(존재하지 않음)
             when(productRepository.findById(productId)).thenReturn(Optional.empty());
 
+            // [When] 테스트할 서비스 메서드 호출
+
+            // [Then] 결과 검증
+            // 1. 예외가 발생하는지 확인
             WishException ex = catchThrowableOfType(
                 () -> postWishProductService.toggleProductWish(userId, productId),
                 WishException.class
             );
 
+            // 2. 예외 객체가 null이 아닌지 확인
             assertThat(ex).isNotNull();
+
+            // 3. 에러 코드가 PRODUCT_NOT_FOUND인지 확인
+            // WishException에 getErrorCode()가 없으면 이 줄은 컴파일 에러가 날 수 있음(확실하지 않음)
             assertThat(ex.getErrorCode()).isEqualTo(WishErrorCode.PRODUCT_NOT_FOUND);
 
+            // 4. 상품이 없으면 위시 조회/저장/삭제가 수행되지 않았는지 확인
             verify(wishProductRepository, never()).findByUserAndProduct(any(), any());
             verify(wishProductRepository, never()).save(any());
             verify(wishProductRepository, never()).delete(any());

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
@@ -2,15 +2,26 @@ package org.sopt.snappinserver.domain.wish.service;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.sopt.snappinserver.domain.product.repository.ProductRepository;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.sopt.snappinserver.domain.wish.domain.entity.WishProduct;
 import org.sopt.snappinserver.domain.wish.repository.WishProductRepository;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishProductResult;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class PostWishProductServiceTest {
@@ -25,5 +36,26 @@ class PostWishProductServiceTest {
     @DisplayName("toggleProductWish")
     class ToggleProductWish {
 
+        @Test
+        @DisplayName("기존 위시가 없으면 위시를 생성하고 liked=true를 반환한다")
+        void like_whenNotExists() {
+            Long userId = 1L;
+            Long productId = 10L;
+
+            User user = mock(User.class);
+            Product product = mock(Product.class);
+
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            when(wishProductRepository.findByUserAndProduct(user, product)).thenReturn(Optional.empty());
+
+            WishProductResult result = postWishProductService.toggleProductWish(userId, productId);
+
+            assertThat(result).isNotNull();
+            assertThat(result.productId()).isEqualTo(productId);
+            assertThat(result.liked()).isTrue();
+            verify(wishProductRepository, times(1)).save(any(WishProduct.class));
+            verify(wishProductRepository, never()).delete(any(WishProduct.class));
+        }
     }
 }

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
@@ -14,12 +14,14 @@ import org.sopt.snappinserver.domain.product.repository.ProductRepository;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.sopt.snappinserver.domain.user.repository.UserRepository;
 import org.sopt.snappinserver.domain.wish.domain.entity.WishProduct;
+import org.sopt.snappinserver.domain.wish.domain.exception.WishErrorCode;
+import org.sopt.snappinserver.domain.wish.domain.exception.WishException;
 import org.sopt.snappinserver.domain.wish.repository.WishProductRepository;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishProductResult;
 
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -79,6 +81,28 @@ class PostWishProductServiceTest {
             assertThat(result.liked()).isFalse();
             verify(wishProductRepository, times(1)).delete(existingWish);
             verify(wishProductRepository, never()).save(any(WishProduct.class));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자일 경우 USER_NOT_FOUND 예외를 던진다")
+        void throw_whenUserNotFound() {
+            Long userId = 1L;
+            Long productId = 10L;
+
+            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+            WishException ex = catchThrowableOfType(
+                () -> postWishProductService.toggleProductWish(userId, productId),
+                WishException.class
+            );
+
+            assertThat(ex).isNotNull();
+            assertThat(ex.getErrorCode()).isEqualTo(WishErrorCode.USER_NOT_FOUND);
+
+            verify(productRepository, never()).findById(anyLong());
+            verify(wishProductRepository, never()).findByUserAndProduct(any(), any());
+            verify(wishProductRepository, never()).save(any());
+            verify(wishProductRepository, never()).delete(any());
         }
     }
 }

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
@@ -57,5 +57,28 @@ class PostWishProductServiceTest {
             verify(wishProductRepository, times(1)).save(any(WishProduct.class));
             verify(wishProductRepository, never()).delete(any(WishProduct.class));
         }
+
+        @Test
+        @DisplayName("기존 위시가 있으면 위시를 삭제하고 liked=false를 반환한다")
+        void cancel_whenExists() {
+            Long userId = 1L;
+            Long productId = 10L;
+
+            User user = mock(User.class);
+            Product product = mock(Product.class);
+            WishProduct existingWish = mock(WishProduct.class);
+
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            when(wishProductRepository.findByUserAndProduct(user, product)).thenReturn(Optional.of(existingWish));
+
+            WishProductResult result = postWishProductService.toggleProductWish(userId, productId);
+
+            assertThat(result).isNotNull();
+            assertThat(result.productId()).isEqualTo(productId);
+            assertThat(result.liked()).isFalse();
+            verify(wishProductRepository, times(1)).delete(existingWish);
+            verify(wishProductRepository, never()).save(any(WishProduct.class));
+        }
     }
 }

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
@@ -1,0 +1,29 @@
+package org.sopt.snappinserver.domain.wish.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.sopt.snappinserver.domain.product.repository.ProductRepository;
+import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.sopt.snappinserver.domain.wish.repository.WishProductRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PostWishProductServiceTest {
+
+    @Mock private WishProductRepository wishProductRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ProductRepository productRepository;
+
+    @InjectMocks private PostWishProductService postWishProductService;
+
+    @Nested
+    @DisplayName("toggleProductWish")
+    class ToggleProductWish {
+
+    }
+}

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
@@ -168,9 +168,7 @@ class PostWishProductServiceTest {
             // 3-2. 상품 조회 실패(존재하지 않음)
             when(productRepository.findById(productId)).thenReturn(Optional.empty());
 
-            // [When] 테스트할 서비스 메서드 호출
-
-            // [Then] 결과 검증
+            // [When/Then] 테스트할 서비스 메서드 호출 및 결과 검증
             // 1. 예외가 발생하는지 확인
             WishException ex = catchThrowableOfType(
                 () -> postWishProductService.toggleProductWish(userId, productId),

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
@@ -142,7 +142,6 @@ class PostWishProductServiceTest {
             assertThat(ex).isNotNull();
 
             // 3. 에러 코드가 USER_NOT_FOUND인지 확인
-            // WishException에 getErrorCode()가 없으면 이 줄은 컴파일 에러가 날 수 있음(확실하지 않음)
             assertThat(ex.getErrorCode()).isEqualTo(WishErrorCode.USER_NOT_FOUND);
 
             // 4. 유저가 없으면 이후 로직이 수행되지 않았는지 확인

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
@@ -18,6 +18,7 @@ import org.sopt.snappinserver.domain.wish.domain.exception.WishErrorCode;
 import org.sopt.snappinserver.domain.wish.domain.exception.WishException;
 import org.sopt.snappinserver.domain.wish.repository.WishProductRepository;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishProductResult;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Optional;
 
@@ -69,8 +70,13 @@ class PostWishProductServiceTest {
             // 3. 위시 생성이므로 liked=true인지 확인
             assertThat(result.liked()).isTrue();
             // 4. 저장이 1번 호출되었는지 확인
-            verify(wishProductRepository, times(1)).save(any(WishProduct.class));
-            // 5. 삭제는 호출되지 않았는지 확인
+            ArgumentCaptor<WishProduct> captor = ArgumentCaptor.forClass(WishProduct.class);
+            verify(wishProductRepository, times(1)).save(captor.capture());
+            // 5. 저장된 위시가 요청 user/product로 생성되었는지 확인
+            WishProduct savedWish = captor.getValue();
+            assertThat(savedWish.getUser()).isSameAs(user);
+            assertThat(savedWish.getProduct()).isSameAs(product);
+            // 6. 삭제는 호출되지 않았는지 확인
             verify(wishProductRepository, never()).delete(any(WishProduct.class));
         }
 

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
@@ -40,7 +40,7 @@ class PostWishProductServiceTest {
     class ToggleProductWish {
 
         @Test
-        @DisplayName("기존 위시가 없으면 위시를 생성하고 liked=true를 반환한다")
+        @DisplayName("성공 케이스 - 기존 위시가 없으면 위시를 생성하고 liked=true를 반환한다")
         void like_whenNotExists() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
@@ -81,7 +81,7 @@ class PostWishProductServiceTest {
         }
 
         @Test
-        @DisplayName("기존 위시가 있으면 위시를 삭제하고 liked=false를 반환한다")
+        @DisplayName("성공 케이스 - 기존 위시가 있으면 위시를 삭제하고 liked=false를 반환한다")
         void cancel_whenExists() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
@@ -118,7 +118,7 @@ class PostWishProductServiceTest {
         }
 
         @Test
-        @DisplayName("유저가 없으면 USER_NOT_FOUND 예외를 던진다")
+        @DisplayName("예외 케이스 - 유저가 없으면 USER_NOT_FOUND 예외를 던진다")
         void throw_whenUserNotFound() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
@@ -152,7 +152,7 @@ class PostWishProductServiceTest {
         }
 
         @Test
-        @DisplayName("상품이 없으면 PRODUCT_NOT_FOUND 예외를 던진다")
+        @DisplayName("예외 케이스 - 상품이 없으면 PRODUCT_NOT_FOUND 예외를 던진다")
         void throw_whenProductNotFound() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/PostWishProductServiceTest.java
@@ -84,7 +84,7 @@ class PostWishProductServiceTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 사용자일 경우 USER_NOT_FOUND 예외를 던진다")
+        @DisplayName("유저가 없으면 USER_NOT_FOUND 예외를 던진다")
         void throw_whenUserNotFound() {
             Long userId = 1L;
             Long productId = 10L;
@@ -100,6 +100,30 @@ class PostWishProductServiceTest {
             assertThat(ex.getErrorCode()).isEqualTo(WishErrorCode.USER_NOT_FOUND);
 
             verify(productRepository, never()).findById(anyLong());
+            verify(wishProductRepository, never()).findByUserAndProduct(any(), any());
+            verify(wishProductRepository, never()).save(any());
+            verify(wishProductRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 상품일 경우 PRODUCT_NOT_FOUND 예외를 던진다")
+        void throw_whenProductNotFound() {
+            Long userId = 1L;
+            Long productId = 10L;
+
+            User user = mock(User.class);
+
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(productRepository.findById(productId)).thenReturn(Optional.empty());
+
+            WishException ex = catchThrowableOfType(
+                () -> postWishProductService.toggleProductWish(userId, productId),
+                WishException.class
+            );
+
+            assertThat(ex).isNotNull();
+            assertThat(ex.getErrorCode()).isEqualTo(WishErrorCode.PRODUCT_NOT_FOUND);
+
             verify(wishProductRepository, never()).findByUserAndProduct(any(), any());
             verify(wishProductRepository, never()).save(any());
             verify(wishProductRepository, never()).delete(any());


### PR DESCRIPTION
## 👀 Summary

- close #254

상품 위시 좋아요/취소(토글) 서비스(PostWishProductService.toggleProductWish)에 대한 서비스 단위 테스트를 추가했습니다.

## 🖇️ Tasks

**PostWishProductServiceTest 추가**

- [x] 좋아요 생성 케이스
- [x] 좋아요 취소 케이스
- [x] 유저 미존재 예외 케이스
- [x] 상품 미존재 예외 케이스


## 🔍 To Reviewer

### ❶ mock 위주로 작성한 이유

상품 좋아요/취소는 조회 결과에 따라 저장(save) 또는 삭제(delete)로 갈리는 분기 로직이 핵심이라서, 서비스가 어떤 분기로 들어가는지와 그에 맞는 repo 호출이 발생하는지를 집중적으로 확인했습니다.  그래서 repo는 mock으로 두고 when(으로 분기 상황을 만들고, verify로 save/delete가 의도대로 호출되는지 검증했어요.

이 부분은 소연님이 작성해주신 테스트 작성 가이드(서비스 단위 테스트에서는 의존성을 mock 처리하고 when/verify로 흐름을 검증하는 방식)를 참고해 구성했습니다.

### ❷ `@Nested` 사용

테스트가 “toggleProductWish”라는 한 메서드에 대한 묶음이라, JUnit5의 `@Nested`로 묶어봤습니다.
`@Nested`는 테스트 클래스 내에서 논리적으로 관련된 테스트 메서드를 그룹화하는 데 사용되는 기능인데요, 테스트 리포트/IDE에서 기능 단위로 계층적으로 보여 가독성이 좋아지고, 같은 대상 메서드 시나리오를 묶어 관리할 수 있어서 테스트 클래스를 더욱 구조화하기 쉽다고 합니다.

다만 클래스 구조가 한 겹 더 생겨서 팀 내에서 익숙하지 않으면 오히려 읽기/유지보수가 번거로워질 수도 있다고도 해서, `@Nested` 사용 여부에 대해 소연님의 의견이 궁금합니다!

### ❸ verify + never()

토글 로직에서는 한 요청에서 save()와 delete()가 동시에 일어나면 안 되고, 반드시 둘 중 하나만 실행되어야 합니다. 그래서 단순히 save 호출/ delete 호출 여부만 확인하는 대신, 반대쪽 동작이 호출되지 않았는지도 never()로 함께 검증했습니다.

- 좋아요 생성 케이스: save()가 1번 호출되고 delete()는 0번 호출되는지 확인
- 좋아요 취소 케이스: delete()가 1번 호출되고 save()는 0번 호출되는지 확인

이렇게 검증 강도를 올리면, 이후 리팩토링 과정에서 실수로 save()와 delete()를 둘 다 호출하게 되거나 의도치 않게 중복 호출이 생기는 경우를 테스트에서 바로 잡아낼 수 있어 '토글의 상호배타 조건'을 더 명확하게 보장할 수 있는 장점이 있다고 하네요.

### ❹ ArgumentCaptor
위시 생성 경로에서 save()가 호출됐는지만 확인하면, 내부적으로 WishProduct가 잘못된 user/product로 생성되어 저장되더라도 테스트가 통과할 수 있는 문제가 있습니다. (>> 토끼가 알려줬어요)

그래서 ArgumentCaptor<WishProduct>로 저장된 엔티티를 캡처한 뒤,
- savedWish.getUser()가 요청 시 사용한 user와 동일한지
- savedWish.getProduct()가 요청 시 사용한 product와 동일한지
를 함께 검증하도록 보강했습니다.

> ArgumentCatptor의 기능을 활용하면 메소드에 들어가는 인자들을 중간에 가로채어 테스트를 진행할 수 있습니다!


---


- **테스트 코드 주석은 제가 Given/When/Then을 단계별로 구분하면서 이해하기 위해 비교적 상세하게 작성했습니다.**
- **어느 범위까지 설명 주석을 작성해놓을지 얼라인이 정해지면, 기준에 맞춰 정리해서 반영 후 머지하겠습니다!**