### PR TITLE
[TEST] #256: 위시 포트폴리오 목록 조회 테스트 코드 작성

### DIFF
--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
@@ -1,8 +1,6 @@
 package org.sopt.snappinserver.domain.wish.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -53,7 +51,7 @@ class GetWishedPortfoliosServiceTest {
     class GetWishedPortfolios {
 
         @Test
-        @DisplayName("좋아요한 포트폴리오 목록 조회 성공 테스트 - 대표 이미지가 있으면 cloudFrontDomain과 합쳐서 내려준다")
+        @DisplayName("좋아요한 포트폴리오 목록 조회 성공 테스트 - 대표 이미지가 있는 경우")
         void getWishedPortfolios_Success_withImage() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
@@ -101,6 +99,59 @@ class GetWishedPortfoliosServiceTest {
             assertThat(result.portfolios().get(0).id()).isEqualTo(10L);
             // 4. imageUrl이 cloudFrontDomain + photo.imageUrl 형태로 합쳐졌는지 확인
             assertThat(result.portfolios().get(0).imageUrl()).isEqualTo("https://cdn.example.com/images/a.jpg");
+        }
+
+        @Test
+        @DisplayName("좋아요한 포트폴리오 목록 조회 성공 테스트 - 대표 이미지가 없는 경우 및 정렬 검사")
+        void getWishedPortfolios_Success_withoutImage_andKeepsOrder() {
+            // [Given] 테스트 시 필요한 데이터 생성
+            // 1. 요청 파라미터 준비
+            Long userId = 1L;
+
+            // 2. 유저 Mock 객체 준비
+            User user = mock(User.class);
+
+            // 3. 포트폴리오 Mock 객체 2개 준비
+            Portfolio portfolio1 = mock(Portfolio.class);
+            when(portfolio1.getId()).thenReturn(10L);
+            Portfolio portfolio2 = mock(Portfolio.class);
+            when(portfolio2.getId()).thenReturn(20L);
+
+            // 4. 위시 엔티티 Mock 객체 2개 준비
+            WishPortfolio wish1 = mock(WishPortfolio.class);
+            when(wish1.getPortfolio()).thenReturn(portfolio1);
+            WishPortfolio wish2 = mock(WishPortfolio.class);
+            when(wish2.getPortfolio()).thenReturn(portfolio2);
+
+            // 5. Mockito에게 행동 지시
+            // 5-1. 유저 조회 성공
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            // 5-2. 위시 목록은 repo가 createdAt desc로 정렬해서 내려준다고 가정
+            //      테스트에서는 wish2(최근) -> wish1(과거) 순으로 내려주고, 서비스가 이 순서를 유지하는지 검증
+            when(wishPortfolioRepository.findAllByUserOrderByCreatedAtDesc(user)).thenReturn(List.of(wish2, wish1));
+
+            // 5-3. 두 포트폴리오 모두 대표 이미지가 없다고 가정 (Optional.empty())
+            when(portfolioPhotoRepository.findFirstByPortfolioOrderByDisplayOrderAsc(portfolio2))
+                .thenReturn(Optional.empty());
+            when(portfolioPhotoRepository.findFirstByPortfolioOrderByDisplayOrderAsc(portfolio1))
+                .thenReturn(Optional.empty());
+
+            // [When] 테스트할 서비스 메서드 호출
+            WishedPortfoliosResult result = service.getWishedPortfolios(userId);
+
+            // [Then] 결과 검증
+            // 1. 결과 객체가 null이 아닌지 확인
+            assertThat(result).isNotNull();
+            // 2. 포트폴리오 리스트가 2개인지 확인 (정렬 검증을 위해 2개 이상 필요)
+            assertThat(result.portfolios()).hasSize(2);
+
+            // 3. 서비스가 중간에서 순서를 바꾸지 않고, repo에서 내려준 순서를 유지하는지 확인
+            assertThat(result.portfolios().get(0).id()).isEqualTo(20L);
+            assertThat(result.portfolios().get(1).id()).isEqualTo(10L);
+
+            // 4. 대표 이미지가 없으면 imageUrl이 null로 내려오는지 확인
+            assertThat(result.portfolios().get(0).imageUrl()).isNull();
+            assertThat(result.portfolios().get(1).imageUrl()).isNull();
         }
     }
 }

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
@@ -25,7 +25,7 @@ import org.sopt.snappinserver.domain.wish.domain.exception.WishErrorCode;
 import org.sopt.snappinserver.domain.wish.domain.exception.WishException;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import org.sopt.snappinserver.domain.photo.domain.entity.Photo; // 확실하지 않음: 프로젝트에 맞게 경로 수정 필요할 수 있음
