### PR TITLE
[TEST] #258: 위시 상품 목록 조회 테스트 코드 작성 

### DIFF
--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -368,7 +368,7 @@ class GetWishedProductsServiceTest {
 
         @Test
         @DisplayName("성공 케이스 - 위시한 상품이 없으면 빈 리스트를 반환한다")
-        void success_emptyWishList_returnsEmpty() {
+        void getWishedProducts_Success_emptyWishList_returnsEmpty() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
             Long userId = USER_ID;
@@ -402,7 +402,7 @@ class GetWishedProductsServiceTest {
 
         @Test
         @DisplayName("예외 케이스 - 유저가 없으면 USER_NOT_FOUND 예외를 던지고, 이후 로직이 수행되지 않는다")
-        void throw_whenUserNotFound() {
+        void getWishedProducts_Fail_whenUserNotFound() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
             Long userId = USER_ID;

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -102,7 +102,21 @@ class GetWishedProductsServiceTest {
             when(mood.getName()).thenReturn("따뜻한");
             when(productMood.getMood()).thenReturn(mood);
 
+            // 8. Mockito에게 행동 지시
+            // 8-1. 유저 조회 성공
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            // 8-2. 위시 목록 조회 결과로 wish 하나 반환 (정렬은 repo가 보장한다고 가정)
+            when(wishProductRepository.findAllByUserWithProductOrderByCreatedAtDesc(user))
+                .thenReturn(List.of(wish));
+            // 8-3. 대표 이미지 조회 성공
+            when(productPhotoRepository.findFirstByProductOrderByDisplayOrderAsc(product))
+                .thenReturn(Optional.of(productPhoto));
+            // 8-4. 리뷰 통계 조회 성공
+            when(reviewRepository.findReviewStatsByProductId(10L)).thenReturn(stats);
+            // 8-5. 무드 태그 조회 성공
+            when(productMoodRepository.findAllByProductOrderById(product))
+                .thenReturn(List.of(productMood));
         }
-        
+
     }
 }

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -43,6 +43,10 @@ import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsRes
 class GetWishedProductsServiceTest {
 
     private static final Long USER_ID = 1L;
+    private static final Long PRODUCT_ID_1 = 10L;
+    private static final Long PRODUCT_ID_2 = 20L;
+
+    private static final String IMAGE_PATH = "/images/a.jpg";
     private static final String CDN_DOMAIN = "https://cdn.example.com";
 
     @Mock private WishProductRepository wishProductRepository;
@@ -76,7 +80,7 @@ class GetWishedProductsServiceTest {
 
             // 3. 상품(Product) Mock 객체 준비
             Product product = mock(Product.class);
-            when(product.getId()).thenReturn(10L);
+            when(product.getId()).thenReturn(PRODUCT_ID_1);
             when(product.getTitle()).thenReturn("스냅 촬영 상품");
             when(product.getPrice()).thenReturn(100000);
 
@@ -92,7 +96,7 @@ class GetWishedProductsServiceTest {
             // 5. 대표 이미지 조회에 필요한 ProductPhoto/Photo Mock 객체 준비
             ProductPhoto productPhoto = mock(ProductPhoto.class);
             Photo photo = mock(Photo.class);
-            when(photo.getImageUrl()).thenReturn("/images/a.jpg");
+            when(photo.getImageUrl()).thenReturn(IMAGE_PATH);
             when(productPhoto.getPhoto()).thenReturn(photo);
 
             // 6. 리뷰 통계 Mock 객체 준비 (평균 별점/리뷰 수)
@@ -116,7 +120,7 @@ class GetWishedProductsServiceTest {
             when(productPhotoRepository.findFirstByProductOrderByDisplayOrderAsc(product))
                 .thenReturn(Optional.of(productPhoto));
             // 8-4. 리뷰 통계 조회 성공
-            when(reviewRepository.findReviewStatsByProductId(10L)).thenReturn(stats);
+            when(reviewRepository.findReviewStatsByProductId(PRODUCT_ID_1)).thenReturn(stats);
             // 8-5. 무드 태그 조회 성공
             when(productMoodRepository.findAllByProductOrderById(product))
                 .thenReturn(List.of(productMood));
@@ -133,16 +137,16 @@ class GetWishedProductsServiceTest {
             WishedProductResult item = result.products().get(0);
 
             // 3. id, title, price 매핑 확인
-            assertThat(item.id()).isEqualTo(10L);
+            assertThat(item.id()).isEqualTo(PRODUCT_ID_1);
             assertThat(item.title()).isEqualTo("스냅 촬영 상품");
             assertThat(item.price()).isEqualTo(100000);
 
             // 4. 대표 이미지가 cloudFrontDomain + imageUrl 형태로 합쳐졌는지 확인
-            assertThat(item.imageUrl()).isEqualTo("https://cdn.example.com/images/a.jpg");
+            assertThat(item.imageUrl()).isEqualTo(CDN_DOMAIN + IMAGE_PATH);
 
             // 5. 리뷰 통계가 매핑되는지 확인
             assertThat(item.rate()).isEqualTo(4.5);
-            assertThat(item.reviewCount()).isEqualTo(10);
+            assertThat(item.reviewCount()).isEqualTo(10L);
 
             // 6. 작가명 매핑 확인
             assertThat(item.photographer()).isEqualTo("작가");
@@ -163,7 +167,7 @@ class GetWishedProductsServiceTest {
 
             // 3. 상품(Product) Mock 객체 준비
             Product product = mock(Product.class);
-            when(product.getId()).thenReturn(10L);
+            when(product.getId()).thenReturn(PRODUCT_ID_1);
             when(product.getTitle()).thenReturn("상품");
             when(product.getPrice()).thenReturn(50000);
 
@@ -191,7 +195,7 @@ class GetWishedProductsServiceTest {
             when(productPhotoRepository.findFirstByProductOrderByDisplayOrderAsc(product))
                 .thenReturn(Optional.empty());
             // 6-4. 리뷰 통계 조회 성공
-            when(reviewRepository.findReviewStatsByProductId(10L)).thenReturn(stats);
+            when(reviewRepository.findReviewStatsByProductId(PRODUCT_ID_1)).thenReturn(stats);
             // 6-5. 무드 태그 없음
             when(productMoodRepository.findAllByProductOrderById(product)).thenReturn(List.of());
 
@@ -219,12 +223,12 @@ class GetWishedProductsServiceTest {
 
             // 3. 상품(Product) Mock 객체 2개 준비
             Product product1 = mock(Product.class);
-            when(product1.getId()).thenReturn(10L);
+            when(product1.getId()).thenReturn(PRODUCT_ID_1);
             when(product1.getTitle()).thenReturn("상품1");
             when(product1.getPrice()).thenReturn(1000);
 
             Product product2 = mock(Product.class);
-            when(product2.getId()).thenReturn(20L);
+            when(product2.getId()).thenReturn(PRODUCT_ID_2);
             when(product2.getTitle()).thenReturn("상품2");
             when(product2.getPrice()).thenReturn(2000);
 
@@ -278,8 +282,8 @@ class GetWishedProductsServiceTest {
             assertThat(result.products()).hasSize(2);
 
             // 3. 서비스가 중간에서 순서를 바꾸지 않고, repo에서 내려준 순서를 유지하는지 확인
-            assertThat(result.products().get(0).id()).isEqualTo(20L);
-            assertThat(result.products().get(1).id()).isEqualTo(10L);
+            assertThat(result.products().get(0).id()).isEqualTo(PRODUCT_ID_2);
+            assertThat(result.products().get(1).id()).isEqualTo(PRODUCT_ID_1);
         }
 
         @Test
@@ -294,7 +298,7 @@ class GetWishedProductsServiceTest {
 
             // 3. 상품(Product) Mock 객체 준비
             Product product = mock(Product.class);
-            when(product.getId()).thenReturn(10L);
+            when(product.getId()).thenReturn(PRODUCT_ID_1);
             when(product.getTitle()).thenReturn("상품");
             when(product.getPrice()).thenReturn(1000);
 
@@ -348,7 +352,7 @@ class GetWishedProductsServiceTest {
                 .thenReturn(List.of(wish));
 
             // 8-4. 리뷰 통계 조회 성공
-            when(reviewRepository.findReviewStatsByProductId(10L)).thenReturn(stats);
+            when(reviewRepository.findReviewStatsByProductId(PRODUCT_ID_1)).thenReturn(stats);
 
             // [When] 테스트할 서비스 메서드 호출
             WishedProductsResult result = service.getWishedProducts(userId);
@@ -401,7 +405,7 @@ class GetWishedProductsServiceTest {
         void throw_whenUserNotFound() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
-            Long userId = 1L;
+            Long userId = USER_ID;
 
             // 2. Mockito에게 행동 지시
             // 2-1. 유저 조회 실패 (존재하지 않음)

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
 import org.sopt.snappinserver.domain.photo.domain.entity.Photo;
 import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductResult;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import org.sopt.snappinserver.domain.product.domain.entity.Product;
@@ -80,7 +81,7 @@ class GetWishedProductsServiceTest {
             when(product.getPrice()).thenReturn(100000);
 
             // 3-1. 작가(photographer) 닉네임 객체 준비
-            var photographer = mock(Photographer.class);
+            Photographer photographer = mock(Photographer.class);
             when(photographer.getNickname()).thenReturn("작가");
             when(product.getPhotographer()).thenReturn(photographer);
 
@@ -90,7 +91,7 @@ class GetWishedProductsServiceTest {
 
             // 5. 대표 이미지 조회에 필요한 ProductPhoto/Photo Mock 객체 준비
             ProductPhoto productPhoto = mock(ProductPhoto.class);
-            var photo = mock(Photo.class);
+            Photo photo = mock(Photo.class);
             when(photo.getImageUrl()).thenReturn("/images/a.jpg");
             when(productPhoto.getPhoto()).thenReturn(photo);
 
@@ -101,7 +102,7 @@ class GetWishedProductsServiceTest {
 
             // 7. 무드 태그(ProductMood -> Mood -> name) Mock 객체 준비
             ProductMood productMood = mock(ProductMood.class);
-            var mood = mock(Mood.class);
+            Mood mood = mock(Mood.class);
             when(mood.getName()).thenReturn("따뜻한");
             when(productMood.getMood()).thenReturn(mood);
 
@@ -129,7 +130,7 @@ class GetWishedProductsServiceTest {
             // 2. 상품 리스트가 1개인지 확인
             assertThat(result.products()).hasSize(1);
 
-            var item = result.products().get(0);
+            WishedProductResult item = result.products().get(0);
 
             // 3. id, title, price 매핑 확인
             assertThat(item.id()).isEqualTo(10L);
@@ -167,7 +168,7 @@ class GetWishedProductsServiceTest {
             when(product.getPrice()).thenReturn(50000);
 
             // 3-1. 작가(photographer) 닉네임 객체 준비
-            var photographer = mock(Photographer.class);
+            Photographer photographer = mock(Photographer.class);
             when(photographer.getNickname()).thenReturn("작가");
             when(product.getPhotographer()).thenReturn(photographer);
 
@@ -228,11 +229,11 @@ class GetWishedProductsServiceTest {
             when(product2.getPrice()).thenReturn(2000);
 
             // 3-1. 작가(photographer) 닉네임 객체 준비
-            var photographer1 = mock(Photographer.class);
+            Photographer photographer1 = mock(Photographer.class);
             when(photographer1.getNickname()).thenReturn("작가1");
             when(product1.getPhotographer()).thenReturn(photographer1);
 
-            var photographer2 = mock(Photographer.class);
+            Photographer photographer2 = mock(Photographer.class);
             when(photographer2.getNickname()).thenReturn("작가2");
             when(product2.getPhotographer()).thenReturn(photographer2);
 

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -262,12 +262,10 @@ class GetWishedProductsServiceTest {
                 .thenReturn(Optional.empty());
 
             // 6-4. 리뷰 통계 조회 성공
-            when(reviewRepository.findReviewStatsByProductId(any()))
-                .thenReturn(stats);
+            when(reviewRepository.findReviewStatsByProductId(anyLong())).thenReturn(stats);
 
             // 6-5. 무드 태그 없음
-            when(productMoodRepository.findAllByProductOrderById(any()))
-                .thenReturn(List.of());
+            when(productMoodRepository.findAllByProductOrderById(any())).thenReturn(List.of());
 
             // [When] 테스트할 서비스 메서드 호출
             WishedProductsResult result = service.getWishedProducts(userId);

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -279,5 +279,31 @@ class GetWishedProductsServiceTest {
             assertThat(result.products().get(0).id()).isEqualTo(20L);
             assertThat(result.products().get(1).id()).isEqualTo(10L);
         }
+
+        @Test
+        @DisplayName("예외 케이스 - 유저가 없으면 USER_NOT_FOUND 예외를 던지고, 이후 로직이 수행되지 않는다")
+        void throw_whenUserNotFound() {
+            // [Given]
+            Long userId = 1L;
+
+            // 유저 조회 실패
+            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+            // [When/Then]
+            WishException ex = catchThrowableOfType(
+                () -> service.getWishedProducts(userId),
+                WishException.class
+            );
+
+            // 1. 예외 객체 검증
+            assertThat(ex).isNotNull();
+            assertThat(ex.getErrorCode()).isEqualTo(WishErrorCode.USER_NOT_FOUND);
+
+            // 2. 유저가 없으면 이후 로직(위시 조회 등)이 수행되지 않았는지 확인
+            verify(wishProductRepository, never()).findAllByUserWithProductOrderByCreatedAtDesc(any());
+            verify(productPhotoRepository, never()).findFirstByProductOrderByDisplayOrderAsc(any());
+            verify(reviewRepository, never()).findReviewStatsByProductId(any());
+            verify(productMoodRepository, never()).findAllByProductOrderById(any());
+        }
     }
 }

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -1,21 +1,42 @@
 package org.sopt.snappinserver.domain.wish.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
+import org.sopt.snappinserver.domain.photo.domain.entity.Photo;
+import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.domain.product.domain.entity.ProductMood;
+import org.sopt.snappinserver.domain.product.domain.entity.ProductPhoto;
 import org.sopt.snappinserver.domain.product.repository.ProductMoodRepository;
 import org.sopt.snappinserver.domain.product.repository.ProductPhotoRepository;
+import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult;
 import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.sopt.snappinserver.domain.wish.domain.entity.WishProduct;
+import org.sopt.snappinserver.domain.wish.domain.exception.WishErrorCode;
+import org.sopt.snappinserver.domain.wish.domain.exception.WishException;
 import org.sopt.snappinserver.domain.wish.repository.WishProductRepository;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsResult;
 
 @ExtendWith(MockitoExtension.class)
 class GetWishedProductsServiceTest {
@@ -30,13 +51,58 @@ class GetWishedProductsServiceTest {
 
     @BeforeEach
     void setUp() {
-        // @Value로 주입되는 cloudFrontDomain은 단위 테스트에서 null일 수 있어 테스트용 값 주입
+        // [Given] 테스트 시 필요한 환경 세팅
+        // 1. @Value로 주입되는 cloudFrontDomain은 단위 테스트에서 null일 수 있음
+        // 2. ReflectionTestUtils로 service 내부 필드(cloudFrontDomain)에 테스트용 값을 주입
         ReflectionTestUtils.setField(service, "cloudFrontDomain", "https://cdn.example.com");
     }
 
     @Nested
     @DisplayName("getWishedProducts")
     class GetWishedProducts {
+        @Test
+        @DisplayName("성공 케이스 - 대표 이미지가 있으면 cloudFrontDomain과 합쳐서 내려주며, 리뷰/무드 정보도 함께 내려준다")
+        void getWishedProducts_Success_withImage_review_moods() {
+            // [Given] 테스트 시 필요한 데이터 생성
+            // 1. 요청 파라미터 준비
+            Long userId = 1L;
 
+            // 2. 유저 Mock 객체 준비
+            User user = mock(User.class);
+
+            // 3. 상품(Product) Mock 객체 준비
+            Product product = mock(Product.class);
+            when(product.getId()).thenReturn(10L);
+            when(product.getTitle()).thenReturn("스냅 촬영 상품");
+            when(product.getPrice()).thenReturn(100000);
+
+            // 3-1. 작가(photographer) 닉네임 객체 준비
+            var photographer = mock(Photographer.class);
+            when(photographer.getNickname()).thenReturn("작가");
+            when(product.getPhotographer()).thenReturn(photographer);
+
+            // 4. 위시 엔티티(WishProduct) Mock 객체 준비
+            WishProduct wish = mock(WishProduct.class);
+            when(wish.getProduct()).thenReturn(product);
+
+            // 5. 대표 이미지 조회에 필요한 ProductPhoto/Photo Mock 객체 준비
+            ProductPhoto productPhoto = mock(ProductPhoto.class);
+            var photo = mock(Photo.class);
+            when(photo.getImageUrl()).thenReturn("/images/a.jpg");
+            when(productPhoto.getPhoto()).thenReturn(photo);
+
+            // 6. 리뷰 통계 Mock 객체 준비 (평균 별점/리뷰 수)
+            ProductReviewStatsResult stats = mock(ProductReviewStatsResult.class);
+            when(stats.averageRating()).thenReturn(4.5);
+            when(stats.reviewCount()).thenReturn(10L);
+
+            // 7. 무드 태그(ProductMood -> Mood -> name) Mock 객체 준비
+            ProductMood productMood = mock(ProductMood.class);
+            var mood = mock(Mood.class);
+            when(mood.getName()).thenReturn("따뜻한");
+            when(productMood.getMood()).thenReturn(mood);
+
+        }
+        
     }
 }

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -242,6 +242,17 @@ class GetWishedProductsServiceTest {
             when(productMoodRepository.findAllByProductOrderById(any()))
                 .thenReturn(List.of());
 
+            // [When]
+            WishedProductsResult result = service.getWishedProducts(userId);
+
+            // [Then]
+            assertThat(result).isNotNull();
+            assertThat(result.products()).hasSize(2);
+
+            // 서비스가 중간에서 순서를 바꾸지 않는지 확인
+            assertThat(result.products().get(0).id()).isEqualTo(20L);
+            assertThat(result.products().get(1).id()).isEqualTo(10L);
+
         }
     }
 }

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -147,5 +147,43 @@ class GetWishedProductsServiceTest {
             assertThat(item.moods()).containsExactly("따뜻한");
         }
 
+        @Test
+        @DisplayName("성공 케이스 - 대표 이미지가 없으면 imageUrl은 null이다")
+        void getWishedProducts_Success_withoutImage() {
+            // [Given] 테스트 시 필요한 데이터 생성
+            Long userId = 1L;
+
+            User user = mock(User.class);
+
+            Product product = mock(Product.class);
+            when(product.getId()).thenReturn(10L);
+            when(product.getTitle()).thenReturn("상품");
+            when(product.getPrice()).thenReturn(50000);
+
+            var photographer = mock(Photographer.class);
+            when(photographer.getNickname()).thenReturn("작가");
+            when(product.getPhotographer()).thenReturn(photographer);
+
+            WishProduct wish = mock(WishProduct.class);
+            when(wish.getProduct()).thenReturn(product);
+
+            ProductReviewStatsResult stats = mock(ProductReviewStatsResult.class);
+            when(stats.averageRating()).thenReturn(4.0);
+            when(stats.reviewCount()).thenReturn(2L);
+
+            // Mockito에게 행동 지시
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(wishProductRepository.findAllByUserWithProductOrderByCreatedAtDesc(user))
+                .thenReturn(List.of(wish));
+
+            // 대표 이미지 없음
+            when(productPhotoRepository.findFirstByProductOrderByDisplayOrderAsc(product))
+                .thenReturn(Optional.empty());
+
+            when(reviewRepository.findReviewStatsByProductId(10L)).thenReturn(stats);
+            when(productMoodRepository.findAllByProductOrderById(product)).thenReturn(List.of());
+
+        }
+
     }
 }

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -1,0 +1,42 @@
+package org.sopt.snappinserver.domain.wish.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import org.sopt.snappinserver.domain.product.repository.ProductMoodRepository;
+import org.sopt.snappinserver.domain.product.repository.ProductPhotoRepository;
+import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
+import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.sopt.snappinserver.domain.wish.repository.WishProductRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GetWishedProductsServiceTest {
+
+    @Mock private WishProductRepository wishProductRepository;
+    @Mock private ProductPhotoRepository productPhotoRepository;
+    @Mock private ProductMoodRepository productMoodRepository;
+    @Mock private ReviewRepository reviewRepository;
+    @Mock private UserRepository userRepository;
+
+    @InjectMocks private GetWishedProductsService service;
+
+    @BeforeEach
+    void setUp() {
+        // @Value로 주입되는 cloudFrontDomain은 단위 테스트에서 null일 수 있어 테스트용 값 주입
+        ReflectionTestUtils.setField(service, "cloudFrontDomain", "https://cdn.example.com");
+    }
+
+    @Nested
+    @DisplayName("getWishedProducts")
+    class GetWishedProducts {
+
+    }
+}

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -283,6 +283,86 @@ class GetWishedProductsServiceTest {
         }
 
         @Test
+        @DisplayName("성공 케이스 - 하나의 상품에 대해 3개의 무드가 있을 때 순서가 유지된다")
+        void getWishedProducts_Success_moodOrderPreserved() {
+            // [Given] 테스트 시 필요한 데이터 생성
+            // 1. 요청 파라미터 준비
+            Long userId = USER_ID;
+
+            // 2. 유저 Mock 객체 준비
+            User user = mock(User.class);
+
+            // 3. 상품(Product) Mock 객체 준비
+            Product product = mock(Product.class);
+            when(product.getId()).thenReturn(10L);
+            when(product.getTitle()).thenReturn("상품");
+            when(product.getPrice()).thenReturn(1000);
+
+            // 3-1. 작가(photographer) 닉네임 객체 준비
+            Photographer photographer = mock(Photographer.class);
+            when(photographer.getNickname()).thenReturn("작가");
+            when(product.getPhotographer()).thenReturn(photographer);
+
+            // 4. 위시 엔티티(WishProduct) Mock 객체 준비
+            WishProduct wish = mock(WishProduct.class);
+            when(wish.getProduct()).thenReturn(product);
+
+            // 5. 대표 이미지 없음
+            when(productPhotoRepository.findFirstByProductOrderByDisplayOrderAsc(product))
+                .thenReturn(Optional.empty());
+
+            // 6. 리뷰 통계 Mock 객체 준비
+            ProductReviewStatsResult stats = mock(ProductReviewStatsResult.class);
+            when(stats.averageRating()).thenReturn(0.0);
+            when(stats.reviewCount()).thenReturn(0L);
+
+            // 7. 무드 태그(ProductMood -> Mood -> name) Mock 객체 3개 준비
+            ProductMood pm1 = mock(ProductMood.class);
+            ProductMood pm2 = mock(ProductMood.class);
+            ProductMood pm3 = mock(ProductMood.class);
+
+            Mood mood1 = mock(Mood.class);
+            Mood mood2 = mock(Mood.class);
+            Mood mood3 = mock(Mood.class);
+
+            // 7-1. 무드 이름 설정
+            when(mood1.getName()).thenReturn("무드1");
+            when(mood2.getName()).thenReturn("무드2");
+            when(mood3.getName()).thenReturn("무드3");
+
+            // 7-2. ProductMood에서 Mood 반환 설정
+            when(pm1.getMood()).thenReturn(mood1);
+            when(pm2.getMood()).thenReturn(mood2);
+            when(pm3.getMood()).thenReturn(mood3);
+
+            // 8. Mockito에게 행동 지시
+            // 8-1. 무드 태그를 정렬된 순서로 반환 (순서 검증 핵심)
+            when(productMoodRepository.findAllByProductOrderById(product))
+                .thenReturn(List.of(pm1, pm2, pm3));
+
+            // 8-2. 유저 조회 성공
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            // 8-3. 위시 목록 조회 결과로 wish 하나 반환
+            when(wishProductRepository.findAllByUserWithProductOrderByCreatedAtDesc(user))
+                .thenReturn(List.of(wish));
+
+            // 8-4. 리뷰 통계 조회 성공
+            when(reviewRepository.findReviewStatsByProductId(10L)).thenReturn(stats);
+
+            // [When] 테스트할 서비스 메서드 호출
+            WishedProductsResult result = service.getWishedProducts(userId);
+
+            // [Then] 결과 검증
+            // 1. 상품 리스트가 1개인지 확인
+            assertThat(result.products()).hasSize(1);
+            // 2. 무드 순서가 유지되는지 확인
+            WishedProductResult item = result.products().get(0);
+            assertThat(item.moods())
+                .containsExactly("무드1", "무드2", "무드3");
+        }
+
+        @Test
         @DisplayName("성공 케이스 - 위시한 상품이 없으면 빈 리스트를 반환한다")
         void success_emptyWishList_returnsEmpty() {
             // [Given] 테스트 시 필요한 데이터 생성

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -192,5 +192,56 @@ class GetWishedProductsServiceTest {
             assertThat(result.products().get(0).imageUrl()).isNull();
         }
 
+        @Test
+        @DisplayName("성공 케이스 - repository의 최신 좋아요 순(createdAt desc) 정렬을 서비스가 그대로 유지한다")
+        void getWishedProducts_Success_keepsOrder() {
+            // [Given] 테스트 시 필요한 데이터 생성
+            Long userId = 1L;
+
+            User user = mock(User.class);
+
+            Product product1 = mock(Product.class);
+            when(product1.getId()).thenReturn(10L);
+            var photographer1 = mock(Photographer.class);
+            when(photographer1.getNickname()).thenReturn("작가1");
+            when(product1.getPhotographer()).thenReturn(photographer1);
+            when(product1.getTitle()).thenReturn("상품1");
+            when(product1.getPrice()).thenReturn(1000);
+
+            Product product2 = mock(Product.class);
+            when(product2.getId()).thenReturn(20L);
+            var photographer2 = mock(Photographer.class);
+            when(photographer2.getNickname()).thenReturn("작가2");
+            when(product2.getPhotographer()).thenReturn(photographer2);
+            when(product2.getTitle()).thenReturn("상품2");
+            when(product2.getPrice()).thenReturn(2000);
+
+            WishProduct wish1 = mock(WishProduct.class);
+            when(wish1.getProduct()).thenReturn(product1);
+            WishProduct wish2 = mock(WishProduct.class);
+            when(wish2.getProduct()).thenReturn(product2);
+
+            // 리뷰 통계는 각 상품마다 호출되므로, 공통 stub 처리
+            ProductReviewStatsResult stats = mock(ProductReviewStatsResult.class);
+            when(stats.averageRating()).thenReturn(0.0);
+            when(stats.reviewCount()).thenReturn(0L);
+
+            // [Given - Mockito 행동 지시]
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            // repo가 최신순으로 내려준다고 가정: wish2(최근) -> wish1(과거)
+            when(wishProductRepository.findAllByUserWithProductOrderByCreatedAtDesc(user))
+                .thenReturn(List.of(wish2, wish1));
+
+            when(productPhotoRepository.findFirstByProductOrderByDisplayOrderAsc(any()))
+                .thenReturn(Optional.empty());
+
+            when(reviewRepository.findReviewStatsByProductId(any()))
+                .thenReturn(stats);
+
+            when(productMoodRepository.findAllByProductOrderById(any()))
+                .thenReturn(List.of());
+
+        }
     }
 }

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -41,6 +41,9 @@ import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsRes
 @ExtendWith(MockitoExtension.class)
 class GetWishedProductsServiceTest {
 
+    private static final Long USER_ID = 1L;
+    private static final String CDN_DOMAIN = "https://cdn.example.com";
+
     @Mock private WishProductRepository wishProductRepository;
     @Mock private ProductPhotoRepository productPhotoRepository;
     @Mock private ProductMoodRepository productMoodRepository;
@@ -54,7 +57,7 @@ class GetWishedProductsServiceTest {
         // [Given] 테스트 시 필요한 환경 세팅
         // 1. @Value로 주입되는 cloudFrontDomain은 단위 테스트에서 null일 수 있음
         // 2. ReflectionTestUtils로 service 내부 필드(cloudFrontDomain)에 테스트용 값을 주입
-        ReflectionTestUtils.setField(service, "cloudFrontDomain", "https://cdn.example.com");
+        ReflectionTestUtils.setField(service, "cloudFrontDomain", CDN_DOMAIN);
     }
 
     @Nested
@@ -65,7 +68,7 @@ class GetWishedProductsServiceTest {
         void getWishedProducts_Success_withImage_review_moods() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
-            Long userId = 1L;
+            Long userId = USER_ID;
 
             // 2. 유저 Mock 객체 준비
             User user = mock(User.class);
@@ -152,7 +155,7 @@ class GetWishedProductsServiceTest {
         void getWishedProducts_Success_withoutImage() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
-            Long userId = 1L;
+            Long userId = USER_ID;
 
             // 2. 유저 Mock 객체 준비
             User user = mock(User.class);
@@ -208,7 +211,7 @@ class GetWishedProductsServiceTest {
         void getWishedProducts_Success_keepsOrder() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
-            Long userId = 1L;
+            Long userId = USER_ID;
 
             // 2. 유저 Mock 객체 준비
             User user = mock(User.class);
@@ -285,7 +288,7 @@ class GetWishedProductsServiceTest {
         void success_emptyWishList_returnsEmpty() {
             // [Given] 테스트 시 필요한 데이터 생성
             // 1. 요청 파라미터 준비
-            Long userId = 1L;
+            Long userId = USER_ID;
 
             // 2. 유저 Mock 객체 준비
             User user = mock(User.class);

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -283,27 +283,32 @@ class GetWishedProductsServiceTest {
         @Test
         @DisplayName("성공 케이스 - 위시한 상품이 없으면 빈 리스트를 반환한다")
         void success_emptyWishList_returnsEmpty() {
-            // [Given]
+            // [Given] 테스트 시 필요한 데이터 생성
+            // 1. 요청 파라미터 준비
             Long userId = 1L;
 
+            // 2. 유저 Mock 객체 준비
             User user = mock(User.class);
 
-            // 유저 조회 성공
+            // 3. Mockito에게 행동 지시
+            // 3-1. 유저 조회 성공
             when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-
-            // 위시 목록이 비어있음
+            // 3-2. 위시 목록이 비어있는 경우
             when(wishProductRepository.findAllByUserWithProductOrderByCreatedAtDesc(user))
                 .thenReturn(List.of());
 
-            // [When]
+            // [When] 테스트할 서비스 메서드 호출
             WishedProductsResult result = service.getWishedProducts(userId);
 
-            // [Then]
+            // [Then] 결과 검증
+            // 1. 결과 객체가 null이 아닌지 확인
             assertThat(result).isNotNull();
+            // 2. 상품 리스트가 null이 아닌지 확인
             assertThat(result.products()).isNotNull();
+            // 3. 상품 리스트가 비어있는지 확인
             assertThat(result.products()).isEmpty();
 
-            // 빈 리스트면 하위 repo 호출이 없어야 함 (불필요 호출 방지)
+            // 4. 위시 목록이 없으면 하위 repository 호출이 발생하지 않는지 확인
             verify(productPhotoRepository, never()).findFirstByProductOrderByDisplayOrderAsc(any());
             verify(reviewRepository, never()).findReviewStatsByProductId(any());
             verify(productMoodRepository, never()).findAllByProductOrderById(any());
@@ -312,23 +317,27 @@ class GetWishedProductsServiceTest {
         @Test
         @DisplayName("예외 케이스 - 유저가 없으면 USER_NOT_FOUND 예외를 던지고, 이후 로직이 수행되지 않는다")
         void throw_whenUserNotFound() {
-            // [Given]
+            // [Given] 테스트 시 필요한 데이터 생성
+            // 1. 요청 파라미터 준비
             Long userId = 1L;
 
-            // 유저 조회 실패
+            // 2. Mockito에게 행동 지시
+            // 2-1. 유저 조회 실패 (존재하지 않음)
             when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-            // [When/Then]
+            // [When/Then] 테스트할 서비스 메서드 호출 및 결과 검증
+            // 1. 예외가 발생하는지 확인
             WishException ex = catchThrowableOfType(
                 () -> service.getWishedProducts(userId),
                 WishException.class
             );
 
-            // 1. 예외 객체 검증
+            // 2. 예외 객체가 null이 아닌지 확인
             assertThat(ex).isNotNull();
+            // 3. 에러 코드가 USER_NOT_FOUND인지 확인
             assertThat(ex.getErrorCode()).isEqualTo(WishErrorCode.USER_NOT_FOUND);
 
-            // 2. 유저가 없으면 이후 로직(위시 조회 등)이 수행되지 않았는지 확인
+            // 4. 유저가 없으면 이후 로직(위시 조회/대표 이미지 조회 등)이 수행되지 않았는지 확인
             verify(wishProductRepository, never()).findAllByUserWithProductOrderByCreatedAtDesc(any());
             verify(productPhotoRepository, never()).findFirstByProductOrderByDisplayOrderAsc(any());
             verify(reviewRepository, never()).findReviewStatsByProductId(any());

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -146,7 +146,7 @@ class GetWishedProductsServiceTest {
 
             // 5. 리뷰 통계가 매핑되는지 확인
             assertThat(item.rate()).isEqualTo(4.5);
-            assertThat(item.reviewCount()).isEqualTo(10L);
+            assertThat(item.reviewCount()).isEqualTo(10);
 
             // 6. 작가명 매핑 확인
             assertThat(item.photographer()).isEqualTo("작가");

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -116,6 +116,35 @@ class GetWishedProductsServiceTest {
             // 8-5. 무드 태그 조회 성공
             when(productMoodRepository.findAllByProductOrderById(product))
                 .thenReturn(List.of(productMood));
+
+            // [When] 테스트할 서비스 메서드 호출
+            WishedProductsResult result = service.getWishedProducts(userId);
+
+            // [Then] 결과 검증
+            // 1. 결과 객체가 null이 아닌지 확인
+            assertThat(result).isNotNull();
+            // 2. 상품 리스트가 1개인지 확인
+            assertThat(result.products()).hasSize(1);
+
+            var item = result.products().get(0);
+
+            // 3. id, title, price 매핑 확인
+            assertThat(item.id()).isEqualTo(10L);
+            assertThat(item.title()).isEqualTo("스냅 촬영 상품");
+            assertThat(item.price()).isEqualTo(100000);
+
+            // 4. 대표 이미지가 cloudFrontDomain + imageUrl 형태로 합쳐졌는지 확인
+            assertThat(item.imageUrl()).isEqualTo("https://cdn.example.com/images/a.jpg");
+
+            // 5. 리뷰 통계가 매핑되는지 확인
+            assertThat(item.rate()).isEqualTo(4.5);
+            assertThat(item.reviewCount()).isEqualTo(10);
+
+            // 6. 작가명 매핑 확인
+            assertThat(item.photographer()).isEqualTo("작가");
+
+            // 7. 무드 태그 매핑 확인
+            assertThat(item.moods()).containsExactly("따뜻한");
         }
 
     }

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -183,6 +183,13 @@ class GetWishedProductsServiceTest {
             when(reviewRepository.findReviewStatsByProductId(10L)).thenReturn(stats);
             when(productMoodRepository.findAllByProductOrderById(product)).thenReturn(List.of());
 
+            // [When]
+            WishedProductsResult result = service.getWishedProducts(userId);
+
+            // [Then]
+            assertThat(result).isNotNull();
+            assertThat(result.products()).hasSize(1);
+            assertThat(result.products().get(0).imageUrl()).isNull();
         }
 
     }

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -151,44 +151,55 @@ class GetWishedProductsServiceTest {
         @DisplayName("성공 케이스 - 대표 이미지가 없으면 imageUrl은 null이다")
         void getWishedProducts_Success_withoutImage() {
             // [Given] 테스트 시 필요한 데이터 생성
+            // 1. 요청 파라미터 준비
             Long userId = 1L;
 
+            // 2. 유저 Mock 객체 준비
             User user = mock(User.class);
 
+            // 3. 상품(Product) Mock 객체 준비
             Product product = mock(Product.class);
             when(product.getId()).thenReturn(10L);
             when(product.getTitle()).thenReturn("상품");
             when(product.getPrice()).thenReturn(50000);
 
+            // 3-1. 작가(photographer) 닉네임 객체 준비
             var photographer = mock(Photographer.class);
             when(photographer.getNickname()).thenReturn("작가");
             when(product.getPhotographer()).thenReturn(photographer);
 
+            // 4. 위시 엔티티(WishProduct) Mock 객체 준비
             WishProduct wish = mock(WishProduct.class);
             when(wish.getProduct()).thenReturn(product);
 
+            // 5. 리뷰 통계 Mock 객체 준비
             ProductReviewStatsResult stats = mock(ProductReviewStatsResult.class);
             when(stats.averageRating()).thenReturn(4.0);
             when(stats.reviewCount()).thenReturn(2L);
 
-            // Mockito에게 행동 지시
+            // 6. Mockito에게 행동 지시
+            // 6-1. 유저 조회 성공
             when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            // 6-2. 위시 목록 조회 결과로 wish 하나 반환
             when(wishProductRepository.findAllByUserWithProductOrderByCreatedAtDesc(user))
                 .thenReturn(List.of(wish));
-
-            // 대표 이미지 없음
+            // 6-3. 대표 이미지 없음
             when(productPhotoRepository.findFirstByProductOrderByDisplayOrderAsc(product))
                 .thenReturn(Optional.empty());
-
+            // 6-4. 리뷰 통계 조회 성공
             when(reviewRepository.findReviewStatsByProductId(10L)).thenReturn(stats);
+            // 6-5. 무드 태그 없음
             when(productMoodRepository.findAllByProductOrderById(product)).thenReturn(List.of());
 
-            // [When]
+            // [When] 테스트할 서비스 메서드 호출
             WishedProductsResult result = service.getWishedProducts(userId);
 
-            // [Then]
+            // [Then] 결과 검증
+            // 1. 결과 객체가 null이 아닌지 확인
             assertThat(result).isNotNull();
+            // 2. 상품 리스트가 1개인지 확인
             assertThat(result.products()).hasSize(1);
+            // 3. 대표 이미지가 없으면 imageUrl이 null인지 확인
             assertThat(result.products().get(0).imageUrl()).isNull();
         }
 
@@ -196,63 +207,77 @@ class GetWishedProductsServiceTest {
         @DisplayName("성공 케이스 - repository의 최신 좋아요 순(createdAt desc) 정렬을 서비스가 그대로 유지한다")
         void getWishedProducts_Success_keepsOrder() {
             // [Given] 테스트 시 필요한 데이터 생성
+            // 1. 요청 파라미터 준비
             Long userId = 1L;
 
+            // 2. 유저 Mock 객체 준비
             User user = mock(User.class);
 
+            // 3. 상품(Product) Mock 객체 2개 준비
             Product product1 = mock(Product.class);
             when(product1.getId()).thenReturn(10L);
-            var photographer1 = mock(Photographer.class);
-            when(photographer1.getNickname()).thenReturn("작가1");
-            when(product1.getPhotographer()).thenReturn(photographer1);
             when(product1.getTitle()).thenReturn("상품1");
             when(product1.getPrice()).thenReturn(1000);
 
             Product product2 = mock(Product.class);
             when(product2.getId()).thenReturn(20L);
-            var photographer2 = mock(Photographer.class);
-            when(photographer2.getNickname()).thenReturn("작가2");
-            when(product2.getPhotographer()).thenReturn(photographer2);
             when(product2.getTitle()).thenReturn("상품2");
             when(product2.getPrice()).thenReturn(2000);
 
+            // 3-1. 작가(photographer) 닉네임 객체 준비
+            var photographer1 = mock(Photographer.class);
+            when(photographer1.getNickname()).thenReturn("작가1");
+            when(product1.getPhotographer()).thenReturn(photographer1);
+
+            var photographer2 = mock(Photographer.class);
+            when(photographer2.getNickname()).thenReturn("작가2");
+            when(product2.getPhotographer()).thenReturn(photographer2);
+
+            // 4. 위시 엔티티(WishProduct) Mock 객체 2개 준비
             WishProduct wish1 = mock(WishProduct.class);
             when(wish1.getProduct()).thenReturn(product1);
+
             WishProduct wish2 = mock(WishProduct.class);
             when(wish2.getProduct()).thenReturn(product2);
 
-            // 리뷰 통계는 각 상품마다 호출되므로, 공통 stub 처리
+            // 5. 리뷰 통계 Mock 객체 준비
             ProductReviewStatsResult stats = mock(ProductReviewStatsResult.class);
             when(stats.averageRating()).thenReturn(0.0);
             when(stats.reviewCount()).thenReturn(0L);
 
-            // [Given - Mockito 행동 지시]
+            // 6. Mockito에게 행동 지시
+            // 6-1. 유저 조회 성공
             when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
-            // repo가 최신순으로 내려준다고 가정: wish2(최근) -> wish1(과거)
+            // 6-2. 위시 목록은 repo가 createdAt desc로 정렬해서 내려준다고 가정
+            // 테스트에서는 wish2(최근) -> wish1(과거) 순으로 내려주고, 서비스가 이 순서를 유지하는지 검증
             when(wishProductRepository.findAllByUserWithProductOrderByCreatedAtDesc(user))
                 .thenReturn(List.of(wish2, wish1));
 
+            // 6-3. 대표 이미지 없음
             when(productPhotoRepository.findFirstByProductOrderByDisplayOrderAsc(any()))
                 .thenReturn(Optional.empty());
 
+            // 6-4. 리뷰 통계 조회 성공
             when(reviewRepository.findReviewStatsByProductId(any()))
                 .thenReturn(stats);
 
+            // 6-5. 무드 태그 없음
             when(productMoodRepository.findAllByProductOrderById(any()))
                 .thenReturn(List.of());
 
-            // [When]
+            // [When] 테스트할 서비스 메서드 호출
             WishedProductsResult result = service.getWishedProducts(userId);
 
-            // [Then]
+            // [Then] 결과 검증
+            // 1. 결과 객체가 null이 아닌지 확인
             assertThat(result).isNotNull();
+            // 2. 상품 리스트가 2개인지 확인 (정렬 검증을 위해 2개 이상 필요)
             assertThat(result.products()).hasSize(2);
 
-            // 서비스가 중간에서 순서를 바꾸지 않는지 확인
+            // 3. 서비스가 중간에서 순서를 바꾸지 않고, repo에서 내려준 순서를 유지하는지 확인
             assertThat(result.products().get(0).id()).isEqualTo(20L);
             assertThat(result.products().get(1).id()).isEqualTo(10L);
-
         }
     }
 }

--- a/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
+++ b/src/test/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsServiceTest.java
@@ -281,6 +281,35 @@ class GetWishedProductsServiceTest {
         }
 
         @Test
+        @DisplayName("성공 케이스 - 위시한 상품이 없으면 빈 리스트를 반환한다")
+        void success_emptyWishList_returnsEmpty() {
+            // [Given]
+            Long userId = 1L;
+
+            User user = mock(User.class);
+
+            // 유저 조회 성공
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            // 위시 목록이 비어있음
+            when(wishProductRepository.findAllByUserWithProductOrderByCreatedAtDesc(user))
+                .thenReturn(List.of());
+
+            // [When]
+            WishedProductsResult result = service.getWishedProducts(userId);
+
+            // [Then]
+            assertThat(result).isNotNull();
+            assertThat(result.products()).isNotNull();
+            assertThat(result.products()).isEmpty();
+
+            // 빈 리스트면 하위 repo 호출이 없어야 함 (불필요 호출 방지)
+            verify(productPhotoRepository, never()).findFirstByProductOrderByDisplayOrderAsc(any());
+            verify(reviewRepository, never()).findReviewStatsByProductId(any());
+            verify(productMoodRepository, never()).findAllByProductOrderById(any());
+        }
+
+        @Test
         @DisplayName("예외 케이스 - 유저가 없으면 USER_NOT_FOUND 예외를 던지고, 이후 로직이 수행되지 않는다")
         void throw_whenUserNotFound() {
             // [Given]


### PR DESCRIPTION
## 👀 Summary

- close #258

<!--관련 있는 Issue를 태그해주세요. (e.g. > - #1) -->

상품 위시 목록 조회 서비스(GetWishedProductsService)에 대한 서비스 단위 테스트를 추가했습니다.

<!--해당 PR에 대한 작업 내용을 요약하여 작성해주세요-->

## 🖇️ Tasks

**GetWishedProductsServiceTest 추가**
- [x] 포트폴리오 대표 이미지 여부에 따른 성공 케이스
  - 대표 이미지 존재 시 cloudFrontDomain과 합쳐서 내려주는지 검사
  - 대표 이미지 미존재 시 null값으로 처리하고 위시 최신순 정렬 검사
- [x] 위시 상품이 없을 시 성공 케이스
  - 빈 리스트를 정상적으로 반환하는지 검사
- [x]  유저 미존재 예외 케이스


## 🔍 To Reviewer

> 아래 설명은 #256과 동일하니 참고해주세요!

### ❶ ReflectionTestUtils 사용
GetWishedPortfoliosService의 서비스 로직에서는 cloudFrontDomain을 아래와 같이 주입받고 있습니다.

```java
@Value("${cloud.aws.cloud-front.domain}")
```

현재 작성된 테스트는 Spring 컨텍스트를 띄우지 않는 서비스 단위 테스트(MockitoExtension 기반)라서 `@Value`가 자동 주입되지 않습니다. 이 상태로 테스트를 돌리면 cloudFrontDomain이 null일 수 있고, 이미지 URL 조합 로직이 의도치 않게 깨질 수 있는 문제가 있다고 해요.

<br>

그래서 **ReflectionTestUtils를 사용해서 서비스 내부 필드에 테스트용 값을 주입**했습니다.

```java
ReflectionTestUtils.setField(service, "cloudFrontDomain", "...")
```

> ReflectionTestUtils는 Spring Test에서 제공하는 유틸리티로, 리플렉션(reflection)을 이용해 객체의 private/protected 필드나 메서드에 테스트 코드에서 접근할 수 있게 해준대요!

이 방식은 설정 주입 여부가 아니라 서비스 로직(문자열 조합/매핑)을 검증하는 게 목적일 때, 불필요하게 SpringBootTest를 올리지 않고도 테스트를 깔끔하게 유지할 수 있어서 사용했습니다.

<br>

또한 해당 세팅은 테스트 케이스마다 독립적으로 동일하게 필요하므로 `@BeforeEach`에 넣었습니다. `@BeforeEach`가 붙은 `setUp()`은 각 `@Test` 실행 직전에 매번 자동으로 호출되기 때문에, 모든 테스트가 동일한 초기 상태(동일한 cloudFrontDomain 값)에서 실행되도록 할 수 있습니다.

### ❷ 최신순 위시 정렬 테스트 방식

기존 서비스 로직은 정렬 자체를 직접 수행하지 않고, wishPortfolioRepository에서 이미 최신순(createdAt desc)으로 조회된 결과를 그대로 매핑하는 구조입니다.

따라서 테스트에서는 정렬 알고리즘을 서비스가 새로 구현했는지를 보는 것이 아니라,
레포지토리가 wish2 → wish1 순서로 반환했을 때 서비스가 중간에서 순서를 바꾸지 않고 동일한 순서로 결과 DTO를 만들어 내려주는지를 검증하는 방식으로 작성했습니다.

즉, 정렬 책임은 레포지토리에 있다는 전제 하에 서비스가 조회 결과의 순서를 보존하는지(순서 유지)를 확인하는 방식이라고 생각해주시면 됩니다.
