### PR TITLE
[REFACTOR] #266: 전체 무드 필터값 조회 응답값 변경

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v2/mood/controller/MoodApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/mood/controller/MoodApi.java
@@ -1,0 +1,18 @@
+package org.sopt.snappinserver.api.v2.mood.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.snappinserver.api.v2.mood.dto.response.GetMoodFilterListResponse;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Tag(name = "05 - Mood", description = "무드 관련 API")
+public interface MoodApi {
+
+    @Operation(
+        summary = "전체 무드 필터 값 조회 API",
+        description = "전체 무드 필터 값 목록을 반환합니다."
+    )
+    @GetMapping
+    ApiResponseBody<GetMoodFilterListResponse, Void> getAllMoodFilters();
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/mood/controller/MoodControllerV2.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/mood/controller/MoodControllerV2.java
@@ -6,7 +6,6 @@ import org.sopt.snappinserver.domain.mood.service.dto.response.GetMoodFilterList
 import org.sopt.snappinserver.domain.mood.service.usecase.GetMoodFilterListUseCase;
 import org.sopt.snappinserver.global.response.code.mood.MoodSuccessCode;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,7 +17,6 @@ public class MoodControllerV2 implements MoodApi {
     private final GetMoodFilterListUseCase getMoodFilterListUseCase;
 
     @Override
-    @GetMapping
     public ApiResponseBody<GetMoodFilterListResponse, Void> getAllMoodFilters() {
         GetMoodFilterListResult result = getMoodFilterListUseCase.getMoodFilters(null);
         GetMoodFilterListResponse response = GetMoodFilterListResponse.from(result);

--- a/src/main/java/org/sopt/snappinserver/api/v2/mood/controller/MoodControllerV2.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/mood/controller/MoodControllerV2.java
@@ -1,0 +1,28 @@
+package org.sopt.snappinserver.api.v2.mood.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.v2.mood.dto.response.GetMoodFilterListResponse;
+import org.sopt.snappinserver.domain.mood.service.dto.response.GetMoodFilterListResult;
+import org.sopt.snappinserver.domain.mood.service.usecase.GetMoodFilterListUseCase;
+import org.sopt.snappinserver.global.response.code.mood.MoodSuccessCode;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v2/moods")
+@RequiredArgsConstructor
+@RestController
+public class MoodControllerV2 implements MoodApi {
+
+    private final GetMoodFilterListUseCase getMoodFilterListUseCase;
+
+    @Override
+    @GetMapping
+    public ApiResponseBody<GetMoodFilterListResponse, Void> getAllMoodFilters() {
+        GetMoodFilterListResult result = getMoodFilterListUseCase.getMoodFilters(null);
+        GetMoodFilterListResponse response = GetMoodFilterListResponse.from(result);
+
+        return ApiResponseBody.ok(MoodSuccessCode.GET_ALL_MOOD_OK, response);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/mood/dto/response/GetMoodFilterListResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/mood/dto/response/GetMoodFilterListResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.snappinserver.api.v2.mood.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.mood.service.dto.response.GetMoodFilterListResult;
+
+@Schema(description = "전체 무드 필터 값 조회 응답 DTO")
+public record GetMoodFilterListResponse(
+
+    @Schema(description = "무드 값 목록")
+    List<GetMoodFilterResponse> moods
+) {
+
+
+    public static GetMoodFilterListResponse from(GetMoodFilterListResult result) {
+        return new GetMoodFilterListResponse(
+            result.moods().stream()
+                .map(GetMoodFilterResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/mood/dto/response/GetMoodFilterResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/mood/dto/response/GetMoodFilterResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.snappinserver.api.v2.mood.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.mood.service.dto.response.GetMoodFilterResult;
+
+@Schema(description = "무드 필터 응답 DTO")
+public record GetMoodFilterResponse(
+
+    @Schema(description = "무드 ID")
+    Long id,
+
+    @Schema(description = "무드 이름")
+    String name
+) {
+
+    public static GetMoodFilterResponse from(GetMoodFilterResult result) {
+        return new GetMoodFilterResponse(
+            result.id(),
+            result.name()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/mood/domain/enums/MoodCategory.java
+++ b/src/main/java/org/sopt/snappinserver/domain/mood/domain/enums/MoodCategory.java
@@ -10,6 +10,7 @@ public enum MoodCategory {
     COMPOSITION("장면구성"),
     ATMOSPHERE("분위기"),
     STYLE("스타일"),
+    NONE("없음")
     ;
 
     private final String category;

--- a/src/main/java/org/sopt/snappinserver/domain/mood/policy/MoodSelector.java
+++ b/src/main/java/org/sopt/snappinserver/domain/mood/policy/MoodSelector.java
@@ -10,8 +10,7 @@ import org.springframework.stereotype.Component;
 public class MoodSelector {
 
     private static final List<Set<String>> OPPOSITE_PAIRS = List.of(
-        Set.of("내추럴", "연출된"),
-        Set.of("아날로그", "디지털")
+        Set.of("따스한", "시크한")
     );
 
     public List<MoodWithScore> selectTop3(int lastRank, List<MoodWithScore> candidates) {

--- a/src/main/java/org/sopt/snappinserver/domain/photo/repository/PhotoMoodRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photo/repository/PhotoMoodRepository.java
@@ -1,6 +1,7 @@
 package org.sopt.snappinserver.domain.photo.repository;
 
 import java.util.List;
+import org.sopt.snappinserver.domain.photo.domain.entity.Photo;
 import org.sopt.snappinserver.domain.photo.domain.entity.PhotoMood;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface PhotoMoodRepository extends JpaRepository<PhotoMood, Long> {
 
     List<PhotoMood> findAllByPhotoIdIn(List<Long> photoIds);
+
+    void deleteAllByPhoto(Photo photo);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photo/repository/PhotoRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.snappinserver.domain.photo.repository;
 
+import java.util.Optional;
 import org.sopt.snappinserver.domain.photo.domain.entity.Photo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -7,5 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
 
-    boolean existsByImageUrl(String imageUrl);
+    Optional<Photo> findByImageUrl(String imageUrl);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/photo/service/ProcessPhotoService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photo/service/ProcessPhotoService.java
@@ -35,8 +35,6 @@ public class ProcessPhotoService implements ProcessPhotoUseCase {
         Photo photo = photoRepository.findByImageUrl(photoProcessCommand.imageUrl())
             .orElseGet(() -> photoRepository.save(Photo.create(photoProcessCommand.imageUrl())));
 
-        photoMoodRepository.deleteAllByPhoto(photo);
-
         List<MoodWithScore> candidates = moodVectorRepository.findTopCandidates(
             toVectorLiteral(photoProcessCommand.embedding())
         );
@@ -44,6 +42,7 @@ public class ProcessPhotoService implements ProcessPhotoUseCase {
         List<Mood> selectedMood = getSelectedMood(selectedScores);
         List<PhotoMood> linkedPhotoMoods = photo.linkMoods(selectedMood, selectedScores);
 
+        photoMoodRepository.deleteAllByPhoto(photo);
         photoMoodRepository.saveAll(linkedPhotoMoods);
     }
 

--- a/src/main/java/org/sopt/snappinserver/domain/photo/service/ProcessPhotoService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photo/service/ProcessPhotoService.java
@@ -3,7 +3,6 @@ package org.sopt.snappinserver.domain.photo.service;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
 import org.sopt.snappinserver.domain.mood.policy.MoodSelector;
 import org.sopt.snappinserver.domain.mood.repository.MoodRepository;
@@ -11,8 +10,6 @@ import org.sopt.snappinserver.domain.mood.repository.MoodVectorRepository;
 import org.sopt.snappinserver.domain.mood.repository.MoodWithScore;
 import org.sopt.snappinserver.domain.photo.domain.entity.Photo;
 import org.sopt.snappinserver.domain.photo.domain.entity.PhotoMood;
-import org.sopt.snappinserver.domain.photo.domain.exception.PhotoErrorCode;
-import org.sopt.snappinserver.domain.photo.domain.exception.PhotoException;
 import org.sopt.snappinserver.domain.photo.repository.PhotoMoodRepository;
 import org.sopt.snappinserver.domain.photo.repository.PhotoRepository;
 import org.sopt.snappinserver.domain.photo.service.dto.request.PhotoProcessCommand;
@@ -23,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 @Service
-@Slf4j
 public class ProcessPhotoService implements ProcessPhotoUseCase {
 
     private static final int LAST_RANK = 3;
@@ -36,24 +32,19 @@ public class ProcessPhotoService implements ProcessPhotoUseCase {
 
     @Override
     public void linkPhotoWithMoodTags(PhotoProcessCommand photoProcessCommand) {
-        validateImageUrlUnique(photoProcessCommand);
-        log.info("성공1");
-        Photo photo = photoRepository.save(Photo.create(photoProcessCommand.imageUrl()));
-        log.info("성공2");
+        Photo photo = photoRepository.findByImageUrl(photoProcessCommand.imageUrl())
+            .orElseGet(() -> photoRepository.save(Photo.create(photoProcessCommand.imageUrl())));
+
+        photoMoodRepository.deleteAllByPhoto(photo);
 
         List<MoodWithScore> candidates = moodVectorRepository.findTopCandidates(
             toVectorLiteral(photoProcessCommand.embedding())
         );
-        log.info("성공3");
         List<MoodWithScore> selectedScores = moodSelector.selectTop3(LAST_RANK, candidates);
-        log.info("성공4");
         List<Mood> selectedMood = getSelectedMood(selectedScores);
-        log.info("성공5");
         List<PhotoMood> linkedPhotoMoods = photo.linkMoods(selectedMood, selectedScores);
-        log.info("성공6");
 
         photoMoodRepository.saveAll(linkedPhotoMoods);
-        log.info("성공7");
     }
 
     private String toVectorLiteral(List<Float> embedding) {
@@ -68,9 +59,4 @@ public class ProcessPhotoService implements ProcessPhotoUseCase {
             .toList();
     }
 
-    private void validateImageUrlUnique(PhotoProcessCommand photoProcessCommand) {
-        if (photoRepository.existsByImageUrl(photoProcessCommand.imageUrl())) {
-            throw new PhotoException(PhotoErrorCode.IMAGE_URL_ALREADY_SAVED);
-        }
-    }
 }

--- a/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
         "/api/v1/categories",
         "/api/v1/home/recommendation",
         "/api/v1/moods",
+        "/api/v2/moods",
 
         "/api/v1/photographers/**",
         "/api/v1/places/**",


### PR DESCRIPTION
## 👀 Summary

- close #266

<!--관련 있는 Issue를 태그해주세요. (e.g. > - #1) -->

<!--해당 PR에 대한 작업 내용을 요약하여 작성해주세요-->


## 🖇️ Tasks

- [x] 전체 무드 필터값 조회 응답값 변경
- [x] 기존 사진에 대한 무드 업데이트 로직 추가 필요

<!--해당 PR에 수행한 작업을 작성해주세요.-->

## 🔍 To Reviewer

### ❶ 응답값 변경 내용

기존 무드 별 카테고리 및 큐레이션 결과 여부가 필요 없어짐에 따라, `snapCategory` 항목과 `isCurated`를 삭제했습니다. 변경된 api 명세에 맞게 api 수정은 완료했습니다. 스프링 기본 철학인 관심사의 분리가 api 변경 시 하위 레이어로 변경 전파를 막기 위해 기존 도메인, 서비스 로직은 변경하지 않고 DTO, api 명세만 수정하였습니다.


### ❷ 기존 사진에 대한 무드 업데이트 로직 추가

람다에서 사용하는 api가 호출될 때, 해당 키값이 이미 저장되어 있으면 사진과 관련된 무드를 삭제하고, 새로운 무드로 다시 저장하는 로직으로 업데이트했습니다. 또한 무드 정의 정책 변경에 따라 상충되는 무드 선택 불가하도록 해당 부분 내용 업데이트했습니다.


<!--리뷰어에게 요청하는 내용을 작성해주세요-->
