### PR TITLE
[REFACTOR] #264: 위시 상품 및 포트폴리오 조회 v2 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/wish/controller/WishApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/wish/controller/WishApi.java
@@ -46,6 +46,8 @@ public interface WishApi {
         @Valid @RequestBody WishProductRequest request
     );
 
+    @Hidden
+    @Deprecated
     @Operation(
         summary = "위시 포트폴리오 목록 조회",
         description = "사용자가 좋아요한 전체 포트폴리오 목록을 조회합니다."

--- a/src/main/java/org/sopt/snappinserver/api/v1/wish/controller/WishApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/wish/controller/WishApi.java
@@ -1,5 +1,6 @@
 package org.sopt.snappinserver.api.v1.wish.controller;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -56,10 +57,8 @@ public interface WishApi {
         CustomUserInfo userInfo
     );
 
-    @Operation(
-        summary = "위시 상품 목록 조회",
-        description = "사용자가 좋아요한 전체 상품 목록을 조회합니다."
-    )
+    @Hidden
+    @Deprecated
     @GetMapping("/products")
     ApiResponseBody<WishedProductsResponse, Void> getWishedProducts(
 

--- a/src/main/java/org/sopt/snappinserver/api/v1/wish/controller/WishApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/wish/controller/WishApi.java
@@ -1,6 +1,5 @@
 package org.sopt.snappinserver.api.v1.wish.controller;
 
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/org/sopt/snappinserver/api/v1/wish/controller/WishApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/wish/controller/WishApi.java
@@ -46,11 +46,11 @@ public interface WishApi {
         @Valid @RequestBody WishProductRequest request
     );
 
-    @Hidden
     @Deprecated
     @Operation(
         summary = "위시 포트폴리오 목록 조회",
-        description = "사용자가 좋아요한 전체 포트폴리오 목록을 조회합니다."
+        description = "v2 API로 대체되었습니다. /api/v2/wishes/portfolios로 대체해서 사용하세요.",
+        deprecated = true
     )
     @GetMapping("/portfolios")
     ApiResponseBody<WishedPortfoliosResponse, Void> getWishedPortfolios(
@@ -59,8 +59,12 @@ public interface WishApi {
         CustomUserInfo userInfo
     );
 
-    @Hidden
     @Deprecated
+    @Operation(
+        summary = "위시 상품 목록 조회",
+        description = "v2 API로 대체되었습니다. /api/v2/wishes/products로 대체해서 사용하세요.",
+        deprecated = true
+    )
     @GetMapping("/products")
     ApiResponseBody<WishedProductsResponse, Void> getWishedProducts(
 

--- a/src/main/java/org/sopt/snappinserver/api/v1/wish/controller/WishController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/wish/controller/WishController.java
@@ -74,6 +74,7 @@ public class WishController implements WishApi {
         return ApiResponseBody.ok(WishSuccessCode.GET_WISHED_PORTFOLIOS_OK, response);
     }
 
+    @Deprecated
     @Override
     public ApiResponseBody<WishedProductsResponse, Void> getWishedProducts(
         @AuthenticationPrincipal CustomUserInfo userInfo

--- a/src/main/java/org/sopt/snappinserver/api/v1/wish/controller/WishController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/wish/controller/WishController.java
@@ -62,6 +62,7 @@ public class WishController implements WishApi {
         return ApiResponseBody.ok(decideSuccessCode(result), response);
     }
 
+    @Deprecated
     @Override
     public ApiResponseBody<WishedPortfoliosResponse, Void> getWishedPortfolios(
         @AuthenticationPrincipal CustomUserInfo userInfo

--- a/src/main/java/org/sopt/snappinserver/api/v1/wish/dto/response/WishedPortfolioResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/wish/dto/response/WishedPortfolioResponse.java
@@ -13,13 +13,17 @@ public record WishedPortfolioResponse(
         description = "포트폴리오 대표 이미지 URL",
         example = "https://example.com/portfolio1.jpg"
     )
-    String imageUrl
+    String imageUrl,
+
+    @Schema(description = "포트폴리오 좋아요 수", example = "3")
+    Integer likeCount
 ) {
 
     public static WishedPortfolioResponse from(WishedPortfolioResult result) {
         return new WishedPortfolioResponse(
             result.id(),
-            result.imageUrl()
+            result.imageUrl(),
+            result.likeCount()
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/v2/wish/controller/WishApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/wish/controller/WishApi.java
@@ -13,7 +13,7 @@ import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@Tag(name = "012 - Wish (v2)", description = "좋아요 관련 API (v2)")
+@Tag(name = "012 - Wish", description = "좋아요 관련 API")
 public interface WishApi {
 
     @Operation(

--- a/src/main/java/org/sopt/snappinserver/api/v2/wish/controller/WishApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/wish/controller/WishApi.java
@@ -2,12 +2,14 @@ package org.sopt.snappinserver.api.v2.wish.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sopt.snappinserver.api.v2.wish.dto.response.WishedProductsMetaResponse;
 import org.sopt.snappinserver.api.v2.wish.dto.response.WishedProductsResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "012 - Wish (v2)", description = "좋아요 관련 API (v2)")
 public interface WishApi {
@@ -22,7 +24,8 @@ public interface WishApi {
         @Parameter(hidden = true)
         CustomUserInfo userInfo,
 
-        Long cursor
+        @Schema(description = "다음 페이지 조회를 위한 커서 값", example = "100", nullable = true)
+        @RequestParam(value = "cursor", required = false) Long cursor
     );
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/v2/wish/controller/WishApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/wish/controller/WishApi.java
@@ -1,0 +1,28 @@
+package org.sopt.snappinserver.api.v2.wish.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.snappinserver.api.v2.wish.dto.response.WishedProductsMetaResponse;
+import org.sopt.snappinserver.api.v2.wish.dto.response.WishedProductsResponse;
+import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Tag(name = "012 - Wish (v2)", description = "좋아요 관련 API (v2)")
+public interface WishApi {
+
+    @Operation(
+        summary = "위시 상품 목록 조회",
+        description = "커서 기반 페이지네이션으로 사용자가 좋아요한 상품 목록을 조회합니다. 페이지 크기는 10입니다."
+    )
+    @GetMapping("/products")
+    ApiResponseBody<WishedProductsResponse, WishedProductsMetaResponse> getWishedProducts(
+
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo,
+
+        Long cursor
+    );
+
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/wish/controller/WishApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/wish/controller/WishApi.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.snappinserver.api.v2.wish.dto.response.WishedPortfoliosMetaResponse;
+import org.sopt.snappinserver.api.v2.wish.dto.response.WishedPortfoliosResponse;
 import org.sopt.snappinserver.api.v2.wish.dto.response.WishedProductsMetaResponse;
 import org.sopt.snappinserver.api.v2.wish.dto.response.WishedProductsResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
@@ -15,6 +17,20 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface WishApi {
 
     @Operation(
+        summary = "위시 포트폴리오 목록 조회",
+        description = "커서 기반 페이지네이션으로 사용자가 좋아요한 포트폴리오 목록을 조회합니다. 페이지 크기는 10입니다."
+    )
+    @GetMapping("/portfolios")
+    ApiResponseBody<WishedPortfoliosResponse, WishedPortfoliosMetaResponse> getWishedPortfolios(
+
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo,
+
+        @Schema(description = "다음 페이지 조회를 위한 커서 값", example = "11", nullable = true)
+        @RequestParam(value = "cursor", required = false) Long cursor
+    );
+
+    @Operation(
         summary = "위시 상품 목록 조회",
         description = "커서 기반 페이지네이션으로 사용자가 좋아요한 상품 목록을 조회합니다. 페이지 크기는 10입니다."
     )
@@ -24,7 +40,7 @@ public interface WishApi {
         @Parameter(hidden = true)
         CustomUserInfo userInfo,
 
-        @Schema(description = "다음 페이지 조회를 위한 커서 값", example = "100", nullable = true)
+        @Schema(description = "다음 페이지 조회를 위한 커서 값", example = "11", nullable = true)
         @RequestParam(value = "cursor", required = false) Long cursor
     );
 

--- a/src/main/java/org/sopt/snappinserver/api/v2/wish/controller/WishControllerV2.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/wish/controller/WishControllerV2.java
@@ -1,0 +1,40 @@
+package org.sopt.snappinserver.api.v2.wish.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.v2.wish.dto.response.WishedProductsMetaResponse;
+import org.sopt.snappinserver.api.v2.wish.dto.response.WishedProductsResponse;
+import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsPageResult;
+import org.sopt.snappinserver.domain.wish.service.usecase.GetWishedProductsUseCase;
+import org.sopt.snappinserver.global.response.code.wish.WishSuccessCode;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v2/wishes")
+@RequiredArgsConstructor
+@RestController
+@Validated
+public class WishControllerV2 implements WishApi {
+
+    private final GetWishedProductsUseCase getWishedProductsUseCase;
+
+    @Override
+    public ApiResponseBody<WishedProductsResponse, WishedProductsMetaResponse> getWishedProducts(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        @RequestParam(value = "cursor", required = false) Long cursor
+    ) {
+        WishedProductsPageResult result =
+            getWishedProductsUseCase.getWishedProductsPage(userInfo.userId(), cursor);
+
+        return ApiResponseBody.ok(
+            WishSuccessCode.GET_WISHED_PRODUCTS_OK,
+            WishedProductsResponse.from(result),
+            WishedProductsMetaResponse.from(result)
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/wish/controller/WishControllerV2.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/wish/controller/WishControllerV2.java
@@ -10,9 +10,7 @@ import org.sopt.snappinserver.global.response.code.wish.WishSuccessCode;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v2/wishes")
@@ -26,7 +24,7 @@ public class WishControllerV2 implements WishApi {
     @Override
     public ApiResponseBody<WishedProductsResponse, WishedProductsMetaResponse> getWishedProducts(
         @AuthenticationPrincipal CustomUserInfo userInfo,
-        @RequestParam(value = "cursor", required = false) Long cursor
+        Long cursor
     ) {
         WishedProductsPageResult result =
             getWishedProductsUseCase.getWishedProductsPage(userInfo.userId(), cursor);

--- a/src/main/java/org/sopt/snappinserver/api/v2/wish/controller/WishControllerV2.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/wish/controller/WishControllerV2.java
@@ -1,10 +1,14 @@
 package org.sopt.snappinserver.api.v2.wish.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.v2.wish.dto.response.WishedPortfoliosMetaResponse;
+import org.sopt.snappinserver.api.v2.wish.dto.response.WishedPortfoliosResponse;
 import org.sopt.snappinserver.api.v2.wish.dto.response.WishedProductsMetaResponse;
 import org.sopt.snappinserver.api.v2.wish.dto.response.WishedProductsResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosPageResult;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsPageResult;
+import org.sopt.snappinserver.domain.wish.service.usecase.GetWishedPortfoliosUseCase;
 import org.sopt.snappinserver.domain.wish.service.usecase.GetWishedProductsUseCase;
 import org.sopt.snappinserver.global.response.code.wish.WishSuccessCode;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
@@ -19,7 +23,23 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class WishControllerV2 implements WishApi {
 
+    private final GetWishedPortfoliosUseCase getWishedPortfoliosUseCase;
     private final GetWishedProductsUseCase getWishedProductsUseCase;
+
+    @Override
+    public ApiResponseBody<WishedPortfoliosResponse, WishedPortfoliosMetaResponse> getWishedPortfolios(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        Long cursor
+    ) {
+        WishedPortfoliosPageResult result =
+            getWishedPortfoliosUseCase.getWishedPortfoliosPage(userInfo.userId(), cursor);
+
+        return ApiResponseBody.ok(
+            WishSuccessCode.GET_WISHED_PORTFOLIOS_OK,
+            WishedPortfoliosResponse.from(result),
+            WishedPortfoliosMetaResponse.from(result)
+        );
+    }
 
     @Override
     public ApiResponseBody<WishedProductsResponse, WishedProductsMetaResponse> getWishedProducts(

--- a/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedPortfolioResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedPortfolioResponse.java
@@ -1,0 +1,29 @@
+package org.sopt.snappinserver.api.v2.wish.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfolioResult;
+
+@Schema(description = "위시 포트폴리오 단일 응답 DTO")
+public record WishedPortfolioResponse(
+
+    @Schema(description = "포트폴리오 아이디", example = "1")
+    Long id,
+
+    @Schema(
+        description = "포트폴리오 대표 이미지 URL",
+        example = "https://example.com/portfolio1.jpg"
+    )
+    String imageUrl,
+
+    @Schema(description = "포트폴리오 좋아요 수", example = "3")
+    Integer likeCount
+) {
+
+    public static WishedPortfolioResponse from(WishedPortfolioResult result) {
+        return new WishedPortfolioResponse(
+            result.id(),
+            result.imageUrl(),
+            result.likeCount()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedPortfoliosMetaResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedPortfoliosMetaResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.snappinserver.api.v2.wish.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosPageResult;
+
+@Schema(description = "위시 포트폴리오 커서 기반 조회 메타 정보 DTO")
+public record WishedPortfoliosMetaResponse(
+
+    @Schema(description = "다음 페이지 조회를 위한 커서 값", example = "11", nullable = true)
+    Long nextCursor,
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    boolean hasNext
+
+) {
+    public static WishedPortfoliosMetaResponse from(WishedPortfoliosPageResult result) {
+        return new WishedPortfoliosMetaResponse(
+            result.nextCursor(),
+            result.hasNext()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedPortfoliosResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedPortfoliosResponse.java
@@ -2,7 +2,6 @@ package org.sopt.snappinserver.api.v2.wish.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
-import org.sopt.snappinserver.api.v1.wish.dto.response.WishedPortfolioResponse;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosPageResult;
 
 @Schema(description = "위시 포트폴리오 커서 기반 목록 응답 DTO")

--- a/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedPortfoliosResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedPortfoliosResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.snappinserver.api.v2.wish.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.api.v1.wish.dto.response.WishedPortfolioResponse;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosPageResult;
+
+@Schema(description = "위시 포트폴리오 커서 기반 목록 응답 DTO")
+public record WishedPortfoliosResponse(
+
+    @Schema(description = "좋아요한 포트폴리오 목록")
+    List<WishedPortfolioResponse> portfolios
+
+) {
+    public static WishedPortfoliosResponse from(WishedPortfoliosPageResult result) {
+        return new WishedPortfoliosResponse(
+            result.portfolios().stream()
+                .map(WishedPortfolioResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedProductResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedProductResponse.java
@@ -1,0 +1,54 @@
+package org.sopt.snappinserver.api.v2.wish.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductResult;
+
+@Schema(description = "위시 상품 단일 응답 DTO")
+public record WishedProductResponse(
+
+    @Schema(description = "상품 아이디", example = "1")
+    Long id,
+
+    @Schema(description = "상품 대표 이미지 URL", example = "https://example.com/product1.jpg")
+    String imageUrl,
+
+    @Schema(description = "상품명", example = "인물 스냅 촬영")
+    String title,
+
+    @Schema(description = "평균 별점", example = "4.8")
+    BigDecimal rate,
+
+    @Schema(description = "리뷰 개수", example = "23")
+    Integer reviewCount,
+
+    @Schema(description = "상품 등록 작가", example = "김사진")
+    String photographer,
+
+    @Schema(description = "상품 가격", example = "150000")
+    Integer price,
+
+    @Schema(description = "상품 무드 태그 목록", example = "[\"따뜻한\", \"자연스러운\", \"투명한\"]")
+    List<String> moods
+) {
+
+    public static WishedProductResponse from(WishedProductResult result) {
+        BigDecimal rate = result.rate() == null
+            ? BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP)
+            : BigDecimal.valueOf(result.rate())
+                .setScale(1, RoundingMode.HALF_UP);
+
+        return new WishedProductResponse(
+            result.id(),
+            result.imageUrl(),
+            result.title(),
+            rate,
+            result.reviewCount(),
+            result.photographer(),
+            result.price(),
+            result.moods()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedProductsMetaResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedProductsMetaResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.snappinserver.api.v2.wish.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsPageResult;
+
+@Schema(description = "위시 상품 커서 기반 조회 메타 정보 DTO")
+public record WishedProductsMetaResponse(
+
+    @Schema(description = "다음 페이지 조회를 위한 커서 값", example = "11", nullable = true)
+    Long nextCursor,
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    boolean hasNext
+
+) {
+    public static WishedProductsMetaResponse from(WishedProductsPageResult result) {
+        return new WishedProductsMetaResponse(
+            result.nextCursor(),
+            result.hasNext()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedProductsResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedProductsResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.snappinserver.api.v2.wish.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.api.v1.wish.dto.response.WishedProductResponse;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsPageResult;
+
+@Schema(description = "위시 상품 커서 기반 목록 응답 DTO")
+public record WishedProductsResponse(
+
+    @Schema(description = "좋아요한 상품 목록")
+    List<WishedProductResponse> products
+
+) {
+    public static WishedProductsResponse from(WishedProductsPageResult result) {
+        return new WishedProductsResponse(
+            result.products().stream()
+                .map(WishedProductResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedProductsResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/wish/dto/response/WishedProductsResponse.java
@@ -2,7 +2,6 @@ package org.sopt.snappinserver.api.v2.wish.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
-import org.sopt.snappinserver.api.v1.wish.dto.response.WishedProductResponse;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsPageResult;
 
 @Schema(description = "위시 상품 커서 기반 목록 응답 DTO")

--- a/src/main/java/org/sopt/snappinserver/domain/wish/domain/exception/WishErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/domain/exception/WishErrorCode.java
@@ -12,6 +12,7 @@ public enum WishErrorCode implements ErrorCode {
     USER_REQUIRED(400, "WISH_400_001", "좋아요를 누른 사용자는 필수입니다."),
     PRODUCT_REQUIRED(400, "WISH_400_002", "좋아요한 상품은 필수입니다."),
     PORTFOLIO_REQUIRED(400, "WISH_400_003", "좋아요한 포트폴리오는 필수입니다."),
+    INVALID_CURSOR(400, "WISH_400_004", "유효하지 않은 커서 값입니다."),
 
     // 401 UNAUTHORIZED
 

--- a/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishPortfolioRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishPortfolioRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.snappinserver.domain.wish.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
@@ -43,4 +44,12 @@ public interface WishPortfolioRepository extends JpaRepository<WishPortfolio, Lo
         @Param("cursor") Long cursor,
         Pageable pageable
     );
+
+    @Query("""
+            select wp.portfolio.id, count(wp)
+            from WishPortfolio wp
+            where wp.portfolio.id in :portfolioIds
+            group by wp.portfolio.id
+        """)
+    List<Object[]> countGroupedByPortfolioId(@Param("portfolioIds") Collection<Long> portfolioIds);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishPortfolioRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishPortfolioRepository.java
@@ -5,7 +5,10 @@ import java.util.Optional;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.sopt.snappinserver.domain.wish.domain.entity.WishPortfolio;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,4 +17,30 @@ public interface WishPortfolioRepository extends JpaRepository<WishPortfolio, Lo
     Optional<WishPortfolio> findByUserAndPortfolio(User user, Portfolio portfolio);
 
     List<WishPortfolio> findAllByUserOrderByCreatedAtDesc(User user);
+
+    @Query("""
+            select wp
+            from WishPortfolio wp
+            join fetch wp.portfolio p
+            where wp.user = :user
+            order by wp.id desc
+        """)
+    List<WishPortfolio> findAllByUserWithPortfolioOrderByIdDesc(
+        @Param("user") User user,
+        Pageable pageable
+    );
+
+    @Query("""
+            select wp
+            from WishPortfolio wp
+            join fetch wp.portfolio p
+            where wp.user = :user
+              and wp.id < :cursor
+            order by wp.id desc
+        """)
+    List<WishPortfolio> findAllByUserWithPortfolioOrderByIdDescAndCursor(
+        @Param("user") User user,
+        @Param("cursor") Long cursor,
+        Pageable pageable
+    );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishProductRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishProductRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.sopt.snappinserver.domain.wish.domain.entity.WishProduct;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,5 +26,33 @@ public interface WishProductRepository extends JpaRepository<WishProduct, Long> 
         """)
     List<WishProduct> findAllByUserWithProductOrderByCreatedAtDesc(
         @Param("user") User user
+    );
+
+    @Query("""
+            select wp
+            from WishProduct wp
+            join fetch wp.product p
+            join fetch p.photographer
+            where wp.user = :user
+            order by wp.id desc
+        """)
+    List<WishProduct> findAllByUserWithProductOrderByIdDesc(
+        @Param("user") User user,
+        Pageable pageable
+    );
+
+    @Query("""
+            select wp
+            from WishProduct wp
+            join fetch wp.product p
+            join fetch p.photographer
+            where wp.user = :user
+              and wp.id < :cursor
+            order by wp.id desc
+        """)
+    List<WishProduct> findAllByUserWithProductOrderByIdDescAndCursor(
+        @Param("user") User user,
+        @Param("cursor") Long cursor,
+        Pageable pageable
     );
 }

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
@@ -12,9 +12,12 @@ import org.sopt.snappinserver.domain.wish.domain.exception.WishErrorCode;
 import org.sopt.snappinserver.domain.wish.domain.exception.WishException;
 import org.sopt.snappinserver.domain.wish.repository.WishPortfolioRepository;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfolioResult;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosPageResult;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosResult;
 import org.sopt.snappinserver.domain.wish.service.usecase.GetWishedPortfoliosUseCase;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +25,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GetWishedPortfoliosService implements GetWishedPortfoliosUseCase {
+
+    private static final int PAGE_SIZE = 10;
+    private static final long MIN_CURSOR_VALUE = 1L;
 
     private final WishPortfolioRepository wishPortfolioRepository;
     private final PortfolioPhotoRepository portfolioPhotoRepository;
@@ -33,9 +39,42 @@ public class GetWishedPortfoliosService implements GetWishedPortfoliosUseCase {
     @Override
     public WishedPortfoliosResult getWishedPortfolios(Long userId) {
         User user = getUser(userId);
-        List<WishedPortfolioResult> results = getWishedPortfolioResults(user);
+        List<WishPortfolio> wishes =
+            wishPortfolioRepository.findAllByUserOrderByCreatedAtDesc(user);
+        List<WishedPortfolioResult> results = mapWishesToResults(wishes);
 
         return WishedPortfoliosResult.from(results);
+    }
+
+    @Override
+    public WishedPortfoliosPageResult getWishedPortfoliosPage(Long userId, Long cursor) {
+        User user = getUser(userId);
+        validateCursor(cursor);
+
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE + 1);
+        List<WishPortfolio> wishes =
+            (cursor == null)
+                ? wishPortfolioRepository.findAllByUserWithPortfolioOrderByIdDesc(user, pageable)
+                : wishPortfolioRepository.findAllByUserWithPortfolioOrderByIdDescAndCursor(
+                    user,
+                    cursor,
+                    pageable
+                );
+
+        boolean hasNext = wishes.size() > PAGE_SIZE;
+        if (hasNext) {
+            wishes = wishes.subList(0, PAGE_SIZE);
+        }
+
+        if (wishes.isEmpty()) {
+            return WishedPortfoliosPageResult.from(List.of(), null, false);
+        }
+
+        List<WishedPortfolioResult> results = mapWishesToResults(wishes);
+
+        Long nextCursor = hasNext ? wishes.get(wishes.size() - 1).getId() : null;
+
+        return WishedPortfoliosPageResult.from(results, nextCursor, hasNext);
     }
 
     private User getUser(Long userId) {
@@ -43,13 +82,17 @@ public class GetWishedPortfoliosService implements GetWishedPortfoliosUseCase {
             .orElseThrow(() -> new WishException(WishErrorCode.USER_NOT_FOUND));
     }
 
-    private List<WishedPortfolioResult> getWishedPortfolioResults(User user) {
-        return wishPortfolioRepository
-            .findAllByUserOrderByCreatedAtDesc(user)
-            .stream()
+    private List<WishedPortfolioResult> mapWishesToResults(List<WishPortfolio> wishes) {
+        return wishes.stream()
             .map(WishPortfolio::getPortfolio)
             .map(this::mapToWishedPortfolioResult)
             .toList();
+    }
+
+    private static void validateCursor(Long cursor) {
+        if (cursor != null && cursor < MIN_CURSOR_VALUE) {
+            throw new WishException(WishErrorCode.INVALID_CURSOR);
+        }
     }
 
     private WishedPortfolioResult mapToWishedPortfolioResult(Portfolio portfolio) {

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedPortfoliosService.java
@@ -1,6 +1,10 @@
 package org.sopt.snappinserver.domain.wish.service;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.Portfolio;
 import org.sopt.snappinserver.domain.portfolio.domain.entity.PortfolioPhoto;
@@ -83,10 +87,40 @@ public class GetWishedPortfoliosService implements GetWishedPortfoliosUseCase {
     }
 
     private List<WishedPortfolioResult> mapWishesToResults(List<WishPortfolio> wishes) {
+        if (wishes.isEmpty()) {
+            return List.of();
+        }
+        Set<Long> portfolioIds = new HashSet<>();
+        for (WishPortfolio w : wishes) {
+            portfolioIds.add(w.getPortfolio().getId());
+        }
+        Map<Long, Long> likeCountByPortfolioId = loadLikeCountByPortfolioIds(portfolioIds);
         return wishes.stream()
             .map(WishPortfolio::getPortfolio)
-            .map(this::mapToWishedPortfolioResult)
+            .map(portfolio ->
+                mapToWishedPortfolioResult(
+                    portfolio,
+                    likeCount(portfolio.getId(), likeCountByPortfolioId)
+                )
+            )
             .toList();
+    }
+
+    private Map<Long, Long> loadLikeCountByPortfolioIds(Set<Long> portfolioIds) {
+        if (portfolioIds.isEmpty()) {
+            return Map.of();
+        }
+        List<Object[]> rows = wishPortfolioRepository.countGroupedByPortfolioId(portfolioIds);
+        Map<Long, Long> map = new HashMap<>();
+        for (Object[] row : rows) {
+            map.put((Long) row[0], (Long) row[1]);
+        }
+        return map;
+    }
+
+    private static int likeCount(Long portfolioId, Map<Long, Long> likeCountByPortfolioId) {
+        long n = likeCountByPortfolioId.getOrDefault(portfolioId, 0L);
+        return n > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) n;
     }
 
     private static void validateCursor(Long cursor) {
@@ -95,13 +129,13 @@ public class GetWishedPortfoliosService implements GetWishedPortfoliosUseCase {
         }
     }
 
-    private WishedPortfolioResult mapToWishedPortfolioResult(Portfolio portfolio) {
+    private WishedPortfolioResult mapToWishedPortfolioResult(Portfolio portfolio, int likeCount) {
         String imageUrl = portfolioPhotoRepository
             .findFirstByPortfolioOrderByDisplayOrderAsc(portfolio)
             .map(PortfolioPhoto::getPhoto)
             .map(photo -> cloudFrontDomain + photo.getImageUrl())
             .orElse(null);
 
-        return WishedPortfolioResult.of(portfolio.getId(), imageUrl);
+        return WishedPortfolioResult.of(portfolio.getId(), imageUrl, likeCount);
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/GetWishedProductsService.java
@@ -15,9 +15,12 @@ import org.sopt.snappinserver.domain.wish.domain.exception.WishErrorCode;
 import org.sopt.snappinserver.domain.wish.domain.exception.WishException;
 import org.sopt.snappinserver.domain.wish.repository.WishProductRepository;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductResult;
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsPageResult;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsResult;
 import org.sopt.snappinserver.domain.wish.service.usecase.GetWishedProductsUseCase;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +28,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GetWishedProductsService implements GetWishedProductsUseCase {
+
+    private static final int PAGE_SIZE = 10;
+    private static final long MIN_CURSOR_VALUE = 1L;
 
     private final WishProductRepository wishProductRepository;
     private final ProductPhotoRepository productPhotoRepository;
@@ -38,9 +44,42 @@ public class GetWishedProductsService implements GetWishedProductsUseCase {
     @Override
     public WishedProductsResult getWishedProducts(Long userId) {
         User user = getUser(userId);
-        List<WishedProductResult> results = getWishedProductResults(user);
+        List<WishProduct> wishes =
+            wishProductRepository.findAllByUserWithProductOrderByCreatedAtDesc(user);
+        List<WishedProductResult> results = mapWishesToResults(wishes);
 
         return WishedProductsResult.from(results);
+    }
+
+    @Override
+    public WishedProductsPageResult getWishedProductsPage(Long userId, Long cursor) {
+        User user = getUser(userId);
+        validateCursor(cursor);
+
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE + 1);
+        List<WishProduct> wishes =
+            (cursor == null)
+                ? wishProductRepository.findAllByUserWithProductOrderByIdDesc(user, pageable)
+                : wishProductRepository.findAllByUserWithProductOrderByIdDescAndCursor(
+                    user,
+                    cursor,
+                    pageable
+                );
+
+        boolean hasNext = wishes.size() > PAGE_SIZE;
+        if (hasNext) {
+            wishes = wishes.subList(0, PAGE_SIZE);
+        }
+
+        if (wishes.isEmpty()) {
+            return WishedProductsPageResult.from(List.of(), null, false);
+        }
+
+        List<WishedProductResult> results = mapWishesToResults(wishes);
+
+        Long nextCursor = hasNext ? wishes.get(wishes.size() - 1).getId() : null;
+
+        return WishedProductsPageResult.from(results, nextCursor, hasNext);
     }
 
     private User getUser(Long userId) {
@@ -48,13 +87,17 @@ public class GetWishedProductsService implements GetWishedProductsUseCase {
             .orElseThrow(() -> new WishException(WishErrorCode.USER_NOT_FOUND));
     }
 
-    private List<WishedProductResult> getWishedProductResults(User user) {
-        return wishProductRepository
-            .findAllByUserWithProductOrderByCreatedAtDesc(user)
-            .stream()
+    private List<WishedProductResult> mapWishesToResults(List<WishProduct> wishes) {
+        return wishes.stream()
             .map(WishProduct::getProduct)
             .map(this::mapToWishedProductResult)
             .toList();
+    }
+
+    private static void validateCursor(Long cursor) {
+        if (cursor != null && cursor < MIN_CURSOR_VALUE) {
+            throw new WishException(WishErrorCode.INVALID_CURSOR);
+        }
     }
 
     private WishedProductResult mapToWishedProductResult(Product product) {

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedPortfolioResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedPortfolioResult.java
@@ -1,8 +1,8 @@
 package org.sopt.snappinserver.domain.wish.service.dto.response;
 
-public record WishedPortfolioResult(Long id, String imageUrl) {
+public record WishedPortfolioResult(Long id, String imageUrl, Integer likeCount) {
 
-    public static WishedPortfolioResult of(Long id, String imageUrl) {
-        return new WishedPortfolioResult(id, imageUrl);
+    public static WishedPortfolioResult of(Long id, String imageUrl, Integer likeCount) {
+        return new WishedPortfolioResult(id, imageUrl, likeCount);
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedPortfoliosPageResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedPortfoliosPageResult.java
@@ -1,0 +1,18 @@
+package org.sopt.snappinserver.domain.wish.service.dto.response;
+
+import java.util.List;
+
+public record WishedPortfoliosPageResult(
+    List<WishedPortfolioResult> portfolios,
+    Long nextCursor,
+    boolean hasNext
+) {
+
+    public static WishedPortfoliosPageResult from(
+        List<WishedPortfolioResult> portfolios,
+        Long nextCursor,
+        boolean hasNext
+    ) {
+        return new WishedPortfoliosPageResult(portfolios, nextCursor, hasNext);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedProductsPageResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/dto/response/WishedProductsPageResult.java
@@ -1,0 +1,18 @@
+package org.sopt.snappinserver.domain.wish.service.dto.response;
+
+import java.util.List;
+
+public record WishedProductsPageResult(
+    List<WishedProductResult> products,
+    Long nextCursor,
+    boolean hasNext
+) {
+
+    public static WishedProductsPageResult from(
+        List<WishedProductResult> products,
+        Long nextCursor,
+        boolean hasNext
+    ) {
+        return new WishedProductsPageResult(products, nextCursor, hasNext);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/usecase/GetWishedPortfoliosUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/usecase/GetWishedPortfoliosUseCase.java
@@ -1,8 +1,11 @@
 package org.sopt.snappinserver.domain.wish.service.usecase;
 
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosPageResult;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedPortfoliosResult;
 
 public interface GetWishedPortfoliosUseCase {
 
     WishedPortfoliosResult getWishedPortfolios(Long userId);
+
+    WishedPortfoliosPageResult getWishedPortfoliosPage(Long userId, Long cursor);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/wish/service/usecase/GetWishedProductsUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/service/usecase/GetWishedProductsUseCase.java
@@ -1,9 +1,12 @@
 package org.sopt.snappinserver.domain.wish.service.usecase;
 
+import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsPageResult;
 import org.sopt.snappinserver.domain.wish.service.dto.response.WishedProductsResult;
 
 public interface GetWishedProductsUseCase {
 
     WishedProductsResult getWishedProducts(Long userId);
+
+    WishedProductsPageResult getWishedProductsPage(Long userId, Long cursor);
 
 }


### PR DESCRIPTION
## 👀 Summary

- close #264 
- close #269 

> 위시 상품 조회, 위시 포폴 조회 두 API 파일 간에 의존성이 있어 한 PR에서 처리했습니다!

<!--관련 있는 Issue를 태그해주세요. (e.g. > - #1) -->

위시 목록 조회 API에서 커서 기반 페이지네이션을 새롭게 적용했습니다. 

그 과정에서 위시 상품 조회는 GET /api/v2/wishes/products , 위시 포트폴리오 목록은 GET /api/v2/wishes/portfolio와 같이 V2로 업데이트되었습니다. 응답 구조에서는 상품 리뷰 목록과 같이 data와 분리된 meta(nextCursor, hasNext)를 두도록 구현했습니다.
위시 포폴 목록 응답에는 포트폴리오별 좋아요(위시) 수 likeCount를 추가했습니다.

기존 v1 위시 상품/포트폴리오 목록 조회는 `@Deprecated` + `@Hidden` 으로 OpenAPI에서 숨김 처리했습니다.



## 🖇️ Tasks

- [x] 기존 v1 위시 상품 / 포트폴리오 목록 조회 API 비활성화
- [x] 커서 기반 페이지네이션을 적용한 v2 API 구현
  - API 인터페이스 및 컨트롤러 업데이트
  - 응답 스펙 및 DTO에 메타 정보 추가
  - 서비스 로직에 무한 스크롤 적용
  - 커서값 관련 예외 코드 추가
- [x] 위시 포트폴리오 목록 응답에 likeCount 추가

<!--해당 PR에 수행한 작업을 작성해주세요.-->

## 🔍 To Reviewer

### ❶ Cursor 기반 페이지네이션
상품 리뷰 목록과 동일하게 응답 meta 에 nextCursor, hasNext 를 두었고, 커서 cursor / meta.nextCursor 값은 상품 id가 아니라 WishProduct PK(id) 입니다. 상품 리뷰 API의 리뷰 id 커서와 동일한 패턴으로 작성했습니다.

### ❷ 포트폴리오 likeCount와 쿼리 최적화 (N+1 방지)
위시 포트폴리오 목록 한 페이지에 포트폴리오가 10개라고 하면, 포트폴리오 마다 wish_portfolio 건수를 count(...)로 따로 조회하면 조회 쿼리가 최대 10번 추가로 나가는 N+1 형태가 됩니다.

이번 구현에서는 mapWishesToResults 단계에서 현재 페이지에 등장하는 포트폴리오 id들만 Set으로 모은 뒤, `WishPortfolioRepository.countGroupedByPortfolioId(portfolioIds)` 한 번으로 `group by portfolio_id` 집계를 가져옵니다. 결과를 Map<포트폴리오 id, 좋아요 수>로 옮겨 두고, 각 행을 DTO로 만들 때 그 맵에서 likeCount 를 꺼내 넣도록 구현했어요.

정리하면, '페이지당 포트폴리오 수만큼 count 쿼리'에서 'id 목록에 대한 집계 쿼리 1번'으로 줄였다고 이해해주시면 됩니다!



### ❸ 기존 v1 API 비활성화

#### `@Deprecated`
Java의 `@Deprecated`는 '이 API는 앞으로 사용 X'는 신호를 주는 용도에 가깝고, 서버가 요청을 거부하거나 엔드포인트를 없애지는 않습니다. 그래서 현재도 GET /api/v1/wishes/~ 는 그대로 동작합니다.

#### `@Hidden`을 추가한 이유
`@Deprecated`만으로는 Swagger(OpenAPI)에서 자동으로 사라지지 않는다고 해요. 
보통은 취소선, deprecated 표시만 되고 문서에 남거나, 스펙 기반으로 타입을 생성하는 저희 클라이언트의 특성 상 여전히 기존 타입이 잡힐 수 있어 v2와 혼동이 생길 수 있다고 생각했고 그래서 `@Hidden`으로 OpenAPI에서는 숨기는 방향을 선택했습니다. 

**`다만 스펙에 없다` = `새 코드에서는 안 쓰게 유도, 런타임 차단`과는 별개라고 하네요.**

실제 HTTP로는 여전히 호출 가능하고, v1용 비즈니스 로직(getWishedProducts 전체 목록 + 레포지토리의 createdAt 정렬 조회 등)도 그대로 유지해야 했어요. 이 파일이나 일부 코드를 삭제하면 관련 로직을 사용하는 곳에서 오류가 발생하니까요.

> 이번 PR에서는 v1에 대해서는 표시·문서 정리만 하고 물리적으로 비활성화는 하지 않았습니다만, 실제로 사용하지 않도록 하기 위한 조치는 따로 필요없을지, 필요하다면 어떤 방법을 사용하는게 좋을지 소연님 의견 궁금합니다!!!
