### PR TITLE
[FEAT] #271: 인기 무드 상품 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductApi.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import org.sopt.snappinserver.api.v1.product.dto.request.ProductReservationRequest;
+import org.sopt.snappinserver.api.v1.product.dto.response.GetPopularMoodProductsResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetProductDetailResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetProductListMeta;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetProductListResponse;
@@ -142,6 +143,16 @@ public interface ProductApi {
     @GetMapping
     ApiResponseBody<GetProductListResponse, GetProductListMeta> getProductList(
         @ModelAttribute GetProductListQuery query
+    );
+
+    @Operation(
+        summary = "인기 무드 상품 목록 조회",
+        description = "특정 무드 태그를 포함한 상품 중 좋아요 수가 많은 상품 12개 중 랜덤으로 4개를 조회합니다."
+    )
+    @GetMapping("/popular")
+    ApiResponseBody<GetPopularMoodProductsResponse, Void> getPopularMoodProducts(
+        @Schema(description = "무드 태그 아이디", example = "1")
+        @RequestParam @NotNull Long moodId
     );
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductApi.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
 import org.sopt.snappinserver.api.v1.product.dto.request.ProductReservationRequest;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetPopularMoodProductsResponse;
@@ -152,7 +153,7 @@ public interface ProductApi {
     @GetMapping("/popular")
     ApiResponseBody<GetPopularMoodProductsResponse, Void> getPopularMoodProducts(
         @Schema(description = "무드 태그 아이디", example = "1")
-        @RequestParam @NotNull Long moodId
+        @RequestParam @NotNull @Positive Long moodId
     );
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductController.java
@@ -8,6 +8,7 @@ import org.sopt.snappinserver.domain.product.service.dto.response.ProductDuratio
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductDurationTimeUseCase;
 import org.sopt.snappinserver.global.response.code.product.ProductSuccessCode;
 import org.sopt.snappinserver.api.v1.product.dto.request.ProductReservationRequest;
+import org.sopt.snappinserver.api.v1.product.dto.response.GetPopularMoodProductsResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetProductDetailResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetProductListMeta;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetProductListResponse;
@@ -20,6 +21,7 @@ import org.sopt.snappinserver.api.v1.product.dto.response.ProductReviewsResponse
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.product.service.dto.request.GetProductListQuery;
 import org.sopt.snappinserver.domain.product.service.dto.request.ProductReservationCommand;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetPopularMoodProductsResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductListResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductAvailableTimesResult;
@@ -30,6 +32,7 @@ import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewP
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductAvailableTimesUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductClosedDatesUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductDetailUseCase;
+import org.sopt.snappinserver.domain.product.service.usecase.GetPopularMoodProductsUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductListUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductPeopleRangeUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
@@ -53,6 +56,7 @@ public class ProductController implements ProductApi {
     private final PostProductReservationUseCase postProductReservationUseCase;
     private final GetProductDetailUseCase getProductDetailUseCase;
     private final GetProductListUseCase getProductListUseCase;
+    private final GetPopularMoodProductsUseCase getPopularMoodProductsUseCase;
     private final GetProductDurationTimeUseCase getProductDurationTimeUseCase;
 
     @Override
@@ -173,6 +177,19 @@ public class ProductController implements ProductApi {
         GetProductListMeta meta = GetProductListMeta.from(result.cursorMeta());
 
         return ApiResponseBody.ok(ProductSuccessCode.GET_PRODUCT_LIST_OK, response, meta);
+    }
+
+    @Override
+    public ApiResponseBody<GetPopularMoodProductsResponse, Void> getPopularMoodProducts(
+        Long moodId
+    ) {
+        GetPopularMoodProductsResult result =
+            getPopularMoodProductsUseCase.getPopularMoodProducts(moodId);
+
+        return ApiResponseBody.ok(
+            ProductSuccessCode.GET_POPULAR_MOOD_PRODUCTS_OK,
+            GetPopularMoodProductsResponse.from(result)
+        );
     }
 
 }

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetPopularMoodProductItemResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetPopularMoodProductItemResponse.java
@@ -1,0 +1,49 @@
+package org.sopt.snappinserver.api.v1.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import org.sopt.snappinserver.domain.product.service.dto.response.PopularMoodProductItemResult;
+
+@Schema(description = "인기 무드 상품 목록 개별 상품 응답 DTO")
+public record GetPopularMoodProductItemResponse(
+
+    @Schema(description = "상품 ID")
+    Long id,
+
+    @Schema(description = "상품 대표 이미지")
+    String imageUrl,
+
+    @Schema(description = "상품명")
+    String title,
+
+    @Schema(description = "평균 별점")
+    BigDecimal rate,
+
+    @Schema(description = "리뷰 개수")
+    long reviewCount,
+
+    @Schema(description = "상품 등록 작가")
+    String photographer,
+
+    @Schema(description = "상품 가격")
+    int price
+) {
+
+    public static GetPopularMoodProductItemResponse from(PopularMoodProductItemResult result) {
+        BigDecimal rate = result.rate() == null
+            ? BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP)
+            : BigDecimal.valueOf(result.rate())
+                .setScale(1, RoundingMode.HALF_UP);
+
+        return new GetPopularMoodProductItemResponse(
+            result.id(),
+            result.imageUrl(),
+            result.title(),
+            rate,
+            result.reviewCount(),
+            result.photographer(),
+            result.price()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetPopularMoodProductsResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetPopularMoodProductsResponse.java
@@ -1,0 +1,25 @@
+package org.sopt.snappinserver.api.v1.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetPopularMoodProductsResult;
+
+@Schema(description = "인기 무드 상품 목록 응답 DTO")
+public record GetPopularMoodProductsResponse(
+
+    @Schema(description = "무드 태그 이름")
+    String mood,
+
+    @Schema(description = "상품 목록")
+    List<GetPopularMoodProductItemResponse> products
+) {
+
+    public static GetPopularMoodProductsResponse from(GetPopularMoodProductsResult result) {
+        return new GetPopularMoodProductsResponse(
+            result.mood(),
+            result.products().stream()
+                .map(GetPopularMoodProductItemResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/mood/domain/exception/MoodErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/mood/domain/exception/MoodErrorCode.java
@@ -14,6 +14,7 @@ public enum MoodErrorCode implements ErrorCode {
     NAME_TOO_LONG(400, "MOOD_400_003", "무드 이름 길이는 10자 이하입니다."),
     DEFINITION_REQUIRED(400, "MOOD_400_004", "무드 정의가 필요합니다."),
     DEFINITION_TOO_LONG(400, "MOOD_400_005", "무드 정의 길이는 1024자 이하입니다."),
+    MOOD_NOT_FOUND(404, "MOOD_400_006", "존재하지 않는 무드 태그입니다."),
 
     // 401 UNAUTHORIZED
 

--- a/src/main/java/org/sopt/snappinserver/domain/mood/domain/exception/MoodErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/mood/domain/exception/MoodErrorCode.java
@@ -14,7 +14,7 @@ public enum MoodErrorCode implements ErrorCode {
     NAME_TOO_LONG(400, "MOOD_400_003", "무드 이름 길이는 10자 이하입니다."),
     DEFINITION_REQUIRED(400, "MOOD_400_004", "무드 정의가 필요합니다."),
     DEFINITION_TOO_LONG(400, "MOOD_400_005", "무드 정의 길이는 1024자 이하입니다."),
-    MOOD_NOT_FOUND(404, "MOOD_400_006", "존재하지 않는 무드 태그입니다."),
+    MOOD_NOT_FOUND(400, "MOOD_400_006", "존재하지 않는 무드 태그입니다."),
 
     // 401 UNAUTHORIZED
 

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryCustom.java
@@ -6,6 +6,7 @@ import org.sopt.snappinserver.domain.mood.domain.enums.MoodCategory;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
 import org.sopt.snappinserver.domain.product.service.dto.request.GetProductListQuery;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductCardResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.PopularMoodProductItemResult;
 
 public interface ProductRepositoryCustom {
 
@@ -17,5 +18,9 @@ public interface ProductRepositoryCustom {
     );
 
     List<String> findProductMoods(Long productId);
+
+    List<Long> findTopProductIdsByMoodOrderByWishCount(Long moodId, int limit);
+
+    List<PopularMoodProductItemResult> findPopularMoodProductItemsByIds(List<Long> productIds);
 
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
@@ -30,12 +30,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.domain.mood.domain.enums.MoodCategory;
 import org.sopt.snappinserver.domain.portfolio.service.dto.response.LikeStatusProjection;
 import org.sopt.snappinserver.domain.product.domain.enums.ProductOptionCategory;
 import org.sopt.snappinserver.domain.product.service.dto.request.GetProductListQuery;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductCardResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.PopularMoodProductItemResult;
 import org.sopt.snappinserver.global.enums.SnapCategory;
 import org.sopt.snappinserver.global.enums.WeekDay;
 import org.springframework.stereotype.Repository;
@@ -174,6 +178,80 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
             .where(productMood.product.id.eq(productId))
             .orderBy(productMood.id.asc())
             .fetch();
+    }
+
+    @Override
+    public List<Long> findTopProductIdsByMoodOrderByWishCount(Long moodId, int limit) {
+        return jpaQueryFactory
+            .select(product.id)
+            .from(product)
+            .join(productMood).on(productMood.product.id.eq(product.id))
+            .where(productMood.mood.id.eq(moodId))
+            .leftJoin(wishProduct).on(wishProduct.product.id.eq(product.id))
+            .groupBy(product.id)
+            .orderBy(wishProduct.id.count().desc(), product.id.desc())
+            .limit(limit)
+            .fetch();
+    }
+
+    @Override
+    public List<PopularMoodProductItemResult> findPopularMoodProductItemsByIds(
+        List<Long> productIds
+    ) {
+        if (productIds == null || productIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<ProductBaseRow> rows = jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    ProductBaseRow.class,
+                    product.id,
+                    photo.imageUrl,
+                    product.title,
+                    Expressions.numberTemplate(
+                        Double.class,
+                        "round({0}, 1)",
+                        review.rating.avg().coalesce(0.0)
+                    ),
+                    review.id.countDistinct(),
+                    photographer.nickname,
+                    product.price
+                )
+            )
+            .from(product)
+            .join(productPhoto).on(
+                productPhoto.product.id.eq(product.id).and(productPhoto.displayOrder.eq(1))
+            )
+            .join(photo).on(photo.id.eq(productPhoto.photo.id))
+            .leftJoin(reservation).on(reservation.product.id.eq(product.id))
+            .leftJoin(review).on(review.reservation.id.eq(reservation.id))
+            .where(product.id.in(productIds))
+            .groupBy(
+                product.id,
+                photo.imageUrl,
+                product.title,
+                photographer.nickname,
+                product.price
+            )
+            .fetch();
+
+        Map<Long, ProductBaseRow> byId = rows.stream()
+            .collect(Collectors.toMap(ProductBaseRow::id, Function.identity()));
+
+        return productIds.stream()
+            .map(byId::get)
+            .filter(Objects::nonNull)
+            .map(row -> new PopularMoodProductItemResult(
+                row.id(),
+                row.imageUrl(),
+                row.title(),
+                row.rate(),
+                row.reviewCount() == null ? 0L : row.reviewCount(),
+                row.photographerName(),
+                row.price()
+            ))
+            .toList();
     }
 
     private BooleanExpression cursorLt(Long cursor) {

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetPopularMoodProductsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetPopularMoodProductsService.java
@@ -1,0 +1,77 @@
+package org.sopt.snappinserver.domain.product.service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
+import org.sopt.snappinserver.domain.mood.domain.exception.MoodErrorCode;
+import org.sopt.snappinserver.domain.mood.domain.exception.MoodException;
+import org.sopt.snappinserver.domain.mood.repository.MoodRepository;
+import org.sopt.snappinserver.domain.product.repository.ProductRepositoryCustom;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetPopularMoodProductsResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.PopularMoodProductItemResult;
+import org.sopt.snappinserver.domain.product.service.usecase.GetPopularMoodProductsUseCase;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class GetPopularMoodProductsService implements GetPopularMoodProductsUseCase {
+
+    private static final int TOP_BY_WISH_COUNT = 12;
+    private static final int RANDOM_PICK = 4;
+
+    private final MoodRepository moodRepository;
+    private final ProductRepositoryCustom productRepository;
+
+    @Value("${cloud.aws.cloud-front.domain}")
+    private String cloudFrontDomain;
+
+    @Override
+    public GetPopularMoodProductsResult getPopularMoodProducts(Long moodId) {
+        Mood mood = moodRepository.findById(moodId)
+            .orElseThrow(() -> new MoodException(MoodErrorCode.MOOD_NOT_FOUND));
+
+        List<Long> topIds = productRepository.findTopProductIdsByMoodOrderByWishCount(
+            moodId,
+            TOP_BY_WISH_COUNT
+        );
+
+        List<Long> pickedIds = pickRandomSubset(topIds, RANDOM_PICK);
+        List<PopularMoodProductItemResult> items =
+            productRepository.findPopularMoodProductItemsByIds(pickedIds);
+
+        List<PopularMoodProductItemResult> withUrls = items.stream()
+            .map(item -> new PopularMoodProductItemResult(
+                item.id(),
+                toFullImageUrl(item.imageUrl()),
+                item.title(),
+                item.rate(),
+                item.reviewCount(),
+                item.photographer(),
+                item.price()
+            ))
+            .toList();
+
+        return new GetPopularMoodProductsResult(mood.getName(), withUrls);
+    }
+
+    private String toFullImageUrl(String imageUrl) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            return null;
+        }
+        return cloudFrontDomain + imageUrl;
+    }
+
+    private static List<Long> pickRandomSubset(List<Long> ids, int maxPick) {
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        List<Long> copy = new ArrayList<>(ids);
+        Collections.shuffle(copy);
+        return copy.subList(0, Math.min(maxPick, copy.size()));
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetPopularMoodProductsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetPopularMoodProductsService.java
@@ -40,7 +40,7 @@ public class GetPopularMoodProductsService implements GetPopularMoodProductsUseC
             TOP_BY_WISH_COUNT
         );
 
-        List<Long> pickedIds = pickRandomSubset(topIds, RANDOM_PICK);
+        List<Long> pickedIds = pickRandomSubset(topIds);
         List<PopularMoodProductItemResult> items =
             productRepository.findPopularMoodProductItemsByIds(pickedIds);
 
@@ -66,12 +66,12 @@ public class GetPopularMoodProductsService implements GetPopularMoodProductsUseC
         return cloudFrontDomain + imageUrl;
     }
 
-    private static List<Long> pickRandomSubset(List<Long> ids, int maxPick) {
+    private static List<Long> pickRandomSubset(List<Long> ids) {
         if (ids.isEmpty()) {
             return List.of();
         }
         List<Long> copy = new ArrayList<>(ids);
         Collections.shuffle(copy);
-        return copy.subList(0, Math.min(maxPick, copy.size()));
+        return copy.subList(0, Math.min(RANDOM_PICK, copy.size()));
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetPopularMoodProductsResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetPopularMoodProductsResult.java
@@ -1,0 +1,10 @@
+package org.sopt.snappinserver.domain.product.service.dto.response;
+
+import java.util.List;
+
+public record GetPopularMoodProductsResult(
+    String mood,
+    List<PopularMoodProductItemResult> products
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/PopularMoodProductItemResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/PopularMoodProductItemResult.java
@@ -1,0 +1,13 @@
+package org.sopt.snappinserver.domain.product.service.dto.response;
+
+public record PopularMoodProductItemResult(
+    Long id,
+    String imageUrl,
+    String title,
+    Double rate,
+    long reviewCount,
+    String photographer,
+    int price
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetPopularMoodProductsUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetPopularMoodProductsUseCase.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.product.service.usecase;
+
+import org.sopt.snappinserver.domain.product.service.dto.response.GetPopularMoodProductsResult;
+
+public interface GetPopularMoodProductsUseCase {
+
+    GetPopularMoodProductsResult getPopularMoodProducts(Long moodId);
+}

--- a/src/main/java/org/sopt/snappinserver/global/response/code/product/ProductSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/product/ProductSuccessCode.java
@@ -17,6 +17,7 @@ public enum ProductSuccessCode implements SuccessCode {
     GET_PRODUCT_PRICE_OK(200, "PRODUCT_200_006", "상품 기본 촬영 비용 조회에 성공했습니다."),
     GET_PRODUCT_LIST_OK(200, "PRODUCT_200_007", "상품 목록 조회에 성공했습니다."),
     GET_PRODUCT_DURATION_TIME_OK(200, "PRODUCT_200_008", "상품의 촬영 시간 조회에 성공했습니다."),
+    GET_POPULAR_MOOD_PRODUCTS_OK(200, "PRODUCT_200_009", "인기 무드 상품 목록 조회에 성공했습니다."),
 
     // 201 CREATED
     POST_PRODUCT_RESERVATION_OK(201, "PRODUCT_201_001", "상품 예약 생성에 성공했습니다.");


### PR DESCRIPTION
## 👀 Summary

- close #271

<!--관련 있는 Issue를 태그해주세요. (e.g. > - #1) -->

<!--해당 PR에 대한 작업 내용을 요약하여 작성해주세요-->

무드 태그(moodId)를 기준으로, 해당 무드를 가진 상품 중 찜(좋아요) 수 상위 12개를 뽑은 뒤 그중 무작위 4개를 반환하는 API를 구현했습니다.


## 🖇️ Tasks

- [x] 인기 무드 상품 목록 조회 API 엔드포인트 추가 
- [x] 도메인 결과 DTO / API 응답 DTO 정의 및 Swagger 스키마 적용
- [x] 무드 존재 여부 검증 및 도메인 예외(MoodException, MOOD_NOT_FOUND) 적용
- [x] 찜 수 기준 상위 12개 상품 선정 후, 그중 4개 무작위로 선택하는 조회 로직 구현
- [x] QueryDSL 기반 Repository 메서드 추가 (상위 ID 조회, 선택 ID 기준 상품 카드 정보 조회)
- [x] 상품 썸네일 URL에 CloudFront 도메인 적용 (기존 상품 목록과 동일 패턴)
- [x] 성공 응답 코드 추가

<!--해당 PR에 수행한 작업을 작성해주세요.-->

## 🔍 To Reviewer

### ❶ 서비스 로직

**1. 무드 검증**
- MoodRepository로 moodId에 해당하는 무드 존재 여부 확인
- 없으면 MoodException으로 예외 처리

**2. 인기 후보 선정**
- ProductRepositoryCustom으로 해당 무드를 태그로 가진 상품만 대상
- 찜(WishProduct) 수 기준 내림차순으로 상품 ID를 최대 12개 조회

**3. 랜덤 4개 선택**
- 위 ID 목록을 복사한 뒤 shuffle
- 앞에서 최대 4개만 선택

**4. 상품 카드 정보·이미지 URL**
- 선택된 ID로 Repository에서 카드용 필드 조회 (대표 이미지, 제목, 평균 별점, 리뷰 수, 작가 닉네임, 가격)
- DB에는 이미지가 상대 경로로 저장되어 있으므로, 응답 직전 cloud.aws.cloud-front.domain을 붙여 전체 URL로 변환


### ❷ DTO 분리
기존에 사용되던 GetProductCardResult는 상품 카드마다 moods 리스트를 포함합니다.

이번에 추가되는 API 응답 스펙에는 상품 단위 무드 목록이 없어, 필드 구성이 비슷한 PopularMoodProductItemResult / GetPopularMoodProductsResult로 도메인 결과를 분리했습니다. 


### ❸ 랜덤 / 정렬

좋아요 수 같은 경우의 순서는 productId 내림차순으로 고정해 두었고, “12개 중 4개”는 Collections.shuffle로 매 요청마다 달라지도록 했습니다. 후보가 4개 미만이면 가능한 개수만 반환합니다.


> 현재 앱잼 기간동안 연결해놓았던 모든 무드 태그에 대해서 조회가 가능한 상태입니다. 최종 확정된 6개의 무드 태그만 관리가 필요할 것 같은데 무드 태그 전체 조회 응답값 변경 PR 머지되면 해결되는 문제인지 궁금합니다!
