### PR TITLE
[Refactor] #279: 리뷰 등록 API 리뉴얼

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductApi.java
@@ -9,7 +9,9 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
+import org.sopt.snappinserver.api.v1.product.dto.request.CreateProductReviewRequest;
 import org.sopt.snappinserver.api.v1.product.dto.request.ProductReservationRequest;
+import org.sopt.snappinserver.api.v1.product.dto.response.CreateProductReviewResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetPopularMoodProductsResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetProductDetailResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetProductListMeta;
@@ -46,6 +48,21 @@ public interface ProductApi {
 
         @Schema(description = "다음 페이지 조회를 위한 커서 값", example = "6")
         @RequestParam(value = "cursor", required = false) Long cursor
+    );
+
+    @Operation(
+        summary = "상품 리뷰 등록",
+        description = "상품에 대한 리뷰를 작성합니다."
+    )
+    @PostMapping("/{productId}/reviews")
+    ApiResponseBody<CreateProductReviewResponse, Void> createProductReview(
+        @Parameter(hidden = true)
+        CustomUserInfo userInfo,
+
+        @Schema(description = "상품 아이디", example = "1")
+        @PathVariable @NotNull Long productId,
+
+        @Valid @RequestBody CreateProductReviewRequest request
     );
 
     @Operation(

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductController.java
@@ -7,6 +7,7 @@ import org.sopt.snappinserver.api.v1.product.dto.response.ProductDurationTimeRes
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductDurationTimeResult;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductDurationTimeUseCase;
 import org.sopt.snappinserver.global.response.code.product.ProductSuccessCode;
+import org.sopt.snappinserver.api.v1.product.dto.request.CreateProductReviewRequest;
 import org.sopt.snappinserver.api.v1.product.dto.request.ProductReservationRequest;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetPopularMoodProductsResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.GetProductDetailResponse;
@@ -15,11 +16,13 @@ import org.sopt.snappinserver.api.v1.product.dto.response.GetProductListResponse
 import org.sopt.snappinserver.api.v1.product.dto.response.ProductAvailableTimesResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.ProductClosedDatesResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.ProductPeopleRangeResponse;
+import org.sopt.snappinserver.api.v1.product.dto.response.CreateProductReviewResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.ProductReservationResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.ProductReviewsMetaResponse;
 import org.sopt.snappinserver.api.v1.product.dto.response.ProductReviewsResponse;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.product.service.dto.request.GetProductListQuery;
+import org.sopt.snappinserver.domain.product.service.dto.request.CreateProductReviewCommand;
 import org.sopt.snappinserver.domain.product.service.dto.request.ProductReservationCommand;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetPopularMoodProductsResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductListResult;
@@ -27,6 +30,7 @@ import org.sopt.snappinserver.domain.product.service.dto.response.GetProductResu
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductAvailableTimesResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductClosedDatesResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductPeopleRangeResult;
+import org.sopt.snappinserver.domain.product.service.dto.response.CreateProductReviewResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductReservationResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewPageResult;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductAvailableTimesUseCase;
@@ -37,6 +41,7 @@ import org.sopt.snappinserver.domain.product.service.usecase.GetProductListUseCa
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductPeopleRangeUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.PostProductReservationUseCase;
+import org.sopt.snappinserver.domain.product.service.usecase.PostProductReviewUseCase;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -53,6 +58,7 @@ public class ProductController implements ProductApi {
     private final GetProductPeopleRangeUseCase getProductPeopleRangeUseCase;
     private final GetProductClosedDatesUseCase getProductClosedDatesUseCase;
     private final GetProductAvailableTimesUseCase getProductAvailableTimesUseCase;
+    private final PostProductReviewUseCase postProductReviewUseCase;
     private final PostProductReservationUseCase postProductReservationUseCase;
     private final GetProductDetailUseCase getProductDetailUseCase;
     private final GetProductListUseCase getProductListUseCase;
@@ -71,6 +77,28 @@ public class ProductController implements ProductApi {
             ProductSuccessCode.GET_PRODUCT_REVIEWS_OK,
             ProductReviewsResponse.from(result),
             ProductReviewsMetaResponse.from(result)
+        );
+    }
+
+    @Override
+    public ApiResponseBody<CreateProductReviewResponse, Void> createProductReview(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        Long productId,
+        CreateProductReviewRequest request
+    ) {
+        CreateProductReviewCommand command = new CreateProductReviewCommand(
+            userInfo.userId(),
+            productId,
+            request.rating(),
+            request.content(),
+            request.imageUrls()
+        );
+
+        CreateProductReviewResult result = postProductReviewUseCase.createProductReview(command);
+
+        return ApiResponseBody.ok(
+            ProductSuccessCode.POST_PRODUCT_REVIEW_CREATED,
+            CreateProductReviewResponse.from(result)
         );
     }
 

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/request/CreateProductReviewRequest.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/request/CreateProductReviewRequest.java
@@ -1,0 +1,28 @@
+package org.sopt.snappinserver.api.v1.product.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+@Schema(description = "상품 리뷰 등록 요청 DTO")
+public record CreateProductReviewRequest(
+
+    @Schema(description = "리뷰 별점", example = "5", minimum = "1", maximum = "5")
+    @NotNull @Min(1) @Max(5)
+    Integer rating,
+
+    @Schema(description = "리뷰 내용", example = "촬영이 너무 만족스러웠어요!")
+    @NotBlank
+    String content,
+
+    @Schema(
+        description = "리뷰 이미지 URL 목록",
+        example = "[\"https://cdn.example.com/review/1.jpg\", \"https://cdn.example.com/review/2.jpg\"]",
+        nullable = true
+    )
+    List<@NotBlank String> imageUrls
+) {
+}

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/CreateProductReviewResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/CreateProductReviewResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.snappinserver.api.v1.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.snappinserver.domain.product.service.dto.response.CreateProductReviewResult;
+
+@Schema(description = "상품 리뷰 등록 응답 DTO")
+public record CreateProductReviewResponse(
+
+    @Schema(description = "생성된 리뷰 ID", example = "301")
+    Long reviewId,
+
+    @Schema(description = "리뷰가 등록된 상품 ID", example = "12")
+    Long productId
+) {
+
+    public static CreateProductReviewResponse from(CreateProductReviewResult result) {
+        return new CreateProductReviewResponse(
+            result.reviewId(),
+            result.productId()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v1/reservation/controller/ReservationApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/reservation/controller/ReservationApi.java
@@ -10,10 +10,10 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import org.sopt.snappinserver.api.v1.reservation.dto.request.CreateReservationReviewRequest;
 import org.sopt.snappinserver.api.v1.reservation.dto.request.RequestPaymentReservationRequest;
+import org.sopt.snappinserver.api.v1.reservation.dto.response.CreateReservationReviewResponse;
 import org.sopt.snappinserver.api.v1.reservation.dto.response.CancelReservationResponse;
 import org.sopt.snappinserver.api.v1.reservation.dto.response.CompleteReservationResponse;
 import org.sopt.snappinserver.api.v1.reservation.dto.response.ConfirmReservationResponse;
-import org.sopt.snappinserver.api.v1.reservation.dto.response.CreateReservationReviewResponse;
 import org.sopt.snappinserver.api.v1.reservation.dto.response.PayReservationResponse;
 import org.sopt.snappinserver.api.v1.reservation.dto.response.RefuseReservationResponse;
 import org.sopt.snappinserver.api.v1.reservation.dto.response.RequestPaymentReservationResponse;
@@ -32,9 +32,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "010 - Reservation", description = "예약 관련 API")
 public interface ReservationApi {
+
+    @Deprecated
     @Operation(
         summary = "리뷰 등록",
-        description = "촬영 완료된 예약 상품에 대해 리뷰를 작성합니다."
+        description = "상품 리뷰 API로 대체되었습니다. POST /api/v1/products/{productId}/reviews 로 대체해서 사용하세요.",
+        deprecated = true
     )
     @PostMapping("/{reservationId}/reviews")
     ApiResponseBody<CreateReservationReviewResponse, Void> createReview(

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
@@ -10,7 +10,6 @@ import static org.sopt.snappinserver.domain.product.domain.entity.QProduct.produ
 import static org.sopt.snappinserver.domain.product.domain.entity.QProductMood.productMood;
 import static org.sopt.snappinserver.domain.product.domain.entity.QProductOption.productOption;
 import static org.sopt.snappinserver.domain.product.domain.entity.QProductPhoto.productPhoto;
-import static org.sopt.snappinserver.domain.reservation.domain.entity.QReservation.reservation;
 import static org.sopt.snappinserver.domain.review.domain.entity.QReview.review;
 import static org.sopt.snappinserver.domain.wish.domain.entity.QWishProduct.wishProduct;
 
@@ -123,8 +122,13 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                     productPhoto.product.id.eq(product.id).and(productPhoto.displayOrder.eq(1))
                 )
                 .join(photo).on(photo.id.eq(productPhoto.photo.id))
-                .leftJoin(reservation).on(reservation.product.id.eq(product.id))
-                .leftJoin(review).on(review.reservation.id.eq(reservation.id))
+                .leftJoin(review).on(
+                    review.product.id.eq(product.id)
+                        .or(
+                            review.reservation.isNotNull()
+                                .and(review.reservation.product.id.eq(product.id))
+                        )
+                )
                 .where(
                     cursorLt(query.cursor()),
                     photographerEq(query.photographerId()),
@@ -224,8 +228,13 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 productPhoto.product.id.eq(product.id).and(productPhoto.displayOrder.eq(1))
             )
             .join(photo).on(photo.id.eq(productPhoto.photo.id))
-            .leftJoin(reservation).on(reservation.product.id.eq(product.id))
-            .leftJoin(review).on(review.reservation.id.eq(reservation.id))
+            .leftJoin(review).on(
+                review.product.id.eq(product.id)
+                    .or(
+                        review.reservation.isNotNull()
+                            .and(review.reservation.product.id.eq(product.id))
+                    )
+            )
             .where(product.id.in(productIds))
             .groupBy(
                 product.id,

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetProductReviewsService.java
@@ -41,7 +41,7 @@ public class GetProductReviewsService implements GetProductReviewsUseCase {
         validateProductExist(productId);
         validateCursorSize(cursor);
 
-        // 리뷰 조회 (Review + Reservation + User fetch join)
+        // 리뷰 조회 (작성자·예약 경로 fetch join)
         Pageable pageable = PageRequest.of(0, PAGE_SIZE + 1);
         List<Review> reviews =
             (cursor == null)

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/PostProductReviewService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/PostProductReviewService.java
@@ -1,0 +1,75 @@
+package org.sopt.snappinserver.domain.product.service;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.photo.domain.entity.Photo;
+import org.sopt.snappinserver.domain.photo.repository.PhotoRepository;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
+import org.sopt.snappinserver.domain.product.domain.exception.ProductErrorCode;
+import org.sopt.snappinserver.domain.product.domain.exception.ProductException;
+import org.sopt.snappinserver.domain.product.repository.ProductRepository;
+import org.sopt.snappinserver.domain.product.service.dto.request.CreateProductReviewCommand;
+import org.sopt.snappinserver.domain.product.service.dto.response.CreateProductReviewResult;
+import org.sopt.snappinserver.domain.product.service.usecase.PostProductReviewUseCase;
+import org.sopt.snappinserver.domain.review.domain.entity.Review;
+import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
+import org.sopt.snappinserver.domain.review.repository.ProductReviewRepository;
+import org.sopt.snappinserver.domain.review.repository.ReviewPhotoRepository;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
+import org.sopt.snappinserver.domain.user.domain.exception.UserErrorCode;
+import org.sopt.snappinserver.domain.user.domain.exception.UserException;
+import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostProductReviewService implements PostProductReviewUseCase {
+
+    private final ProductRepository productRepository;
+    private final UserRepository userRepository;
+    private final ProductReviewRepository productReviewRepository;
+    private final PhotoRepository photoRepository;
+    private final ReviewPhotoRepository reviewPhotoRepository;
+
+    @Override
+    public CreateProductReviewResult createProductReview(CreateProductReviewCommand command) {
+        User author = getUser(command.userId());
+        Product product = getProduct(command.productId());
+
+        Review review = Review.create(author, product, command.rating(), command.content());
+        productReviewRepository.save(review);
+
+        createAndSaveReviewPhotos(command, review);
+
+        return CreateProductReviewResult.of(review.getId(), product.getId());
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId).orElseThrow(
+            () -> new UserException(UserErrorCode.USER_NOT_FOUND)
+        );
+    }
+
+    private Product getProduct(Long productId) {
+        return productRepository.findById(productId).orElseThrow(
+            () -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND)
+        );
+    }
+
+    private void createAndSaveReviewPhotos(CreateProductReviewCommand command, Review review) {
+        if (!CollectionUtils.isEmpty(command.imageUrls())) {
+            List<Photo> photos = command.imageUrls().stream().map(Photo::create).toList();
+            photoRepository.saveAll(photos);
+
+            List<ReviewPhoto> reviewPhotos = IntStream
+                .range(0, photos.size())
+                .mapToObj(i -> ReviewPhoto.create(review, photos.get(i), i + 1))
+                .toList();
+            reviewPhotoRepository.saveAll(reviewPhotos);
+        }
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/request/CreateProductReviewCommand.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/request/CreateProductReviewCommand.java
@@ -1,0 +1,13 @@
+package org.sopt.snappinserver.domain.product.service.dto.request;
+
+import java.util.List;
+
+public record CreateProductReviewCommand(
+    Long userId,
+    Long productId,
+    Integer rating,
+    String content,
+    List<String> imageUrls
+) {
+
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/CreateProductReviewResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/CreateProductReviewResult.java
@@ -1,0 +1,8 @@
+package org.sopt.snappinserver.domain.product.service.dto.response;
+
+public record CreateProductReviewResult(Long reviewId, Long productId) {
+
+    public static CreateProductReviewResult of(Long reviewId, Long productId) {
+        return new CreateProductReviewResult(reviewId, productId);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewResult.java
@@ -29,7 +29,7 @@ public record ProductReviewResult(
     }
 
     private static String extractReviewer(Review review) {
-        return review.resolveReviewer().getName();
+        return review.resolveReviewerName();
     }
 
     private static LocalDate extractCreatedDate(Review review) {

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/ProductReviewResult.java
@@ -29,9 +29,7 @@ public record ProductReviewResult(
     }
 
     private static String extractReviewer(Review review) {
-        return review.getReservation()
-            .getUser()
-            .getName();
+        return review.resolveReviewer().getName();
     }
 
     private static LocalDate extractCreatedDate(Review review) {

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/PostProductReviewUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/PostProductReviewUseCase.java
@@ -1,0 +1,9 @@
+package org.sopt.snappinserver.domain.product.service.usecase;
+
+import org.sopt.snappinserver.domain.product.service.dto.request.CreateProductReviewCommand;
+import org.sopt.snappinserver.domain.product.service.dto.response.CreateProductReviewResult;
+
+public interface PostProductReviewUseCase {
+
+    CreateProductReviewResult createProductReview(CreateProductReviewCommand command);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
@@ -23,6 +23,7 @@ import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReserva
 import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationDetailReviewResult;
 import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationDetailUseCase;
 import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
+import org.sopt.snappinserver.domain.review.repository.ReservationReviewRepository;
 import org.sopt.snappinserver.domain.review.repository.ReviewPhotoRepository;
 import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,6 +40,7 @@ public class GetReservationDetailService implements GetReservationDetailUseCase 
     private final ProductPhotoRepository productPhotoRepository;
     private final ProductMoodRepository productMoodRepository;
     private final ReviewRepository reviewRepository;
+    private final ReservationReviewRepository reservationReviewRepository;
     private final ReviewPhotoRepository reviewPhotoRepository;
     private final ReservationAdditionalPaymentRepository reservationAdditionalPaymentRepository;
 
@@ -181,14 +183,14 @@ public class GetReservationDetailService implements GetReservationDetailUseCase 
     }
 
     private GetReservationDetailReviewResult mapToReviewResult(Reservation reservation) {
-        return reviewRepository.findByReservation(reservation)
+        return reservationReviewRepository.findFirstByReservationOrderByIdDesc(reservation)
             .map(review -> {
                 List<ReviewPhoto> photos =
                     reviewPhotoRepository.findAllByReviewIds(List.of(review.getId()));
 
                 return new GetReservationDetailReviewResult(
                     review.getId(),
-                    reservation.getUser().getName(),
+                    review.resolveReviewer().getName(),
                     review.getRating(),
                     LocalDate.ofInstant(review.getCreatedAt(), KOREA_ZONE),
                     photos.stream()

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationDetailService.java
@@ -190,7 +190,7 @@ public class GetReservationDetailService implements GetReservationDetailUseCase 
 
                 return new GetReservationDetailReviewResult(
                     review.getId(),
-                    review.resolveReviewer().getName(),
+                    review.resolveReviewerName(),
                     review.getRating(),
                     LocalDate.ofInstant(review.getCreatedAt(), KOREA_ZONE),
                     photos.stream()

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/GetReservationListService.java
@@ -20,6 +20,7 @@ import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReserva
 import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationListProductResult;
 import org.sopt.snappinserver.domain.reservation.service.dto.response.GetReservationListResult;
 import org.sopt.snappinserver.domain.reservation.service.usecase.GetReservationListUseCase;
+import org.sopt.snappinserver.domain.review.repository.ReservationReviewRepository;
 import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -36,6 +37,7 @@ public class GetReservationListService implements GetReservationListUseCase {
 
     private final ReservationRepository reservationRepository;
     private final ReviewRepository reviewRepository;
+    private final ReservationReviewRepository reservationReviewRepository;
     private final ProductMoodRepository productMoodRepository;
     private final ProductPhotoRepository productPhotoRepository;
 
@@ -126,7 +128,7 @@ public class GetReservationListService implements GetReservationListUseCase {
     }
 
     private Set<Long> getReviewedReservationIds(List<Long> reservationIds) {
-        return new HashSet<>(reviewRepository.findReviewedReservationIds(reservationIds));
+        return new HashSet<>(reservationReviewRepository.findReviewedReservationIds(reservationIds));
     }
 
     private Map<Long, ProductReviewStatsResult> getReviewStats(List<Long> productIds) {

--- a/src/main/java/org/sopt/snappinserver/domain/reservation/service/PostReservationReviewService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/reservation/service/PostReservationReviewService.java
@@ -17,8 +17,8 @@ import org.sopt.snappinserver.domain.review.domain.entity.Review;
 import org.sopt.snappinserver.domain.review.domain.entity.ReviewPhoto;
 import org.sopt.snappinserver.domain.review.domain.exception.ReviewErrorCode;
 import org.sopt.snappinserver.domain.review.domain.exception.ReviewException;
+import org.sopt.snappinserver.domain.review.repository.ReservationReviewRepository;
 import org.sopt.snappinserver.domain.review.repository.ReviewPhotoRepository;
-import org.sopt.snappinserver.domain.review.repository.ReviewRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
@@ -29,7 +29,7 @@ import org.springframework.util.CollectionUtils;
 public class PostReservationReviewService implements PostReservationReviewUseCase {
 
     private final ReservationRepository reservationRepository;
-    private final ReviewRepository reviewRepository;
+    private final ReservationReviewRepository reservationReviewRepository;
     private final PhotoRepository photoRepository;
     private final ReviewPhotoRepository reviewPhotoRepository;
 
@@ -46,8 +46,8 @@ public class PostReservationReviewService implements PostReservationReviewUseCas
         validateShootCompleted(reservation);
         validateReviewDuplicated(reservationId);
 
-        Review review = createReview(command, reservation);
-        reviewRepository.save(review);
+        Review review = Review.createForReservation(reservation, command.rating(), command.content());
+        reservationReviewRepository.save(review);
 
         createAndSaveReviewPhotos(command, review);
 
@@ -73,13 +73,9 @@ public class PostReservationReviewService implements PostReservationReviewUseCas
     }
 
     private void validateReviewDuplicated(Long reservationId) {
-        if (reviewRepository.existsByReservationId(reservationId)) {
+        if (reservationReviewRepository.existsByReservationId(reservationId)) {
             throw new ReviewException(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
         }
-    }
-
-    private Review createReview(CreateReservationReviewCommand command, Reservation reservation) {
-        return Review.create(reservation, command.rating(), command.content());
     }
 
     private void createAndSaveReviewPhotos(CreateReservationReviewCommand command, Review review) {
@@ -95,4 +91,3 @@ public class PostReservationReviewService implements PostReservationReviewUseCas
         }
     }
 }
-

--- a/src/main/java/org/sopt/snappinserver/domain/review/domain/entity/Review.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/domain/entity/Review.java
@@ -20,6 +20,7 @@ public class Review extends BaseEntity {
     private static final int MIN_RATING_SCORE = 1;
     private static final int MAX_RATING_SCORE = 5;
     private static final int MAX_CONTENT_LENGTH = 512;
+    private static final String UNKNOWN_REVIEWER_NAME = "알 수 없음";
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "review_seq_gen")
@@ -101,7 +102,11 @@ public class Review extends BaseEntity {
         return reservation != null ? reservation.getUser() : null;
     }
 
-    /** 상품·별점·본문만 검증. 작성자는 서비스에서 조회·검증 후 넘깁니다. */
+    public String resolveReviewerName() {
+        User reviewer = resolveReviewer();
+        return reviewer != null ? reviewer.getName() : UNKNOWN_REVIEWER_NAME;
+    }
+
     private static void validateReview(Product product, Integer rating, String content) {
         validateProduct(product);
         validateRating(rating);

--- a/src/main/java/org/sopt/snappinserver/domain/review/domain/entity/Review.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/domain/entity/Review.java
@@ -38,9 +38,9 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    /** 과거 예약 기반 리뷰만 존재할 수 있으며, 신규 리뷰는 비워 둡니다. */
+    /** 과거 예약 기반 리뷰만 연결 - 상품만으로 작성한 리뷰는 null */
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "reservation_id")
+    @JoinColumn(name = "reservation_id", nullable = true)
     private Reservation reservation;
 
     @Column(nullable = false)

--- a/src/main/java/org/sopt/snappinserver/domain/review/domain/entity/Review.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/domain/entity/Review.java
@@ -5,9 +5,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.sopt.snappinserver.domain.product.domain.entity.Product;
 import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
 import org.sopt.snappinserver.domain.review.domain.exception.ReviewErrorCode;
 import org.sopt.snappinserver.domain.review.domain.exception.ReviewException;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
 import org.sopt.snappinserver.global.entity.BaseEntity;
 
 @Getter
@@ -28,8 +30,17 @@ public class Review extends BaseEntity {
     )
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "reservation_id", nullable = false, unique = true)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    /** 과거 예약 기반 리뷰만 존재할 수 있으며, 신규 리뷰는 비워 둡니다. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id")
     private Reservation reservation;
 
     @Column(nullable = false)
@@ -39,30 +50,67 @@ public class Review extends BaseEntity {
     private String content;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Review(Reservation reservation, Integer rating, String content) {
+    private Review(
+        Product product,
+        User user,
+        Reservation reservation,
+        Integer rating,
+        String content
+    ) {
+        this.product = product;
+        this.user = user;
         this.reservation = reservation;
         this.rating = rating;
         this.content = content;
     }
 
-    public static Review create(Reservation reservation, Integer rating, String content) {
-        validateReview(reservation, rating, content);
+    public static Review create(User author, Product product, Integer rating, String content) {
+        validateReview(product, rating, content);
         return Review.builder()
+            .user(author)
+            .product(product)
+            .reservation(null)
+            .rating(rating)
+            .content(content)
+            .build();
+    }
+
+    /**
+     * v1 예약 기반 리뷰 등록용. 예약의 상품·예약자 정보를 함께 저장합니다.
+     */
+    public static Review createForReservation(Reservation reservation, Integer rating, String content) {
+        if (reservation == null) {
+            throw new ReviewException(ReviewErrorCode.RESERVATION_REQUIRED);
+        }
+        User author = reservation.getUser();
+        Product product = reservation.getProduct();
+        validateReview(product, rating, content);
+        return Review.builder()
+            .user(author)
+            .product(product)
             .reservation(reservation)
             .rating(rating)
             .content(content)
             .build();
     }
 
-    private static void validateReview(Reservation reservation, Integer rating, String content) {
-        validateReservationExists(reservation);
+    public User resolveReviewer() {
+        if (user != null) {
+            return user;
+        }
+        return reservation != null ? reservation.getUser() : null;
+    }
+
+    /** 상품·별점·본문만 검증. 작성자는 서비스에서 조회·검증 후 넘깁니다. */
+    private static void validateReview(Product product, Integer rating, String content) {
+        validateProduct(product);
         validateRating(rating);
         validateContent(content);
     }
 
-    private static void validateReservationExists(Reservation reservation) {
-        if (reservation == null) {
-            throw new ReviewException(ReviewErrorCode.RESERVATION_REQUIRED);
+    private static void validateProduct(Product product) {
+        if (product == null) {
+            throw new ReviewException(ReviewErrorCode.REVIEW_PRODUCT_REQUIRED);
         }
     }
 

--- a/src/main/java/org/sopt/snappinserver/domain/review/domain/exception/ReviewErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/domain/exception/ReviewErrorCode.java
@@ -18,6 +18,7 @@ public enum ReviewErrorCode implements ErrorCode {
     REVIEW_ALREADY_EXISTS(400, "REVIEW_400_007", "이미 존재하는 리뷰입니다."),
     UNSUPPORTED_IMAGE_TYPE(400, "REVIEW_400_008", "지원하지 않는 파일 형식입니다."),
     INVALID_FILE_NAME(400, "REVIEW_400_009", "지원하지 않는 파일 확장자입니다."),
+    REVIEW_PRODUCT_REQUIRED(400, "REVIEW_400_010", "리뷰 대상 상품은 필수입니다."),
 
     // 401 UNAUTHORIZED
 

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ProductReviewRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ProductReviewRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.snappinserver.domain.review.repository;
+
+import org.sopt.snappinserver.domain.review.domain.entity.Review;
+
+/**
+ * 상품 기반 리뷰 등록 전용
+ * 실제 저장·조회는 ReviewRepository에 위임
+ */
+public interface ProductReviewRepository {
+
+    Review save(Review review);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ProductReviewRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ProductReviewRepositoryImpl.java
@@ -1,0 +1,17 @@
+package org.sopt.snappinserver.domain.review.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.review.domain.entity.Review;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductReviewRepositoryImpl implements ProductReviewRepository {
+
+    private final ReviewRepository reviewRepository;
+
+    @Override
+    public Review save(Review review) {
+        return reviewRepository.save(review);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ReservationReviewRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ReservationReviewRepository.java
@@ -1,0 +1,21 @@
+package org.sopt.snappinserver.domain.review.repository;
+
+import java.util.List;
+import java.util.Optional;
+import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
+import org.sopt.snappinserver.domain.review.domain.entity.Review;
+
+/**
+ * 예약 기반 리뷰 등록 전용
+ * 실제 저장·조회는 ReviewRepository에 위임
+ */
+public interface ReservationReviewRepository {
+
+    boolean existsByReservationId(Long reservationId);
+
+    Optional<Review> findFirstByReservationOrderByIdDesc(Reservation reservation);
+
+    List<Long> findReviewedReservationIds(List<Long> reservationIds);
+
+    Review save(Review review);
+}

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ReservationReviewRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ReservationReviewRepositoryImpl.java
@@ -1,0 +1,35 @@
+package org.sopt.snappinserver.domain.review.repository;
+
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.domain.reservation.domain.entity.Reservation;
+import org.sopt.snappinserver.domain.review.domain.entity.Review;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReservationReviewRepositoryImpl implements ReservationReviewRepository {
+
+    private final ReviewRepository reviewRepository;
+
+    @Override
+    public boolean existsByReservationId(Long reservationId) {
+        return reviewRepository.existsByReservation_Id(reservationId);
+    }
+
+    @Override
+    public Optional<Review> findFirstByReservationOrderByIdDesc(Reservation reservation) {
+        return reviewRepository.findFirstByReservationOrderByIdDesc(reservation);
+    }
+
+    @Override
+    public List<Long> findReviewedReservationIds(List<Long> reservationIds) {
+        return reviewRepository.findReviewedReservationIds(reservationIds);
+    }
+
+    @Override
+    public Review save(Review review) {
+        return reviewRepository.save(review);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
@@ -11,18 +11,26 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+/**
+ * 리뷰 Spring Data 저장 - 상품·예약 혼합 조회·통계 등 공용 쿼리
+ * 예약 전용·상품 전용 쓰기/예약 조회 경계는 ReservationReviewRepository,ProductReviewRepository가 위임
+ */
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    boolean existsByReservationId(Long reservationId);
+    boolean existsByReservation_Id(Long reservationId);
 
     // 리뷰 목록 첫 페이지 조회 (cursor 없음)
     @Query("""
-            select review
+            select distinct review
             from Review review
-            join fetch review.reservation reservation
-            join fetch reservation.user user
-            where reservation.product.id = :productId
+            left join fetch review.user author
+            left join fetch review.reservation reservation
+            left join fetch reservation.user reservationUser
+            where (
+                (review.product is not null and review.product.id = :productId)
+                or (review.reservation is not null and review.reservation.product.id = :productId)
+            )
             order by review.id desc
         """)
     List<Review> findReviewsWithUserByProductId(
@@ -32,11 +40,15 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     // 커서 이후 리뷰 목록 페이지 조회
     @Query("""
-            select review
+            select distinct review
             from Review review
-            join fetch review.reservation reservation
-            join fetch reservation.user user
-            where reservation.product.id = :productId
+            left join fetch review.user author
+            left join fetch review.reservation reservation
+            left join fetch reservation.user reservationUser
+            where (
+                (review.product is not null and review.product.id = :productId)
+                or (review.reservation is not null and review.reservation.product.id = :productId)
+            )
               and review.id < :cursor
             order by review.id desc
         """)
@@ -53,8 +65,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             cast(round(avg(r.rating), 1) as double)
         )
         from Review r
-        join r.reservation res
-        where res.product.id = :productId
+        where (
+            (r.product is not null and r.product.id = :productId)
+            or (r.reservation is not null and r.reservation.product.id = :productId)
+        )
         """)
     ProductReviewStatsResult findReviewStatsByProductId(
         @Param("productId") Long productId
@@ -63,15 +77,17 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     // 상품 리뷰 통계 수치 여러 개 배치 조회
     @Query("""
         select
-            res.product.id,
+            case when r.product is not null then r.product.id else r.reservation.product.id end,
             new org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult(
                 count(r),
                 cast(round(avg(r.rating), 1) as double)
             )
         from Review r
-        join r.reservation res
-        where res.product.id in :productIds
-        group by res.product.id
+        where (
+            (r.product is not null and r.product.id in :productIds)
+            or (r.reservation is not null and r.reservation.product.id in :productIds)
+        )
+        group by case when r.product is not null then r.product.id else r.reservation.product.id end
         """)
     List<Object[]> findReviewStatsByProductIds(@Param("productIds") List<Long> productIds);
 
@@ -85,9 +101,5 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         @Param("reservationIds") List<Long> reservationIds
     );
 
-    // 예약 기준 리뷰 단일 조회
-    Optional<Review> findByReservation(Reservation reservation);
-
+    Optional<Review> findFirstByReservationOrderByIdDesc(Reservation reservation);
 }
-
-

--- a/src/main/java/org/sopt/snappinserver/domain/review/service/GetReviewDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/service/GetReviewDetailService.java
@@ -41,7 +41,7 @@ public class GetReviewDetailService implements GetReviewDetailUseCase {
 
         return new GetReviewDetailResult(
             review.getId(),
-            review.getReservation().getUser().getName(),
+            review.resolveReviewer().getName(),
             review.getRating(),
             review.getCreatedAt().atZone(KOREA_ZONE).toLocalDate(),
             images,

--- a/src/main/java/org/sopt/snappinserver/domain/review/service/GetReviewDetailService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/service/GetReviewDetailService.java
@@ -41,7 +41,7 @@ public class GetReviewDetailService implements GetReviewDetailUseCase {
 
         return new GetReviewDetailResult(
             review.getId(),
-            review.resolveReviewer().getName(),
+            review.resolveReviewerName(),
             review.getRating(),
             review.getCreatedAt().atZone(KOREA_ZONE).toLocalDate(),
             images,

--- a/src/main/java/org/sopt/snappinserver/global/response/code/product/ProductSuccessCode.java
+++ b/src/main/java/org/sopt/snappinserver/global/response/code/product/ProductSuccessCode.java
@@ -20,7 +20,8 @@ public enum ProductSuccessCode implements SuccessCode {
     GET_POPULAR_MOOD_PRODUCTS_OK(200, "PRODUCT_200_009", "인기 무드 상품 목록 조회에 성공했습니다."),
 
     // 201 CREATED
-    POST_PRODUCT_RESERVATION_OK(201, "PRODUCT_201_001", "상품 예약 생성에 성공했습니다.");
+    POST_PRODUCT_RESERVATION_OK(201, "PRODUCT_201_001", "상품 예약 생성에 성공했습니다."),
+    POST_PRODUCT_REVIEW_CREATED(201, "PRODUCT_201_002", "상품 리뷰 등록에 성공했습니다.");
 
     private final int status;
     private final String code;


### PR DESCRIPTION
## 👀 Summary

- close #279

<!--관련 있는 Issue를 태그해주세요. (e.g. > - #1) -->

리뷰 등록을 예약 단위에서 상품 단위로 확장했습니다. 
로그인한 사용자는 예약 여부와 관계없이 POST `/api/v1/products/{productId}/reviews`로 리뷰를 남길 수 있고, 동일 상품에 동일 사용자가 여러 번 작성할 수 있습니다.  기존 POST` /api/v1/reservations/{reservationId}/reviews`는 동작·요청/응답 스펙을 유지하되 deprecated 처리했습니다.

Review 엔티티에 product·user 연관을 추가하고 reservation은 선택적으로 두었으며, 조회·집계 쿼리는 상품 기준으로 예약/비예약 데이터를 함께 보도록 구조를 변경했습니다.


## 🖇️ Tasks
- [x] 상품 리뷰 등록 API 구현 및 성공 코드 추가
- [x] 예약 리뷰 등록 API deprecated
- [x] Review 엔티티·레포지토리·서비스(상품/예약) 반영 및 조회·집계 수정
- [x] ReservationReviewRepository / ProductReviewRepository 파사드 유지
- [x] DB 변경사항 적용



<!--해당 PR에 수행한 작업을 작성해주세요.-->

## 🔍 To Reviewer

### ❶ 리뷰 전체 흐름 변경 배경
리뷰는 원래 예약 1건 : 리뷰 1건에 가깝게 모델링되어 있었고, 예약을 통해서만 상품과 연결되는 구조였습니다. 

요구사항이 예약·촬영 여부와 무관하게, 로그인한 사용자가 상품 기준으로 리뷰를 남길 수 있게 바뀌면서, 저장 구조와 등록 유스케이스를 어떻게 나눌지 고민했습니다!

### ❷ 예약 기준 vs 상품 기준을 나눈 이유

예약 플로우에는 기존에 내가 잡은 예약 건에 대한 후기가 남아 있고, 본인 예약 / 촬영 완료 / 예약당 1리뷰 같은 규칙이 요구사항과 맞습니다. 그래서 PostReservationReviewService로 유지하고, 기존 API는 스펙을 깨지 않되 deprecated로 두었습니다.

상품 플로우는 예약 엔티티 없이도 의미가 있으므로, Product + 작성자 User를 리뷰에 직접 두고 Reservation은 선택으로 두었습니다. 신규 상품 리뷰는 reservation = null로 들어갑니다.
읽기 쪽에서는 한 상품에 달린 모든 리뷰를 한 번에 보여줘야 하므로, 한 테이블(review)에 두 종류가 공존하는 전제로 조회·집계를 설계했습니다.

### ❸ 엔티티(Review) 작업 사항

- **product, user**를 @ManyToOne으로 추가
- **reservation**은 @ManyToOne + nullable = true (상품만 리뷰 시 NULL)
- create(author, product, …): 상품 리뷰 등록. reservation 없음
- createForReservation(reservation, …): 예약 리뷰 등록. 예약에서 user/product를 꺼내 함께 세팅해, 조회 시 항상 직접 연관으로도 접근 가능하게 함
- resolveReviewer(): user가 있으면 사용, 없으면 예약만 붙은 레거시 행을 위해 reservation.getUser() 사용

### ❹ 저장소: ReviewRepository와 파사드
ReviewRepository는 Spring Data 구현체 + JPQL로 상품별 목록·통계·예약 ID 목록 등 공용 조회를 담당하고,
ProductReviewRepository / ReservationReviewRepository는 ReviewRepository에 위임만 하는 파사드입니다.

테이블 분리가 아니라 쓰기/예약 연동 조회의 진입점을 코드상으로 나누기 위함이었습니다!


### ❺ 등록 흐름 
#### 상품 기준 (신규)

1. 클라이언트가 **POST /api/v1/products/{productId}/reviews**로 별점·본문·이미지 URL을 보냅니다. 경로의 productId가 리뷰 대상 상품입니다.
2. **PostProductReviewService**에서 JWT로 얻은 userId로 작성자를 조회하고, productId로 상품을 조회합니다. 둘 다 없으면 각각 유저/상품 예외로 끝납니다.
3. **Review.create(author, product, rating, content)**로 엔티티를 만들면 product·user는 채워지고 reservation은 null인 행이 됩니다.
4. **ProductReviewRepository.save**는 내부적으로 **ReviewRepository(JpaRepository)**에 위임해 review 테이블에 INSERT합니다.
5. 이미지 URL이 있으면 Photo를 만들고 저장한 뒤, 그 순서대로 **ReviewPhoto**로 리뷰와 묶어 저장합니다. (기존 예약 리뷰와 같은 방식)

#### 예약 기준 (deprecated, 기존 호환)
1.  **POST /api/v1/reservations/{reservationId}/reviews**는 예약 ID로 동작합니다.
2. **PostReservationReviewService**에서 예약을 조회한 뒤, 본인 예약인지·촬영 완료인지·해당 예약에 이미 리뷰가 있는지를 검사합니다. (예전과 같은 비즈니스 의도)
3. **Review.createForReservation(reservation, …)**에서 예약으로부터 user·product를 꺼내 함께 넣고, reservation FK도 연결합니다. 그래서 예약으로 등록된 리뷰도 조회·집계 시 product/user로 일관되게 잡을 수 있습니다.
4. ReservationReviewRepository.save 역시 ReviewRepository에 위임해 INSERT합니다.
5. 이미지 처리는 상품 플로우와 동일하게 **Photo + ReviewPhoto**입니다.

> 상품 플로우는 “상품 + 작성자만으로 리뷰 행을 만들고 예약은 비우고”, 예약 플로우는 “예약을 통해서 같은 행에 예약·상품·작성자를 모두 채운다”는 차이입니다!

### ❻ 리뷰 조회·집계 방식 변경
예전에는 리뷰가 항상 예약을 거쳐 상품에 도달했기 때문에, 상품 기준으로 볼 때 예약 → 상품 한 경로만 보면 됐습니다.

지금은 (1) product에 직접 붙은 리뷰와 (2) reservation만으로 연결된 예전 데이터가 같이 있으므로, 특정 productId의 리뷰는 다음을 모두 포함해야 합니다.

- review.product.id = productId
- review.reservation.product.id = productId (예약 경로만 있는 행)

따라서 JPQL·QueryDSL·상품 카드 집계에서 이 OR 조건을 반영했습니다. 그래야 상품 상세·리뷰 목록·평균 별점이 신규·기존 데이터를 같이 보여줍니다!

### ❼ DB 마이그레이션 관련

### 1) review — 상품 리뷰 시 reservation_id가 NULL이 됨
review.reservation_id가 NOT NULL이면 상품만으로 리뷰를 넣을 때 INSERT가 실패합니다.

```
ALTER TABLE review
    ALTER COLUMN reservation_id DROP NOT NULL;
```

#### 2) review — product_id, user_id (없을 때만)

```
ALTER TABLE review
    ADD COLUMN IF NOT EXISTS product_id BIGINT,
    ADD COLUMN IF NOT EXISTS user_id BIGINT;
```

**기존에 예약으로만 연결돼 있던 행을 맞추려면(선택)**

```
UPDATE review r
SET
    product_id = res.product_id,
    user_id = res.user_id
FROM reservation res
WHERE r.reservation_id = res.id
  AND (r.product_id IS NULL OR r.user_id IS NULL);
```

**3) portfolio — created_at / updated_at (BaseEntity)**
컬럼이 없으면 추가한 뒤 NOT NULL로 맞춥니다.

```
ALTER TABLE portfolio ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ;
ALTER TABLE portfolio ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ;
UPDATE portfolio
SET created_at = NOW(), updated_at = NOW()
WHERE created_at IS NULL OR updated_at IS NULL;
ALTER TABLE portfolio ALTER COLUMN created_at SET NOT NULL;
ALTER TABLE portfolio ALTER COLUMN updated_at SET NOT NULL;
```


**4) 시퀀스와 MAX(id) 불일치 시 (INSERT 시 PK 중복 오류가 날 때)**
photo / review 등 INSERT 시 duplicate key / PK 위반이 나면 시퀀스를 테이블 최대 id에 맞춥니다.

```
SELECT setval('photo_seq', COALESCE((SELECT MAX(id) FROM photo), 1));
SELECT setval('review_seq', COALESCE((SELECT MAX(id) FROM review), 1));
```

> 리뷰 시 유스케이스 분리, 조회 WHERE가 두 경로를 커버하는지, DB 제약이 엔티티 nullable과 맞는지 위주로 봐 주시면 감사하겠습니다.