### PR TITLE
[REFACTOR] #263: 온보딩 정보 입력, 조회 및 v2 로그인 응답 수정

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/auth/controller/AuthApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/auth/controller/AuthApi.java
@@ -19,9 +19,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Tag(name = "01 - Auth", description = "인증/인가 관련 API")
 public interface AuthApi {
 
+    @Deprecated
     @Operation(
         summary = "카카오 로그인",
-        description = "인가 코드를 받아 카카오로 소셜 로그인을 진행합니다."
+        description = "v2 API로 대체되었습니다. /api/v2/auth/login/kakao로 대체해서 사용하세요.",
+        deprecated = true
     )
     @PostMapping("/login/kakao")
     ApiResponseBody<CreateKakaoLoginResponse, Void> createKakaoLogin(

--- a/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserApi.java
@@ -20,9 +20,11 @@ import org.springframework.web.bind.annotation.RequestHeader;
 @Tag(name = "01 - User", description = "사용자 관련 API")
 public interface UserApi {
 
+    @Deprecated
     @Operation(
         summary = "유저 정보 조회 API",
-        description = "현재 로그인한 사용자의 역할을 기반으로 사용자 정보를 조회합니다."
+        description = "v2 API로 대체되었습니다. /api/v2/users/me를 사용하세요.",
+        deprecated = true
     )
     @GetMapping("/me")
     ApiResponseBody<GetUserInfoResponse, Void> getUserInfo(

--- a/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserApi.java
@@ -4,12 +4,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
+import org.sopt.snappinserver.api.v1.user.dto.request.CreateOnboardingRequest;
 import org.sopt.snappinserver.api.v1.user.dto.response.GetSwitchedUserProfileResponse;
 import org.sopt.snappinserver.api.v1.user.dto.response.GetUserInfoResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "01 - User", description = "사용자 관련 API")
@@ -40,5 +43,16 @@ public interface UserApi {
 
         @Parameter(hidden = true)
         HttpServletResponse httpServletResponse
+    );
+
+    @Operation(
+        summary = "온보딩 정보 입력 API",
+        description = "카카오 로그인 이후, 온보딩 정보가 입력되지 않은 사용자에 한해 추가 정보를 입력받습니다."
+    )
+    @PostMapping("/onboarding")
+    ApiResponseBody<Void, Void> createOnboarding(
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo,
+        @RequestBody CreateOnboardingRequest request
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserApi.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import org.sopt.snappinserver.api.v1.user.dto.request.CreateOnboardingRequest;
 import org.sopt.snappinserver.api.v1.user.dto.response.GetOnboardingResponse;
 import org.sopt.snappinserver.api.v1.user.dto.response.GetSwitchedUserProfileResponse;
@@ -56,6 +57,7 @@ public interface UserApi {
         CustomUserInfo userInfo,
 
         @RequestBody
+        @Valid
         CreateOnboardingRequest request
     );
 

--- a/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserApi.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import org.sopt.snappinserver.api.v1.user.dto.request.CreateOnboardingRequest;
+import org.sopt.snappinserver.api.v1.user.dto.response.GetOnboardingResponse;
 import org.sopt.snappinserver.api.v1.user.dto.response.GetSwitchedUserProfileResponse;
 import org.sopt.snappinserver.api.v1.user.dto.response.GetUserInfoResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
@@ -53,6 +54,18 @@ public interface UserApi {
     ApiResponseBody<Void, Void> createOnboarding(
         @Parameter(hidden = true)
         CustomUserInfo userInfo,
-        @RequestBody CreateOnboardingRequest request
+
+        @RequestBody
+        CreateOnboardingRequest request
+    );
+
+    @Operation(
+        summary = "온보딩 정보 조회 API",
+        description = "예약 문의 화면에서 예약자 정보를 불러올 때 사용합니다."
+    )
+    @GetMapping("/onboarding")
+    ApiResponseBody<GetOnboardingResponse, Void> getOnboarding(
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo
     );
 }

--- a/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserController.java
@@ -74,7 +74,7 @@ public class UserController implements UserApi {
     @Override
     public ApiResponseBody<Void, Void> createOnboarding(
         @AuthenticationPrincipal CustomUserInfo userInfo,
-        @RequestBody CreateOnboardingRequest request
+        CreateOnboardingRequest request
     ) {
         CreateOnboardingCommand command = CreateOnboardingCommand.create(
             userInfo.userId(),

--- a/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserController.java
@@ -6,14 +6,17 @@ import static org.sopt.snappinserver.global.response.code.user.UserSuccessCode.S
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.v1.user.dto.request.CreateOnboardingRequest;
+import org.sopt.snappinserver.api.v1.user.dto.response.GetOnboardingResponse;
 import org.sopt.snappinserver.api.v1.user.dto.response.GetSwitchedUserProfileResponse;
 import org.sopt.snappinserver.api.v1.user.dto.response.GetUserInfoResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.user.service.dto.request.CreateOnboardingCommand;
 import org.sopt.snappinserver.domain.user.service.dto.request.SwitchUserRoleCommand;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetOnboardingResult;
 import org.sopt.snappinserver.domain.user.service.dto.response.GetUserInfoResult;
 import org.sopt.snappinserver.domain.user.service.dto.response.SwitchUserRoleResult;
 import org.sopt.snappinserver.domain.user.service.usecase.CreateUserOnboardingUseCase;
+import org.sopt.snappinserver.domain.user.service.usecase.GetOnboardingUseCase;
 import org.sopt.snappinserver.domain.user.service.usecase.GetUserInfoUseCase;
 import org.sopt.snappinserver.domain.user.service.usecase.SwitchUserRoleUseCase;
 import org.sopt.snappinserver.global.response.code.user.UserSuccessCode;
@@ -34,6 +37,7 @@ public class UserController implements UserApi {
     private final GetUserInfoUseCase getUserInfoUseCase;
     private final SwitchUserRoleUseCase switchUserRoleUseCase;
     private final CreateUserOnboardingUseCase createUserOnboardingUseCase;
+    private final GetOnboardingUseCase getOnboardingUseCase;
 
     @Value("${auth.cookie.secure}")
     private boolean isSecure;
@@ -78,6 +82,18 @@ public class UserController implements UserApi {
         );
         createUserOnboardingUseCase.createUserOnboarding(command);
         return ApiResponseBody.ok(CREATE_ONBOARDING_OK);
+    }
+
+    @Override
+    public ApiResponseBody<GetOnboardingResponse, Void> getOnboarding(
+        @AuthenticationPrincipal CustomUserInfo userInfo
+    ) {
+        GetOnboardingResult result = getOnboardingUseCase.getOnboarding(userInfo.userId());
+
+        return ApiResponseBody.ok(
+            UserSuccessCode.GET_ONBOARDING_OK,
+            GetOnboardingResponse.create(result)
+        );
     }
 
     private SwitchUserRoleCommand getCommand(

--- a/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/controller/UserController.java
@@ -1,15 +1,19 @@
 package org.sopt.snappinserver.api.v1.user.controller;
 
+import static org.sopt.snappinserver.global.response.code.user.UserSuccessCode.CREATE_ONBOARDING_OK;
 import static org.sopt.snappinserver.global.response.code.user.UserSuccessCode.SWITCH_USER_ROLE_OK;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.v1.user.dto.request.CreateOnboardingRequest;
 import org.sopt.snappinserver.api.v1.user.dto.response.GetSwitchedUserProfileResponse;
 import org.sopt.snappinserver.api.v1.user.dto.response.GetUserInfoResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.domain.user.service.dto.request.CreateOnboardingCommand;
 import org.sopt.snappinserver.domain.user.service.dto.request.SwitchUserRoleCommand;
 import org.sopt.snappinserver.domain.user.service.dto.response.GetUserInfoResult;
 import org.sopt.snappinserver.domain.user.service.dto.response.SwitchUserRoleResult;
+import org.sopt.snappinserver.domain.user.service.usecase.CreateUserOnboardingUseCase;
 import org.sopt.snappinserver.domain.user.service.usecase.GetUserInfoUseCase;
 import org.sopt.snappinserver.domain.user.service.usecase.SwitchUserRoleUseCase;
 import org.sopt.snappinserver.global.response.code.user.UserSuccessCode;
@@ -18,6 +22,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,6 +33,7 @@ public class UserController implements UserApi {
 
     private final GetUserInfoUseCase getUserInfoUseCase;
     private final SwitchUserRoleUseCase switchUserRoleUseCase;
+    private final CreateUserOnboardingUseCase createUserOnboardingUseCase;
 
     @Value("${auth.cookie.secure}")
     private boolean isSecure;
@@ -59,6 +65,19 @@ public class UserController implements UserApi {
         httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
         return ApiResponseBody.ok(SWITCH_USER_ROLE_OK, response);
+    }
+
+    @Override
+    public ApiResponseBody<Void, Void> createOnboarding(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        @RequestBody CreateOnboardingRequest request
+    ) {
+        CreateOnboardingCommand command = CreateOnboardingCommand.create(
+            userInfo.userId(),
+            request
+        );
+        createUserOnboardingUseCase.createUserOnboarding(command);
+        return ApiResponseBody.ok(CREATE_ONBOARDING_OK);
     }
 
     private SwitchUserRoleCommand getCommand(

--- a/src/main/java/org/sopt/snappinserver/api/v1/user/dto/request/CreateOnboardingRequest.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/dto/request/CreateOnboardingRequest.java
@@ -1,6 +1,11 @@
 package org.sopt.snappinserver.api.v1.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import org.sopt.snappinserver.global.enums.Gender;
 import org.sopt.snappinserver.global.enums.SnapCategory;
@@ -9,21 +14,33 @@ import org.sopt.snappinserver.global.enums.SnapCategory;
 public record CreateOnboardingRequest(
 
     @Schema(description = "이름")
+    @NotBlank(message = "이름은 필수입니다.")
+    @Size(max = 4, message = "이름은 최대 4글자입니다.")
+    @Pattern(regexp = "^[가-힣]+$", message = "이름은 한글만 입력 가능합니다.")
     String name,
 
     @Schema(description = "성별입니다. MALE, FEMALE 중 하나로 요청해 주세요.")
+    @NotNull(message = "성별은 필수입니다.")
     Gender gender,
 
     @Schema(description = "닉네임")
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9]{2,10}$", message = "닉네임은 한글, 영문, 숫자 2~10자만 입력 가능합니다.")
     String nickname,
 
     @Schema(description = "전화번호입니다. 010-0000-0000 형태로 요청해주세요.")
+    @NotBlank(message = "전화번호는 필수입니다.")
+    @Pattern(regexp = "^\\d{3}-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)")
     String phoneNumber,
 
     @Schema(description = "이메일")
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Size(max = 320, message = "이메일은 최대 320자입니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}$", message = "이메일 형식이 올바르지 않습니다.")
     String email,
 
     @Schema(description = "원하는 스냅 카테고리 목록")
+    @NotEmpty(message = "스냅 카테고리는 필수입니다.")
     List<SnapCategory> snapCategories
 ) {
 

--- a/src/main/java/org/sopt/snappinserver/api/v1/user/dto/request/CreateOnboardingRequest.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/dto/request/CreateOnboardingRequest.java
@@ -1,0 +1,30 @@
+package org.sopt.snappinserver.api.v1.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.global.enums.Gender;
+import org.sopt.snappinserver.global.enums.SnapCategory;
+
+@Schema(description = "온보딩 정보 입력 요청 DTO")
+public record CreateOnboardingRequest(
+
+    @Schema(description = "이름")
+    String name,
+
+    @Schema(description = "성별입니다. MALE, FEMALE 중 하나로 요청해 주세요.")
+    Gender gender,
+
+    @Schema(description = "닉네임")
+    String nickname,
+
+    @Schema(description = "전화번호입니다. 010-0000-0000 형태로 요청해주세요.")
+    String phoneNumber,
+
+    @Schema(description = "이메일")
+    String email,
+
+    @Schema(description = "원하는 스냅 카테고리 목록")
+    List<SnapCategory> snapCategories
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/api/v1/user/dto/response/GetOnboardingResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/dto/response/GetOnboardingResponse.java
@@ -1,0 +1,30 @@
+package org.sopt.snappinserver.api.v1.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetOnboardingResult;
+
+@Schema(description = "온보딩 조회 응답")
+public record GetOnboardingResponse(
+
+    @Schema(description = "온보딩 시 작성한 이름")
+    String name,
+
+    @Schema(description = "온보딩 시 작성한 전화번호")
+    String phoneNumber,
+
+    @Schema(description = "온보딩 시 작성한 이메일")
+    String email,
+
+    @Schema(description = "온보딩 시 작성한 성별")
+    String gender
+) {
+
+    public static GetOnboardingResponse create(GetOnboardingResult result) {
+        return new GetOnboardingResponse(
+            result.name(),
+            result.phoneNumber(),
+            result.email(),
+            result.gender().getGender()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v1/user/dto/response/GetOnboardingResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/user/dto/response/GetOnboardingResponse.java
@@ -13,18 +13,14 @@ public record GetOnboardingResponse(
     String phoneNumber,
 
     @Schema(description = "온보딩 시 작성한 이메일")
-    String email,
-
-    @Schema(description = "온보딩 시 작성한 성별")
-    String gender
+    String email
 ) {
 
     public static GetOnboardingResponse create(GetOnboardingResult result) {
         return new GetOnboardingResponse(
             result.name(),
             result.phoneNumber(),
-            result.email(),
-            result.gender().getGender()
+            result.email()
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/v2/auth/dto/response/CreateKakaoLoginResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/auth/dto/response/CreateKakaoLoginResponse.java
@@ -16,7 +16,10 @@ public record CreateKakaoLoginResponse(
     String role,
 
     @Schema(description = "작가 프로필 보유 여부")
-    boolean hasPhotographerProfile
+    boolean hasPhotographerProfile,
+
+    @Schema(description = "온보딩 완료 여부")
+    boolean isOnboardingCompleted
 ) {
 
     public static CreateKakaoLoginResponse from(LoginWithPhotographerProfileResult loginResult) {
@@ -24,7 +27,8 @@ public record CreateKakaoLoginResponse(
             loginResult.isNew(),
             loginResult.accessToken(),
             loginResult.role(),
-            loginResult.hasPhotographerProfile()
+            loginResult.hasPhotographerProfile(),
+            loginResult.isOnboardingCompleted()
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/v2/user/controller/UserApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/user/controller/UserApi.java
@@ -8,7 +8,7 @@ import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.web.bind.annotation.GetMapping;
 
-@Tag(name = "01 - User", description = "사용자 관련 API")
+@Tag(name = "01 - User", description = "사용자 관련 API V2")
 public interface UserApi {
 
     @Operation(

--- a/src/main/java/org/sopt/snappinserver/api/v2/user/controller/UserApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/user/controller/UserApi.java
@@ -1,0 +1,23 @@
+package org.sopt.snappinserver.api.v2.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.snappinserver.api.v2.user.dto.response.GetUserInfoResponse;
+import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Tag(name = "01 - User", description = "사용자 관련 API")
+public interface UserApi {
+
+    @Operation(
+        summary = "유저 정보 조회 API",
+        description = "현재 로그인한 사용자의 역할을 기반으로 사용자 정보를 조회합니다."
+    )
+    @GetMapping("/me")
+    ApiResponseBody<GetUserInfoResponse, Void> getUserInfo(
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo
+    );
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/user/controller/UserController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/user/controller/UserController.java
@@ -1,0 +1,30 @@
+package org.sopt.snappinserver.api.v2.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.v2.user.dto.response.GetUserInfoResponse;
+import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetUserInfoResult;
+import org.sopt.snappinserver.domain.user.service.usecase.GetUserInfoUseCase;
+import org.sopt.snappinserver.global.response.code.user.UserSuccessCode;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v2/users")
+@RequiredArgsConstructor
+@RestController
+public class UserController implements UserApi{
+
+    private final GetUserInfoUseCase getUserInfoUseCase;
+
+    @Override
+    public ApiResponseBody<GetUserInfoResponse, Void> getUserInfo(
+        @AuthenticationPrincipal CustomUserInfo userInfo
+    ) {
+        GetUserInfoResult result = getUserInfoUseCase.getUserInfo(userInfo.userId());
+        GetUserInfoResponse response = GetUserInfoResponse.from(result);
+
+        return ApiResponseBody.ok(UserSuccessCode.GET_USER_INFO_OK, response);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/user/controller/UserControllerV2.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/user/controller/UserControllerV2.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v2/users")
 @RequiredArgsConstructor
 @RestController
-public class UserController implements UserApi{
+public class UserControllerV2 implements UserApi{
 
     private final GetUserInfoUseCase getUserInfoUseCase;
 

--- a/src/main/java/org/sopt/snappinserver/api/v2/user/dto/response/GetClientInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/user/dto/response/GetClientInfoResponse.java
@@ -10,6 +10,9 @@ public record GetClientInfoResponse(
     @Schema(description = "고객명")
     String name,
 
+    @Schema(description = "닉네임")
+    String nickname,
+
     @Schema(description = "고객 큐레이션 무드 결과 목록")
     List<String> curatedMoods
 ) {
@@ -17,6 +20,7 @@ public record GetClientInfoResponse(
     public static GetClientInfoResponse from(GetClientInfoResult result) {
         return new GetClientInfoResponse(
             result.name(),
+            result.nickname(),
             result.curatedMoods()
         );
     }

--- a/src/main/java/org/sopt/snappinserver/api/v2/user/dto/response/GetClientInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/user/dto/response/GetClientInfoResponse.java
@@ -1,0 +1,23 @@
+package org.sopt.snappinserver.api.v2.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetClientInfoResult;
+
+@Schema(description = "고객 정보 응답 DTO")
+public record GetClientInfoResponse(
+
+    @Schema(description = "고객명")
+    String name,
+
+    @Schema(description = "고객 큐레이션 무드 결과 목록")
+    List<String> curatedMoods
+) {
+
+    public static GetClientInfoResponse from(GetClientInfoResult result) {
+        return new GetClientInfoResponse(
+            result.name(),
+            result.curatedMoods()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/user/dto/response/GetPhotographerInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/user/dto/response/GetPhotographerInfoResponse.java
@@ -1,0 +1,31 @@
+package org.sopt.snappinserver.api.v2.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetPhotographerInfoResult;
+
+@Schema(description = "작가 정보 응답 DTO")
+public record GetPhotographerInfoResponse(
+
+    @Schema(description = "작가명")
+    String name,
+
+    @Schema(description = "한줄 소개")
+    String bio,
+
+    @Schema(description = "작가 촬영 상품")
+    List<String> specialties,
+
+    @Schema(description = "작가 활동 지역")
+    List<String> locations
+) {
+
+    public static GetPhotographerInfoResponse from(GetPhotographerInfoResult result) {
+        return new GetPhotographerInfoResponse(
+            result.name(),
+            result.bio(),
+            result.specialties(),
+            result.locations()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/user/dto/response/GetUserInfoResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/user/dto/response/GetUserInfoResponse.java
@@ -1,0 +1,42 @@
+package org.sopt.snappinserver.api.v2.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetUserInfoResult;
+
+@Schema(description = "유저 정보 조회 응답 DTO")
+public record GetUserInfoResponse(
+
+    @Schema(description = "유저 ID")
+    Long id,
+
+    @Schema(description = "현재 로그인된 유저 역할")
+    String role,
+
+    @Schema(description = "유저 프로필 이미지")
+    String profileImageUrl,
+
+    @Schema(description = "작가 프로필 보유 여부")
+    boolean hasPhotographerProfile,
+
+    @Schema(description = "고객 관련 정보 DTO")
+    GetClientInfoResponse clientInfo,
+
+    @Schema(description = "작가 프로필 관련 정보 DTO")
+    GetPhotographerInfoResponse photographerInfo
+) {
+
+    public static GetUserInfoResponse from(GetUserInfoResult result) {
+        return new GetUserInfoResponse(
+            result.id(),
+            result.role(),
+            result.profileImageUrl(),
+            result.hasPhotographerProfile(),
+            result.clientInfo() != null
+                ? GetClientInfoResponse.from(result.clientInfo())
+                : null,
+            result.photographerInfo() != null
+                ? GetPhotographerInfoResponse.from(result.photographerInfo())
+                : null
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/auth/facade/AuthFacade.java
+++ b/src/main/java/org/sopt/snappinserver/domain/auth/facade/AuthFacade.java
@@ -27,7 +27,7 @@ public class AuthFacade {
         GetPhotographerExistenceResult photographerExistence = getPhotographerExistenceUseCase
             .getHasPhotographerProfile(loginResult.userId());
         GetOnboardingExistsResult onboardingExistence = getOnboardingExistsUseCase
-            .getOnboardingExists(loginResult.userId());
+            .hasOnboarding(loginResult.userId());
 
         return LoginWithPhotographerProfileResult.of(
             loginResult,

--- a/src/main/java/org/sopt/snappinserver/domain/auth/facade/AuthFacade.java
+++ b/src/main/java/org/sopt/snappinserver/domain/auth/facade/AuthFacade.java
@@ -6,6 +6,8 @@ import org.sopt.snappinserver.domain.auth.service.dto.response.LoginWithPhotogra
 import org.sopt.snappinserver.domain.auth.service.usecase.LoginUseCase;
 import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerExistenceResult;
 import org.sopt.snappinserver.domain.photographer.service.usecase.GetPhotographerExistenceUseCase;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetOnboardingExistsResult;
+import org.sopt.snappinserver.domain.user.service.usecase.GetOnboardingExistsUseCase;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,6 +16,7 @@ public class AuthFacade {
 
     private final LoginUseCase loginUseCase;
     private final GetPhotographerExistenceUseCase getPhotographerExistenceUseCase;
+    private final GetOnboardingExistsUseCase getOnboardingExistsUseCase;
 
     public LoginWithPhotographerProfileResult loginWithPhotographerProfile(
         String redirectUri,
@@ -23,8 +26,14 @@ public class AuthFacade {
         LoginResult loginResult = loginUseCase.kakaoLogin(redirectUri, accessCode, userAgent);
         GetPhotographerExistenceResult photographerExistence = getPhotographerExistenceUseCase
             .getHasPhotographerProfile(loginResult.userId());
+        GetOnboardingExistsResult onboardingExistence = getOnboardingExistsUseCase
+            .getOnboardingExists(loginResult.userId());
 
-        return LoginWithPhotographerProfileResult.of(loginResult, photographerExistence);
+        return LoginWithPhotographerProfileResult.of(
+            loginResult,
+            photographerExistence,
+            onboardingExistence
+        );
     }
 
 }

--- a/src/main/java/org/sopt/snappinserver/domain/auth/service/dto/response/LoginWithPhotographerProfileResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/auth/service/dto/response/LoginWithPhotographerProfileResult.java
@@ -1,25 +1,29 @@
 package org.sopt.snappinserver.domain.auth.service.dto.response;
 
 import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerExistenceResult;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetOnboardingExistsResult;
 
 public record LoginWithPhotographerProfileResult(
     boolean isNew,
     String accessToken,
     String refreshToken,
     String role,
-    boolean hasPhotographerProfile
+    boolean hasPhotographerProfile,
+    boolean isOnboardingCompleted
 ) {
 
     public static LoginWithPhotographerProfileResult of(
         LoginResult loginResult,
-        GetPhotographerExistenceResult getPhotographerExistenceResult
+        GetPhotographerExistenceResult getPhotographerExistenceResult,
+        GetOnboardingExistsResult getOnboardingExistsResult
     ) {
         return new LoginWithPhotographerProfileResult(
             loginResult.isNew(),
             loginResult.accessToken(),
             loginResult.refreshToken(),
             loginResult.role(),
-            getPhotographerExistenceResult.hasPhotographerProfile()
+            getPhotographerExistenceResult.hasPhotographerProfile(),
+            getOnboardingExistsResult.isOnboardingCompleted()
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/user/domain/entity/Onboarding.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/domain/entity/Onboarding.java
@@ -37,7 +37,8 @@ public class Onboarding extends BaseEntity {
     private static final Pattern KOREAN_ONLY_PATTERN = Pattern.compile("^[가-힣]+$");
     private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9]{2,10}$");
     private static final Pattern PHONE_NUMBER_PATTERN = Pattern.compile("^\\d{3}-\\d{4}-\\d{4}$");
-    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}$");
+    private static final Pattern EMAIL_PATTERN = Pattern
+        .compile("^[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}$");
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "onboarding_seq_gen")
@@ -49,7 +50,7 @@ public class Onboarding extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
     @Column(nullable = false, length = MAX_NAME_LENGTH)

--- a/src/main/java/org/sopt/snappinserver/domain/user/domain/entity/Onboarding.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/domain/entity/Onboarding.java
@@ -1,0 +1,215 @@
+package org.sopt.snappinserver.domain.user.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.snappinserver.domain.user.domain.exception.UserErrorCode;
+import org.sopt.snappinserver.domain.user.domain.exception.UserException;
+import org.sopt.snappinserver.global.entity.BaseEntity;
+import org.sopt.snappinserver.global.enums.Gender;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "onboarding")
+public class Onboarding extends BaseEntity {
+
+    private static final int MAX_NAME_LENGTH = 4;
+    private static final int MAX_NICKNAME_LENGTH = 10;
+    private static final int MAX_PHONE_NUMBER_LENGTH = 13;
+    private static final int MAX_EMAIL_LENGTH = 320;
+
+    private static final Pattern WHITESPACE_PATTERN = Pattern.compile(".*\\s.*");
+    private static final Pattern KOREAN_ONLY_PATTERN = Pattern.compile("^[가-힣]+$");
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9]{2,10}$");
+    private static final Pattern PHONE_NUMBER_PATTERN = Pattern.compile("^\\d{3}-\\d{4}-\\d{4}$");
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}$");
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "onboarding_seq_gen")
+    @SequenceGenerator(
+        name = "onboarding_seq_gen",
+        sequenceName = "onboarding_seq",
+        allocationSize = 1
+    )
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = MAX_NAME_LENGTH)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Gender gender;
+
+    @Column(nullable = false, length = MAX_NICKNAME_LENGTH)
+    private String nickname;
+
+    @Column(nullable = false, length = MAX_PHONE_NUMBER_LENGTH)
+    private String phoneNumber;
+
+    @Column(nullable = false, length = MAX_EMAIL_LENGTH)
+    private String email;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Onboarding(
+        User user,
+        String name,
+        Gender gender,
+        String nickname,
+        String phoneNumber,
+        String email
+    ) {
+        this.user = user;
+        this.name = name;
+        this.gender = gender;
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+        this.email = email;
+    }
+
+    public static Onboarding create(
+        User user,
+        String name,
+        Gender gender,
+        String nickname,
+        String phoneNumber,
+        String email
+    ) {
+        validateOnboarding(name, gender, nickname, phoneNumber, email);
+        return Onboarding.builder()
+            .user(user)
+            .name(name)
+            .gender(gender)
+            .nickname(nickname)
+            .phoneNumber(phoneNumber)
+            .email(email)
+            .build();
+    }
+
+    private static void validateOnboarding(
+        String name,
+        Gender gender,
+        String nickname,
+        String phoneNumber,
+        String email
+    ) {
+        validateName(name);
+        validateGender(gender);
+        validateNickname(nickname);
+        validatePhoneNumber(phoneNumber);
+        validateEmail(email);
+    }
+
+    private static void validateName(String name) {
+        validateNameExists(name);
+        validateNotIncludeWhitespace(name);
+        validateNamePattern(name);
+        validateNameLength(name);
+    }
+
+    private static void validateNameExists(String name) {
+        if (name == null || name.isBlank()) {
+            throw new UserException(UserErrorCode.ONBOARDING_NAME_REQUIRED);
+        }
+    }
+
+    private static void validateNotIncludeWhitespace(String name) {
+        if (WHITESPACE_PATTERN.matcher(name).matches()) {
+            throw new UserException(UserErrorCode.ONBOARDING_NAME_HAS_WHITESPACE);
+        }
+    }
+
+    private static void validateNamePattern(String name) {
+        if (!KOREAN_ONLY_PATTERN.matcher(name).matches()) {
+            throw new UserException(UserErrorCode.ONBOARDING_NAME_NOT_KOREAN);
+        }
+    }
+
+    private static void validateNameLength(String name) {
+        if (name.length() > MAX_NAME_LENGTH) {
+            throw new UserException(UserErrorCode.ONBOARDING_NAME_TOO_LONG);
+        }
+    }
+
+    private static void validateGender(Gender gender) {
+        if (gender == null) {
+            throw new UserException(UserErrorCode.ONBOARDING_GENDER_REQUIRED);
+        }
+    }
+
+    private static void validateNickname(String nickname) {
+        validateNicknameExists(nickname);
+        validateNickNameNotIncludeWhitespace(nickname);
+        validateNickNamePattern(nickname);
+    }
+
+    private static void validateNicknameExists(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            throw new UserException(UserErrorCode.ONBOARDING_NICKNAME_REQUIRED);
+        }
+    }
+
+    private static void validateNickNameNotIncludeWhitespace(String nickname) {
+        if (WHITESPACE_PATTERN.matcher(nickname).matches()) {
+            throw new UserException(UserErrorCode.ONBOARDING_NICKNAME_HAS_WHITESPACE);
+        }
+    }
+
+    private static void validateNickNamePattern(String nickname) {
+        if (!NICKNAME_PATTERN.matcher(nickname).matches()) {
+            throw new UserException(UserErrorCode.ONBOARDING_NICKNAME_INVALID);
+        }
+    }
+
+    private static void validatePhoneNumber(String phoneNumber) {
+        validatePhoneNumberExists(phoneNumber);
+        validatePhoneNumberPattern(phoneNumber);
+    }
+
+    private static void validatePhoneNumberExists(String phoneNumber) {
+        if (phoneNumber == null || phoneNumber.isBlank()) {
+            throw new UserException(UserErrorCode.ONBOARDING_PHONE_NUMBER_REQUIRED);
+        }
+    }
+
+    private static void validatePhoneNumberPattern(String phoneNumber) {
+        if (!PHONE_NUMBER_PATTERN.matcher(phoneNumber).matches()) {
+            throw new UserException(UserErrorCode.ONBOARDING_PHONE_NUMBER_INVALID);
+        }
+    }
+
+    private static void validateEmail(String email) {
+        validateEmailExists(email);
+        validateEmailPattern(email);
+    }
+
+    private static void validateEmailExists(String email) {
+        if (email == null || email.isBlank()) {
+            throw new UserException(UserErrorCode.ONBOARDING_EMAIL_REQUIRED);
+        }
+    }
+
+    private static void validateEmailPattern(String email) {
+        if (!EMAIL_PATTERN.matcher(email).matches()) {
+            throw new UserException(UserErrorCode.ONBOARDING_EMAIL_INVALID);
+        }
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/domain/entity/OnboardingSnapCategory.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/domain/entity/OnboardingSnapCategory.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
@@ -32,7 +33,8 @@ public class OnboardingSnapCategory {
     )
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "onboarding_id", nullable = false)
     private Onboarding onboarding;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/sopt/snappinserver/domain/user/domain/entity/OnboardingSnapCategory.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/domain/entity/OnboardingSnapCategory.java
@@ -1,0 +1,54 @@
+package org.sopt.snappinserver.domain.user.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.snappinserver.global.enums.SnapCategory;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "onboarding_snap_category")
+public class OnboardingSnapCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "onboarding_snap_category_seq_gen")
+    @SequenceGenerator(
+        name = "onboarding_snap_category_seq_gen",
+        sequenceName = "onboarding_snap_category_seq",
+        allocationSize = 1
+    )
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Onboarding onboarding;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SnapCategory snapCategory;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private OnboardingSnapCategory(Onboarding onboarding, SnapCategory snapCategory) {
+        this.onboarding = onboarding;
+        this.snapCategory = snapCategory;
+    }
+
+    public static OnboardingSnapCategory create(Onboarding onboarding, SnapCategory snapCategory) {
+        return OnboardingSnapCategory.builder()
+            .onboarding(onboarding)
+            .snapCategory(snapCategory)
+            .build();
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/domain/exception/UserErrorCode.java
@@ -15,6 +15,28 @@ public enum UserErrorCode implements ErrorCode {
     PROFILE_IMAGE_URL_REQUIRED(400, "USER_400_004", "프로필 이미지 url은 필수입니다."),
     PROFILE_IMAGE_URL_TOO_LONG(400, "USER_400_005", "프로필 이미지 url 길이는 1024자 이하입니다."),
 
+    // Onboarding - 이름
+    ONBOARDING_NAME_REQUIRED(400, "USER_400_006", "이름은 필수입니다."),
+    ONBOARDING_NAME_HAS_WHITESPACE(400, "USER_400_007", "띄어쓰기 없이 작성해주세요."),
+    ONBOARDING_NAME_NOT_KOREAN(400, "USER_400_008", "한글로 작성해주세요."),
+    ONBOARDING_NAME_TOO_LONG(400, "USER_400_009", "이름을 4글자 이내로 입력해주세요."),
+
+    // Onboarding - 성별
+    ONBOARDING_GENDER_REQUIRED(400, "USER_400_010", "성별은 필수입니다."),
+
+    // Onboarding - 닉네임
+    ONBOARDING_NICKNAME_REQUIRED(400, "USER_400_011", "닉네임은 필수입니다."),
+    ONBOARDING_NICKNAME_HAS_WHITESPACE(400, "USER_400_012", "띄어쓰기 없이 작성해주세요."),
+    ONBOARDING_NICKNAME_INVALID(400, "USER_400_013", "한글, 영문, 숫자 2-10자 이내로 입력해주세요."),
+
+    // Onboarding - 전화번호
+    ONBOARDING_PHONE_NUMBER_REQUIRED(400, "USER_400_014", "전화번호는 필수입니다."),
+    ONBOARDING_PHONE_NUMBER_INVALID(400, "USER_400_015", "정확한 전화번호를 입력해주세요."),
+
+    // Onboarding - 이메일
+    ONBOARDING_EMAIL_REQUIRED(400, "USER_400_016", "이메일은 필수입니다."),
+    ONBOARDING_EMAIL_INVALID(400, "USER_400_017", "정확한 이메일 주소를 입력해주세요."),
+
     // 401 UNAUTHORIZED
 
     // 403 FORBIDDEN

--- a/src/main/java/org/sopt/snappinserver/domain/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/domain/exception/UserErrorCode.java
@@ -47,6 +47,9 @@ public enum UserErrorCode implements ErrorCode {
     PHOTOGRAPHER_NOT_FOUND(404, "USER_404_002", "해당 사용자의 작가 프로필이 존재하지 않습니다."),
     ONBOARDING_NOT_FOUND(404, "USER_404_003", "해당 사용자의 온보딩 정보가 존재하지 않습니다."),
 
+    // 409 Conflict
+    ONBOARDING_ALREADY_SAVED(409, "USER_409_001", "이미 해당 사용자의 온보딩 정보가 존재합니다.");
+
     ;
 
     private final int status;

--- a/src/main/java/org/sopt/snappinserver/domain/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/domain/exception/UserErrorCode.java
@@ -45,6 +45,7 @@ public enum UserErrorCode implements ErrorCode {
     // 404 NOT FOUND
     USER_NOT_FOUND(404, "USER_404_001", "존재하지 않는 사용자입니다."),
     PHOTOGRAPHER_NOT_FOUND(404, "USER_404_002", "해당 사용자의 작가 프로필이 존재하지 않습니다."),
+    ONBOARDING_NOT_FOUND(404, "USER_404_003", "해당 사용자의 온보딩 정보가 존재하지 않습니다."),
 
     ;
 

--- a/src/main/java/org/sopt/snappinserver/domain/user/repository/OnboardingRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/repository/OnboardingRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.snappinserver.domain.user.repository;
+
+import org.sopt.snappinserver.domain.user.domain.entity.Onboarding;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OnboardingRepository extends JpaRepository<Onboarding, Long> {
+
+    boolean existsByUser(User user);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/repository/OnboardingRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/repository/OnboardingRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.snappinserver.domain.user.repository;
 
+import java.util.Optional;
 import org.sopt.snappinserver.domain.user.domain.entity.Onboarding;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface OnboardingRepository extends JpaRepository<Onboarding, Long> {
 
     boolean existsByUser(User user);
+
+    Optional<Onboarding> findByUser(User user);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/user/repository/OnboardingSnapCategoryRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/repository/OnboardingSnapCategoryRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.snappinserver.domain.user.repository;
+
+import org.sopt.snappinserver.domain.user.domain.entity.OnboardingSnapCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OnboardingSnapCategoryRepository
+    extends JpaRepository<OnboardingSnapCategory, Long> {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/CreateUserOnboardingService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/CreateUserOnboardingService.java
@@ -27,6 +27,7 @@ public class CreateUserOnboardingService implements CreateUserOnboardingUseCase 
     @Override
     public void createUserOnboarding(CreateOnboardingCommand command) {
         User user = getExistingUser(command.userId());
+        validatedUniqueOnboarding(user);
         Onboarding onboarding = Onboarding.create(
             user,
             command.name(),
@@ -41,6 +42,12 @@ public class CreateUserOnboardingService implements CreateUserOnboardingUseCase 
             .map(category -> OnboardingSnapCategory.create(onboarding, category))
             .toList();
         onboardingSnapCategoryRepository.saveAll(categories);
+    }
+
+    private void validatedUniqueOnboarding(User user) {
+        if(onboardingRepository.existsByUser(user)) {
+            throw new UserException(UserErrorCode.ONBOARDING_ALREADY_SAVED);
+        }
     }
 
     private User getExistingUser(Long userID) {

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/CreateUserOnboardingService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/CreateUserOnboardingService.java
@@ -1,0 +1,50 @@
+package org.sopt.snappinserver.domain.user.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.user.domain.entity.Onboarding;
+import org.sopt.snappinserver.domain.user.domain.entity.OnboardingSnapCategory;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
+import org.sopt.snappinserver.domain.user.domain.exception.UserErrorCode;
+import org.sopt.snappinserver.domain.user.domain.exception.UserException;
+import org.sopt.snappinserver.domain.user.repository.OnboardingRepository;
+import org.sopt.snappinserver.domain.user.repository.OnboardingSnapCategoryRepository;
+import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.sopt.snappinserver.domain.user.service.dto.request.CreateOnboardingCommand;
+import org.sopt.snappinserver.domain.user.service.usecase.CreateUserOnboardingUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class CreateUserOnboardingService implements CreateUserOnboardingUseCase {
+
+    private final UserRepository userRepository;
+    private final OnboardingRepository onboardingRepository;
+    private final OnboardingSnapCategoryRepository onboardingSnapCategoryRepository;
+
+    @Override
+    public void createUserOnboarding(CreateOnboardingCommand command) {
+        User user = getExistingUser(command.userId());
+        Onboarding onboarding = Onboarding.create(
+            user,
+            command.name(),
+            command.gender(),
+            command.nickname(),
+            command.phoneNumber(),
+            command.email()
+        );
+        onboardingRepository.save(onboarding);
+
+        List<OnboardingSnapCategory> categories = command.snapCategories().stream()
+            .map(category -> OnboardingSnapCategory.create(onboarding, category))
+            .toList();
+        onboardingSnapCategoryRepository.saveAll(categories);
+    }
+
+    private User getExistingUser(Long userID) {
+        return userRepository.findById(userID)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/GetOnboardingExistsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/GetOnboardingExistsService.java
@@ -20,7 +20,7 @@ public class GetOnboardingExistsService implements GetOnboardingExistsUseCase {
     private final OnboardingRepository onboardingRepository;
 
     @Override
-    public GetOnboardingExistsResult getOnboardingExists(Long userId) {
+    public GetOnboardingExistsResult hasOnboarding(Long userId) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
         return new GetOnboardingExistsResult(onboardingRepository.existsByUser(user));

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/GetOnboardingExistsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/GetOnboardingExistsService.java
@@ -1,0 +1,28 @@
+package org.sopt.snappinserver.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
+import org.sopt.snappinserver.domain.user.domain.exception.UserErrorCode;
+import org.sopt.snappinserver.domain.user.domain.exception.UserException;
+import org.sopt.snappinserver.domain.user.repository.OnboardingRepository;
+import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetOnboardingExistsResult;
+import org.sopt.snappinserver.domain.user.service.usecase.GetOnboardingExistsUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class GetOnboardingExistsService implements GetOnboardingExistsUseCase {
+
+    private final UserRepository userRepository;
+    private final OnboardingRepository onboardingRepository;
+
+    @Override
+    public GetOnboardingExistsResult getOnboardingExists(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        return new GetOnboardingExistsResult(onboardingRepository.existsByUser(user));
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/GetOnboardingService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/GetOnboardingService.java
@@ -1,0 +1,33 @@
+package org.sopt.snappinserver.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.user.domain.entity.Onboarding;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
+import org.sopt.snappinserver.domain.user.domain.exception.UserErrorCode;
+import org.sopt.snappinserver.domain.user.domain.exception.UserException;
+import org.sopt.snappinserver.domain.user.repository.OnboardingRepository;
+import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.sopt.snappinserver.domain.user.service.dto.response.GetOnboardingResult;
+import org.sopt.snappinserver.domain.user.service.usecase.GetOnboardingUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class GetOnboardingService implements GetOnboardingUseCase {
+
+    private final UserRepository userRepository;
+    private final OnboardingRepository onboardingRepository;
+
+    @Override
+    public GetOnboardingResult getOnboarding(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        Onboarding onboarding = onboardingRepository.findByUser(user)
+            .orElseThrow(() -> new UserException(UserErrorCode.ONBOARDING_NOT_FOUND));
+
+        return GetOnboardingResult.create(onboarding);
+    }
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
@@ -9,9 +9,11 @@ import org.sopt.snappinserver.domain.photographer.domain.entity.Photographer;
 import org.sopt.snappinserver.domain.photographer.repository.PhotographerAvailableLocationRepository;
 import org.sopt.snappinserver.domain.photographer.repository.PhotographerRepository;
 import org.sopt.snappinserver.domain.photographer.repository.PhotographerSpecialtyRepository;
+import org.sopt.snappinserver.domain.user.domain.entity.Onboarding;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.sopt.snappinserver.domain.user.domain.exception.UserErrorCode;
 import org.sopt.snappinserver.domain.user.domain.exception.UserException;
+import org.sopt.snappinserver.domain.user.repository.OnboardingRepository;
 import org.sopt.snappinserver.domain.user.repository.UserRepository;
 import org.sopt.snappinserver.domain.user.service.dto.response.GetClientInfoResult;
 import org.sopt.snappinserver.domain.user.service.dto.response.GetPhotographerInfoResult;
@@ -34,6 +36,7 @@ public class GetUserInfoService implements GetUserInfoUseCase {
     private final CurationRepositoryCustom curationRepository;
     private final PhotographerSpecialtyRepository specialtyRepository;
     private final PhotographerAvailableLocationRepository locationRepository;
+    private final OnboardingRepository onboardingRepository;
 
     @Value("${cloud.aws.cloud-front.domain}")
     private String cloudFrontDomain;
@@ -64,7 +67,8 @@ public class GetUserInfoService implements GetUserInfoUseCase {
         boolean hasPhotographerProfile = photographerRepository.existsByUser(user);
         List<Long> moodIds = curationRepository.findTop3MoodIdsByUserId(user.getId());
         List<String> moodNames = getMoodNames(moodIds);
-        GetClientInfoResult clientInfo = new GetClientInfoResult(user.getName(), moodNames);
+        Onboarding onboarding = getExistingOnboarding(user);
+        GetClientInfoResult clientInfo = GetClientInfoResult.create(onboarding, moodNames);
 
         return GetUserInfoResult.of(
             user,
@@ -73,6 +77,11 @@ public class GetUserInfoService implements GetUserInfoUseCase {
             clientInfo,
             null
         );
+    }
+
+    private Onboarding getExistingOnboarding(User user) {
+        return onboardingRepository.findByUser(user)
+            .orElseThrow(() -> new UserException(UserErrorCode.ONBOARDING_NOT_FOUND));
     }
 
     private List<String> getMoodNames(List<Long> moodIds) {

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/dto/request/CreateOnboardingCommand.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/dto/request/CreateOnboardingCommand.java
@@ -23,7 +23,7 @@ public record CreateOnboardingCommand(
             request.nickname(),
             request.phoneNumber(),
             request.email(),
-            request.snapCategories()
+            List.copyOf(request.snapCategories())
         );
     }
 

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/dto/request/CreateOnboardingCommand.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/dto/request/CreateOnboardingCommand.java
@@ -1,0 +1,30 @@
+package org.sopt.snappinserver.domain.user.service.dto.request;
+
+import java.util.List;
+import org.sopt.snappinserver.api.v1.user.dto.request.CreateOnboardingRequest;
+import org.sopt.snappinserver.global.enums.Gender;
+import org.sopt.snappinserver.global.enums.SnapCategory;
+
+public record CreateOnboardingCommand(
+    Long userId,
+    String name,
+    Gender gender,
+    String nickname,
+    String phoneNumber,
+    String email,
+    List<SnapCategory> snapCategories
+) {
+
+    public static CreateOnboardingCommand create(Long userId, CreateOnboardingRequest request) {
+        return new CreateOnboardingCommand(
+            userId,
+            request.name(),
+            request.gender(),
+            request.nickname(),
+            request.phoneNumber(),
+            request.email(),
+            request.snapCategories()
+        );
+    }
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetClientInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetClientInfoResult.java
@@ -1,10 +1,19 @@
 package org.sopt.snappinserver.domain.user.service.dto.response;
 
 import java.util.List;
+import org.sopt.snappinserver.domain.user.domain.entity.Onboarding;
 
 public record GetClientInfoResult(
     String name,
+    String nickname,
     List<String> curatedMoods
 ) {
 
+    public static GetClientInfoResult create(Onboarding onboarding, List<String> curatedMoods) {
+        return new GetClientInfoResult(
+            onboarding.getName(),
+            onboarding.getNickname(),
+            curatedMoods
+        );
+    }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetOnboardingExistsResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetOnboardingExistsResult.java
@@ -1,0 +1,7 @@
+package org.sopt.snappinserver.domain.user.service.dto.response;
+
+public record GetOnboardingExistsResult(
+    boolean isOnboardingCompleted
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetOnboardingResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetOnboardingResult.java
@@ -1,21 +1,18 @@
 package org.sopt.snappinserver.domain.user.service.dto.response;
 
 import org.sopt.snappinserver.domain.user.domain.entity.Onboarding;
-import org.sopt.snappinserver.global.enums.Gender;
 
 public record GetOnboardingResult(
     String name,
     String phoneNumber,
-    String email,
-    Gender gender
+    String email
 ) {
 
     public static GetOnboardingResult create(Onboarding onboarding) {
         return new GetOnboardingResult(
             onboarding.getName(),
             onboarding.getPhoneNumber(),
-            onboarding.getEmail(),
-            onboarding.getGender()
+            onboarding.getEmail()
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetOnboardingResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetOnboardingResult.java
@@ -1,0 +1,21 @@
+package org.sopt.snappinserver.domain.user.service.dto.response;
+
+import org.sopt.snappinserver.domain.user.domain.entity.Onboarding;
+import org.sopt.snappinserver.global.enums.Gender;
+
+public record GetOnboardingResult(
+    String name,
+    String phoneNumber,
+    String email,
+    Gender gender
+) {
+
+    public static GetOnboardingResult create(Onboarding onboarding) {
+        return new GetOnboardingResult(
+            onboarding.getName(),
+            onboarding.getPhoneNumber(),
+            onboarding.getEmail(),
+            onboarding.getGender()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/usecase/CreateUserOnboardingUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/usecase/CreateUserOnboardingUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.user.service.usecase;
+
+import org.sopt.snappinserver.domain.user.service.dto.request.CreateOnboardingCommand;
+
+public interface CreateUserOnboardingUseCase {
+
+    void createUserOnboarding(CreateOnboardingCommand command);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/usecase/GetOnboardingExistsUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/usecase/GetOnboardingExistsUseCase.java
@@ -4,5 +4,5 @@ import org.sopt.snappinserver.domain.user.service.dto.response.GetOnboardingExis
 
 public interface GetOnboardingExistsUseCase {
 
-    GetOnboardingExistsResult getOnboardingExists(Long userId);
+    GetOnboardingExistsResult hasOnboarding(Long userId);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/usecase/GetOnboardingExistsUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/usecase/GetOnboardingExistsUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.user.service.usecase;
+
+import org.sopt.snappinserver.domain.user.service.dto.response.GetOnboardingExistsResult;
+
+public interface GetOnboardingExistsUseCase {
+
+    GetOnboardingExistsResult getOnboardingExists(Long userId);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/usecase/GetOnboardingUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/usecase/GetOnboardingUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.user.service.usecase;
+
+import org.sopt.snappinserver.domain.user.service.dto.response.GetOnboardingResult;
+
+public interface GetOnboardingUseCase {
+
+    GetOnboardingResult getOnboarding(Long userId);
+}

--- a/src/main/java/org/sopt/snappinserver/global/enums/Gender.java
+++ b/src/main/java/org/sopt/snappinserver/global/enums/Gender.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Gender {
 
-    MALE("남자"),
-    FEMALE("여자"),
+    MALE("남성"),
+    FEMALE("여성"),
     ;
 
     private final String gender;

--- a/src/main/java/org/sopt/snappinserver/global/enums/SnapCategory.java
+++ b/src/main/java/org/sopt/snappinserver/global/enums/SnapCategory.java
@@ -13,6 +13,7 @@ public enum SnapCategory {
     DAILY("일상스냅"),
     FAMILY("가족스냅"),
     RECITAL("연주스냅"),
+    FRIENDS("우정스냅")
     ;
 
     private final String category;

--- a/src/main/java/org/sopt/snappinserver/global/response/code/user/UserSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/user/UserSuccessCode.java
@@ -12,6 +12,7 @@ public enum UserSuccessCode implements SuccessCode {
     GET_USER_INFO_OK(200, "USER_200_001", "성공적으로 유저 정보를 조회했습니다."),
     SWITCH_USER_ROLE_OK(200, "USER_200_002", "성공적으로 유저 역할을 전환했습니다."),
     CREATE_ONBOARDING_OK(200, "USER_200_003", "성공적으로 온보딩 정보를 저장했습니다."),
+    GET_ONBOARDING_OK(200, "USER_200_004", "성공적으로 온보딩 정보를 조회했습니다."),
 
     // 201 CREATED
 

--- a/src/main/java/org/sopt/snappinserver/global/response/code/user/UserSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/user/UserSuccessCode.java
@@ -11,6 +11,7 @@ public enum UserSuccessCode implements SuccessCode {
     // 200 OK
     GET_USER_INFO_OK(200, "USER_200_001", "성공적으로 유저 정보를 조회했습니다."),
     SWITCH_USER_ROLE_OK(200, "USER_200_002", "성공적으로 유저 역할을 전환했습니다."),
+    CREATE_ONBOARDING_OK(200, "USER_200_003", "성공적으로 온보딩 정보를 저장했습니다."),
 
     // 201 CREATED
 

--- a/src/main/java/org/sopt/snappinserver/global/response/code/user/UserSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/user/UserSuccessCode.java
@@ -11,10 +11,10 @@ public enum UserSuccessCode implements SuccessCode {
     // 200 OK
     GET_USER_INFO_OK(200, "USER_200_001", "성공적으로 유저 정보를 조회했습니다."),
     SWITCH_USER_ROLE_OK(200, "USER_200_002", "성공적으로 유저 역할을 전환했습니다."),
-    CREATE_ONBOARDING_OK(200, "USER_200_003", "성공적으로 온보딩 정보를 저장했습니다."),
-    GET_ONBOARDING_OK(200, "USER_200_004", "성공적으로 온보딩 정보를 조회했습니다."),
+    GET_ONBOARDING_OK(200, "USER_200_003", "성공적으로 온보딩 정보를 조회했습니다."),
 
     // 201 CREATED
+    CREATE_ONBOARDING_OK(201, "USER_201_001", "성공적으로 온보딩 정보를 저장했습니다."),
 
     ;
 


### PR DESCRIPTION
## 👀 Summary

- close #263

<!--관련 있는 Issue를 태그해주세요. (e.g. > - #1) -->

<!--해당 PR에 대한 작업 내용을 요약하여 작성해주세요-->


## 🖇️ Tasks

- [x] 온보딩 정보 입력 API 작성
- [x] 온보딩(예약자) 정보 조회 API 작성
- [x] 온보딩 추가에 따른 v2 로그인 응답 변경

<!--해당 PR에 수행한 작업을 작성해주세요.-->

## 🔍 To Reviewer

### ❶ 온보딩 정보 입력
카카오 로그인 이후, 온보딩 정보가 누락된 사용자(온보딩 기능 도입 이전 가입자 포함)를 대상으로 온보딩 API를 추가했습니다.

온보딩 데이터는 별도 질문 응답 구조 대신 `User` 테이블과 연관된 독립 테이블로 설계했습니다. 마지막 단계에서 모든 답변이 완료된 경우에만 저장되며, 마지막 항목인 스냅 카테고리 선택은 `Onboarding`과 `SnapCategory` 사이의 중간 테이블로 관리합니다.

### ❷ v2 로그인 응답 수정 (온보딩 여부 반영)
카카오 로그인 후 온보딩 완료 여부에 따라 리다이렉트 대상이 달라지므로, 로그인 응답에 `isOnboardingCompleted` 필드를 추가했습니다.
- `true` → 홈 화면으로 리다이렉트
- `false` → 온보딩 화면으로 리다이렉트

❶과 별개의 API이나 변경 사유가 동일하여 같은 PR에 포함했습니다.

### ❸ 예약자 정보 조회
사용자가 온보딩 시 입력한 정보를 조회하는 API입니다. ❶과 별개의 API이나 동일한 컨트롤러에 위치하며, 마감 일정을 고려해 하나의 PR로 함께 올립니다.



<!--리뷰어에게 요청하는 내용을 작성해주세요-->