+import org.sopt.snappinserver.domain.photo.domain.entity.Photo;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioPhoto;
 import org.sopt.snappinserver.domain.portfolio.repository.PortfolioPhotoRepository;

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
@@ -71,7 +71,7 @@ class GetWishedPortfoliosServiceTest {
             // 3-1. 포트폴리오 식별자(id) 반환값 설정
             when(portfolio1.getId()).thenReturn(10L);
 
-            // 4. 위시 엔티티 Mock 객체 준비 (user가 좋아요한 포트폴리오를 의미)
+            // 4. 위시 엔티티 Mock 객체 준비
             WishPortfolio wish1 = mock(WishPortfolio.class);
             // 4-1. wish에서 portfolio를 꺼내면 위에서 만든 portfolio1이 나오도록 설정
             when(wish1.getPortfolio()).thenReturn(portfolio1);
@@ -89,7 +89,7 @@ class GetWishedPortfoliosServiceTest {
             when(userRepository.findById(userId)).thenReturn(Optional.of(user));
             // 6-2. 위시 목록 조회 결과로 wish1 하나를 반환 (최근 좋아요 순 정렬은 repo가 보장한다고 가정)
             when(wishPortfolioRepository.findAllByUserOrderByCreatedAtDesc(user)).thenReturn(List.of(wish1));
-            // 6-3. 대표 이미지(첫 번째 사진) 조회 성공
+            // 6-3. 대표 이미지 조회 성공
             when(portfolioPhotoRepository.findFirstByPortfolioOrderByDisplayOrderAsc(portfolio1))
                 .thenReturn(Optional.of(portfolioPhoto));
 
@@ -108,7 +108,7 @@ class GetWishedPortfoliosServiceTest {
         }
 
         @Test
-        @DisplayName("성공 케이스 - 대표 이미지가 없으면 imageUrl은 null이며, repo 정렬 순서가 유지된다")
+        @DisplayName("성공 케이스 - 대표 이미지가 없으면 imageUrl은 null이며, repository의 정렬 순서가 유지된다")
         void getWishedPortfolios_Success_withoutImage_andKeepsOrder() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
@@ -176,8 +176,7 @@ class GetWishedPortfoliosServiceTest {
             // [Then] 결과 검증
             // 1. 예외가 발생하는지 확인
             WishException ex = catchThrowableOfType(
-                () -> service.getWishedPortfolios(userId),
-                WishException.class
+                () -> service.getWishedPortfolios(userId), WishException.class
             );
 
             // 2. 예외 객체가 null이 아닌지 확인

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
@@ -1,7 +1,11 @@
 package org.sopt.snappinserver.domain.wish.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -17,6 +21,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.sopt.snappinserver.domain.wish.domain.exception.WishErrorCode;
+import org.sopt.snappinserver.domain.wish.domain.exception.WishException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import org.sopt.snappinserver.domain.photo.domain.entity.Photo; // 확실하지 않음: 프로젝트에 맞게 경로 수정 필요할 수 있음
@@ -51,7 +57,7 @@ class GetWishedPortfoliosServiceTest {
     class GetWishedPortfolios {
 
         @Test
-        @DisplayName("좋아요한 포트폴리오 목록 조회 성공 테스트 - 대표 이미지가 있는 경우")
+        @DisplayName("성공 케이스 - 대표 이미지가 있으면 cloudFrontDomain과 합쳐서 내려준다")
         void getWishedPortfolios_Success_withImage() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
@@ -102,7 +108,7 @@ class GetWishedPortfoliosServiceTest {
         }
 
         @Test
-        @DisplayName("좋아요한 포트폴리오 목록 조회 성공 테스트 - 대표 이미지가 없는 경우 및 정렬 검사")
+        @DisplayName("성공 케이스 - 대표 이미지가 없으면 imageUrl은 null이며, repo 정렬 순서가 유지된다")
         void getWishedPortfolios_Success_withoutImage_andKeepsOrder() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
@@ -152,6 +158,35 @@ class GetWishedPortfoliosServiceTest {
             // 4. 대표 이미지가 없으면 imageUrl이 null로 내려오는지 확인
             assertThat(result.portfolios().get(0).imageUrl()).isNull();
             assertThat(result.portfolios().get(1).imageUrl()).isNull();
+        }
+
+        @Test
+        @DisplayName("예외 테스트 - 유저가 없으면 USER_NOT_FOUND 예외를 던진다")
+        void throw_whenUserNotFound() {
+            // [Given] 테스트 시 필요한 데이터 생성
+            // 1. 요청 파라미터 준비
+            Long userId = 1L;
+
+            // 2. Mockito에게 행동 지시
+            // 2-1. 유저 조회 실패(존재하지 않음)
+            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+            // [When] 테스트할 서비스 메서드 호출
+
+            // [Then] 결과 검증
+            // 1. 예외가 발생하는지 확인
+            WishException ex = catchThrowableOfType(
+                () -> service.getWishedPortfolios(userId),
+                WishException.class
+            );
+
+            // 2. 예외 객체가 null이 아닌지 확인
+            assertThat(ex).isNotNull();
+            // 3. 에러 코드가 USER_NOT_FOUND인지 확인
+            assertThat(ex.getErrorCode()).isEqualTo(WishErrorCode.USER_NOT_FOUND);
+            // 4. 유저가 없으면 이후 로직(위시 조회/대표 이미지 조회)이 수행되지 않았는지 확인
+            verify(wishPortfolioRepository, never()).findAllByUserOrderByCreatedAtDesc(any());
+            verify(portfolioPhotoRepository, never()).findFirstByPortfolioOrderByDisplayOrderAsc(any());
         }
     }
 }

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
@@ -38,6 +38,9 @@ import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosR
 @ExtendWith(MockitoExtension.class)
 class GetWishedPortfoliosServiceTest {
 
+    private static final Long USER_ID = 1L;
+    private static final String CDN_DOMAIN = "https://cdn.example.com";
+
     @Mock private WishPortfolioRepository wishPortfolioRepository;
     @Mock private PortfolioPhotoRepository portfolioPhotoRepository;
     @Mock private UserRepository userRepository;
@@ -49,7 +52,7 @@ class GetWishedPortfoliosServiceTest {
         // [Given] 테스트 시 필요한 환경 세팅
         // 1. @Value로 주입되는 cloudFrontDomain은 테스트에서 스프링 컨텍스트를 띄우지 않기 때문에 값이 비어있을 수 있음
         // 2. ReflectionTestUtils로 service 내부 필드(cloudFrontDomain)에 테스트용 값을 주입
-        ReflectionTestUtils.setField(service, "cloudFrontDomain", "https://cdn.example.com");
+        ReflectionTestUtils.setField(service, "cloudFrontDomain", CDN_DOMAIN);
     }
 
     @Nested
@@ -61,7 +64,7 @@ class GetWishedPortfoliosServiceTest {
         void getWishedPortfolios_Success_withImage() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
-            Long userId = 1L;
+            Long userId = USER_ID;
 
             // 2. Mock 객체 준비
             User user = mock(User.class);
@@ -112,7 +115,7 @@ class GetWishedPortfoliosServiceTest {
         void getWishedPortfolios_Success_withoutImage_andKeepsOrder() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
-            Long userId = 1L;
+            Long userId = USER_ID;
 
             // 2. 유저 Mock 객체 준비
             User user = mock(User.class);
@@ -161,44 +164,11 @@ class GetWishedPortfoliosServiceTest {
         }
 
         @Test
-        @DisplayName("성공 케이스 - 위시한 포트폴리오가 없으면 빈 리스트를 반환한다")
-        void getWishedPortfolios_Success_emptyWishList() {
-            // [Given] 테스트 시 필요한 데이터 생성
-            // 1. 요청 파라미터 준비
-            Long userId = 1L;
-
-            // 2. 유저 Mock 객체 준비
-            User user = mock(User.class);
-
-            // 3. Mockito에게 행동 지시
-            // 3-1. 유저 조회 성공
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-            // 3-2. 위시 포트폴리오 목록이 비어있는 경우
-            when(wishPortfolioRepository.findAllByUserOrderByCreatedAtDesc(user))
-                .thenReturn(List.of());
-
-            // [When] 테스트할 서비스 메서드 호출
-            WishedPortfoliosResult result = service.getWishedPortfolios(userId);
-
-            // [Then] 결과 검증
-            // 1. 결과 객체가 null이 아닌지 확인
-            assertThat(result).isNotNull();
-            // 2. 포트폴리오 리스트가 null이 아닌지 확인
-            assertThat(result.portfolios()).isNotNull();
-            // 3. 포트폴리오 리스트가 비어있는지 확인
-            assertThat(result.portfolios()).isEmpty();
-
-            // 4. 위시 목록이 없으면 대표 이미지 조회가 발생하지 않는지 확인
-            verify(portfolioPhotoRepository, never())
-                .findFirstByPortfolioOrderByDisplayOrderAsc(any());
-        }
-
-        @Test
         @DisplayName("예외 케이스 - 유저가 없으면 USER_NOT_FOUND 예외를 던진다")
         void throw_whenUserNotFound() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
-            Long userId = 1L;
+            Long userId = USER_ID;
 
             // 2. Mockito에게 행동 지시
             // 2-1. 유저 조회 실패(존재하지 않음)

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
@@ -1,5 +1,15 @@
 package org.sopt.snappinserver.domain.wish.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -9,9 +19,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.test.util.ReflectionTestUtils;
+
+import org.sopt.snappinserver.domain.photo.domain.entity.Photo; // 확실하지 않음: 프로젝트에 맞게 경로 수정 필요할 수 있음
+import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
+import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioPhoto;
 import org.sopt.snappinserver.domain.portfolio.repository.PortfolioPhotoRepository;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.sopt.snappinserver.domain.wish.domain.entity.WishPortfolio;
 import org.sopt.snappinserver.domain.wish.repository.WishPortfolioRepository;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosResult;
 
 @ExtendWith(MockitoExtension.class)
 class GetWishedPortfoliosServiceTest {
@@ -22,14 +40,67 @@ class GetWishedPortfoliosServiceTest {
 
     @InjectMocks private GetWishedPortfoliosService service;
 
+    @BeforeEach
+    void setUp() {
+        // [Given] 테스트 시 필요한 환경 세팅
+        // 1. @Value로 주입되는 cloudFrontDomain은 테스트에서 스프링 컨텍스트를 띄우지 않기 때문에 값이 비어있을 수 있음
+        // 2. ReflectionTestUtils로 service 내부 필드(cloudFrontDomain)에 테스트용 값을 주입
+        ReflectionTestUtils.setField(service, "cloudFrontDomain", "https://cdn.example.com");
+    }
+
     @Nested
     @DisplayName("getWishedPortfolios")
     class GetWishedPortfolios {
 
         @Test
-        @DisplayName("좋아요한 포트폴리오 목록 조회 성공 테스트")
-        void getWishedPortfolios_Success() {
+        @DisplayName("좋아요한 포트폴리오 목록 조회 성공 테스트 - 대표 이미지가 있으면 cloudFrontDomain과 합쳐서 내려준다")
+        void getWishedPortfolios_Success_withImage() {
+            // [Given] 테스트 시 필요한 데이터 생성
+            // 1. 요청 파라미터 준비
+            Long userId = 1L;
 
+            // 2. Mock 객체 준비
+            User user = mock(User.class);
+
+            // 3. 포트폴리오 Mock 객체 준비
+            Portfolio portfolio1 = mock(Portfolio.class);
+            // 3-1. 포트폴리오 식별자(id) 반환값 설정
+            when(portfolio1.getId()).thenReturn(10L);
+
+            // 4. 위시 엔티티 Mock 객체 준비 (user가 좋아요한 포트폴리오를 의미)
+            WishPortfolio wish1 = mock(WishPortfolio.class);
+            // 4-1. wish에서 portfolio를 꺼내면 위에서 만든 portfolio1이 나오도록 설정
+            when(wish1.getPortfolio()).thenReturn(portfolio1);
+
+            // 5. 대표 이미지 조회에 필요한 PortfolioPhoto/Photo Mock 객체 준비
+            PortfolioPhoto portfolioPhoto = mock(PortfolioPhoto.class);
+            Photo photo = mock(Photo.class);
+            // 5-1. Photo의 imageUrl이 "/images/a.jpg"로 반환되도록 설정
+            when(photo.getImageUrl()).thenReturn("/images/a.jpg");
+            // 5-2. PortfolioPhoto에서 photo를 꺼내면 위에서 만든 photo가 나오도록 설정
+            when(portfolioPhoto.getPhoto()).thenReturn(photo);
+
+            // 6. Mockito에게 행동 지시
+            // 6-1. 유저 조회 성공
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            // 6-2. 위시 목록 조회 결과로 wish1 하나를 반환 (최근 좋아요 순 정렬은 repo가 보장한다고 가정)
+            when(wishPortfolioRepository.findAllByUserOrderByCreatedAtDesc(user)).thenReturn(List.of(wish1));
+            // 6-3. 대표 이미지(첫 번째 사진) 조회 성공
+            when(portfolioPhotoRepository.findFirstByPortfolioOrderByDisplayOrderAsc(portfolio1))
+                .thenReturn(Optional.of(portfolioPhoto));
+
+            // [When] 테스트할 서비스 메서드 호출
+            WishedPortfoliosResult result = service.getWishedPortfolios(userId);
+
+            // [Then] 결과 검증
+            // 1. 결과 객체가 null이 아닌지 확인
+            assertThat(result).isNotNull();
+            // 2. 포트폴리오 리스트가 1개인지 확인
+            assertThat(result.portfolios()).hasSize(1);
+            // 3. 내려준 포트폴리오 id가 기대값(10L)인지 확인
+            assertThat(result.portfolios().get(0).id()).isEqualTo(10L);
+            // 4. imageUrl이 cloudFrontDomain + photo.imageUrl 형태로 합쳐졌는지 확인
+            assertThat(result.portfolios().get(0).imageUrl()).isEqualTo("https://cdn.example.com/images/a.jpg");
         }
     }
 }

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
@@ -168,7 +168,7 @@ class GetWishedPortfoliosServiceTest {
         void getWishedPortfolios_Success_emptyWishList() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
-            Long userId = 1L;
+            Long userId = USER_ID;
 
             // 2. 유저 Mock 객체 준비
             User user = mock(User.class);

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
@@ -1,0 +1,35 @@
+package org.sopt.snappinserver.domain.wish.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.sopt.snappinserver.domain.portfolio.repository.PortfolioPhotoRepository;
+import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.sopt.snappinserver.domain.wish.repository.WishPortfolioRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GetWishedPortfoliosServiceTest {
+
+    @Mock private WishPortfolioRepository wishPortfolioRepository;
+    @Mock private PortfolioPhotoRepository portfolioPhotoRepository;
+    @Mock private UserRepository userRepository;
+
+    @InjectMocks private GetWishedPortfoliosService service;
+
+    @Nested
+    @DisplayName("getWishedPortfolios")
+    class GetWishedPortfolios {
+
+        @Test
+        @DisplayName("좋아요한 포트폴리오 목록 조회 성공 테스트")
+        void getWishedPortfolios_Success() {
+
+        }
+    }
+}

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
@@ -171,9 +171,7 @@ class GetWishedPortfoliosServiceTest {
             // 2-1. 유저 조회 실패(존재하지 않음)
             when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-            // [When] 테스트할 서비스 메서드 호출
-
-            // [Then] 결과 검증
+            // [When/Then] 테스트할 서비스 메서드 호출 및 결과 검증
             // 1. 예외가 발생하는지 확인
             WishException ex = catchThrowableOfType(
                 () -> service.getWishedPortfolios(userId), WishException.class

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
@@ -39,6 +39,10 @@ import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosR
 class GetWishedPortfoliosServiceTest {
 
     private static final Long USER_ID = 1L;
+    private static final Long PORTFOLIO_ID_1 = 10L;
+    private static final Long PORTFOLIO_ID_2 = 20L;
+
+    private static final String IMAGE_PATH = "/images/a.jpg";
     private static final String CDN_DOMAIN = "https://cdn.example.com";
 
     @Mock private WishPortfolioRepository wishPortfolioRepository;
@@ -72,7 +76,7 @@ class GetWishedPortfoliosServiceTest {
             // 3. 포트폴리오 Mock 객체 준비
             Portfolio portfolio1 = mock(Portfolio.class);
             // 3-1. 포트폴리오 식별자(id) 반환값 설정
-            when(portfolio1.getId()).thenReturn(10L);
+            when(portfolio1.getId()).thenReturn(PORTFOLIO_ID_1);
 
             // 4. 위시 엔티티 Mock 객체 준비
             WishPortfolio wish1 = mock(WishPortfolio.class);
@@ -83,7 +87,7 @@ class GetWishedPortfoliosServiceTest {
             PortfolioPhoto portfolioPhoto = mock(PortfolioPhoto.class);
             Photo photo = mock(Photo.class);
             // 5-1. Photo의 imageUrl이 "/images/a.jpg"로 반환되도록 설정
-            when(photo.getImageUrl()).thenReturn("/images/a.jpg");
+            when(photo.getImageUrl()).thenReturn(IMAGE_PATH);
             // 5-2. PortfolioPhoto에서 photo를 꺼내면 위에서 만든 photo가 나오도록 설정
             when(portfolioPhoto.getPhoto()).thenReturn(photo);
 
@@ -105,9 +109,9 @@ class GetWishedPortfoliosServiceTest {
             // 2. 포트폴리오 리스트가 1개인지 확인
             assertThat(result.portfolios()).hasSize(1);
             // 3. 내려준 포트폴리오 id가 기대값(10L)인지 확인
-            assertThat(result.portfolios().get(0).id()).isEqualTo(10L);
+            assertThat(result.portfolios().get(0).id()).isEqualTo(PORTFOLIO_ID_1);
             // 4. imageUrl이 cloudFrontDomain + photo.imageUrl 형태로 합쳐졌는지 확인
-            assertThat(result.portfolios().get(0).imageUrl()).isEqualTo("https://cdn.example.com/images/a.jpg");
+            assertThat(result.portfolios().get(0).imageUrl()).isEqualTo(CDN_DOMAIN + IMAGE_PATH);
         }
 
         @Test
@@ -122,9 +126,9 @@ class GetWishedPortfoliosServiceTest {
 
             // 3. 포트폴리오 Mock 객체 2개 준비
             Portfolio portfolio1 = mock(Portfolio.class);
-            when(portfolio1.getId()).thenReturn(10L);
+            when(portfolio1.getId()).thenReturn(PORTFOLIO_ID_1);
             Portfolio portfolio2 = mock(Portfolio.class);
-            when(portfolio2.getId()).thenReturn(20L);
+            when(portfolio2.getId()).thenReturn(PORTFOLIO_ID_2);
 
             // 4. 위시 엔티티 Mock 객체 2개 준비
             WishPortfolio wish1 = mock(WishPortfolio.class);
@@ -155,8 +159,8 @@ class GetWishedPortfoliosServiceTest {
             assertThat(result.portfolios()).hasSize(2);
 
             // 3. 서비스가 중간에서 순서를 바꾸지 않고, repo에서 내려준 순서를 유지하는지 확인
-            assertThat(result.portfolios().get(0).id()).isEqualTo(20L);
-            assertThat(result.portfolios().get(1).id()).isEqualTo(10L);
+            assertThat(result.portfolios().get(0).id()).isEqualTo(PORTFOLIO_ID_2);
+            assertThat(result.portfolios().get(1).id()).isEqualTo(PORTFOLIO_ID_1);
 
             // 4. 대표 이미지가 없으면 imageUrl이 null로 내려오는지 확인
             assertThat(result.portfolios().get(0).imageUrl()).isNull();

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
@@ -161,7 +161,7 @@ class GetWishedPortfoliosServiceTest {
         }
 
         @Test
-        @DisplayName("예외 테스트 - 유저가 없으면 USER_NOT_FOUND 예외를 던진다")
+        @DisplayName("예외 케이스 - 유저가 없으면 USER_NOT_FOUND 예외를 던진다")
         void throw_whenUserNotFound() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosServiceTest.java
@@ -161,6 +161,39 @@ class GetWishedPortfoliosServiceTest {
         }
 
         @Test
+        @DisplayName("성공 케이스 - 위시한 포트폴리오가 없으면 빈 리스트를 반환한다")
+        void getWishedPortfolios_Success_emptyWishList() {
+            // [Given] 테스트 시 필요한 데이터 생성
+            // 1. 요청 파라미터 준비
+            Long userId = 1L;
+
+            // 2. 유저 Mock 객체 준비
+            User user = mock(User.class);
+
+            // 3. Mockito에게 행동 지시
+            // 3-1. 유저 조회 성공
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            // 3-2. 위시 포트폴리오 목록이 비어있는 경우
+            when(wishPortfolioRepository.findAllByUserOrderByCreatedAtDesc(user))
+                .thenReturn(List.of());
+
+            // [When] 테스트할 서비스 메서드 호출
+            WishedPortfoliosResult result = service.getWishedPortfolios(userId);
+
+            // [Then] 결과 검증
+            // 1. 결과 객체가 null이 아닌지 확인
+            assertThat(result).isNotNull();
+            // 2. 포트폴리오 리스트가 null이 아닌지 확인
+            assertThat(result.portfolios()).isNotNull();
+            // 3. 포트폴리오 리스트가 비어있는지 확인
+            assertThat(result.portfolios()).isEmpty();
+
+            // 4. 위시 목록이 없으면 대표 이미지 조회가 발생하지 않는지 확인
+            verify(portfolioPhotoRepository, never())
+                .findFirstByPortfolioOrderByDisplayOrderAsc(any());
+        }
+
+        @Test
         @DisplayName("예외 케이스 - 유저가 없으면 USER_NOT_FOUND 예외를 던진다")
         void throw_whenUserNotFound() {
             // [Given] 테스트 시 필요한 데이터 생성


### PR DESCRIPTION
## 👀 Summary

- close #256

상품 위시 좋아요/취소(토글) 서비스(PostWishProductService.toggleProductWish)에 대한 서비스 단위 테스트를 추가했습니다.


## 🖇️ Tasks

**GetWishedPortfoliosServiceTest 추가**
- [x] 포트폴리오 대표 이미지 여부에 따른 성공 케이스
  - 대표 이미지 존재 시 cloudFrontDomain과 합쳐서 내려주는지 검사
  - 대표 이미지 미존재 시 null값으로 처리하고 위시 최신순 정렬 검사
- [x] 위시 상품이 없을 시 성공 케이스
  - 빈 리스트를 정상적으로 반환하는지 검사
- [x]  유저 미존재 예외 케이스


## 🔍 To Reviewer

### ❶ ReflectionTestUtils 사용
GetWishedPortfoliosService의 서비스 로직에서는 cloudFrontDomain을 아래와 같이 주입받고 있습니다.

```java
@Value("${cloud.aws.cloud-front.domain}")
```

현재 작성된 테스트는 Spring 컨텍스트를 띄우지 않는 서비스 단위 테스트(MockitoExtension 기반)라서 `@Value`가 자동 주입되지 않습니다. 이 상태로 테스트를 돌리면 cloudFrontDomain이 null일 수 있고, 이미지 URL 조합 로직이 의도치 않게 깨질 수 있는 문제가 있다고 해요.

<br>

그래서 **ReflectionTestUtils를 사용해서 서비스 내부 필드에 테스트용 값을 주입**했습니다.

```java
ReflectionTestUtils.setField(service, "cloudFrontDomain", "...")
```

> ReflectionTestUtils는 Spring Test에서 제공하는 유틸리티로, 리플렉션(reflection)을 이용해 객체의 private/protected 필드나 메서드에 테스트 코드에서 접근할 수 있게 해준대요!

이 방식은 설정 주입 여부가 아니라 서비스 로직(문자열 조합/매핑)을 검증하는 게 목적일 때, 불필요하게 SpringBootTest를 올리지 않고도 테스트를 깔끔하게 유지할 수 있어서 사용했습니다.

<br>

또한 해당 세팅은 테스트 케이스마다 독립적으로 동일하게 필요하므로 `@BeforeEach`에 넣었습니다. `@BeforeEach`가 붙은 `setUp()`은 각 `@Test` 실행 직전에 매번 자동으로 호출되기 때문에, 모든 테스트가 동일한 초기 상태(동일한 cloudFrontDomain 값)에서 실행되도록 할 수 있습니다.

### ❷ 최신순 위시 정렬 테스트 방식

기존 서비스 로직은 정렬 자체를 직접 수행하지 않고, wishPortfolioRepository에서 이미 최신순(createdAt desc)으로 조회된 결과를 그대로 매핑하는 구조입니다.

따라서 테스트에서는 정렬 알고리즘을 서비스가 새로 구현했는지를 보는 것이 아니라,
레포지토리가 wish2 → wish1 순서로 반환했을 때 서비스가 중간에서 순서를 바꾸지 않고 동일한 순서로 결과 DTO를 만들어 내려주는지를 검증하는 방식으로 작성했습니다.

즉, 정렬 책임은 레포지토리에 있다는 전제 하에 서비스가 조회 결과의 순서를 보존하는지(순서 유지)를 확인하는 방식이라고 생각해주시면 됩니다.
