### PR TITLE
[FIX] #279: 상품 리뷰 조인·평균 별점 서브쿼리 수정

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
@@ -130,13 +130,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                     productPhoto.product.id.eq(product.id).and(productPhoto.displayOrder.eq(1))
                 )
                 .join(photo).on(photo.id.eq(productPhoto.photo.id))
-                .leftJoin(review).on(
-                    review.product.id.eq(product.id)
-                        .or(
-                            review.reservation.isNotNull()
-                                .and(review.reservation.product.id.eq(product.id))
-                        )
-                )
+                .leftJoin(review).on(review.product.id.eq(product.id))
                 .where(
                     cursorLt(query.cursor()),
                     photographerEq(query.photographerId()),
@@ -190,18 +184,11 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
         QWishProduct wishProductSub = new QWishProduct("wishProductSub");
         SortType sort = query.sort() == null ? SortType.RECOMMENDED : query.sort();
 
-        // review 조인으로 행이 늘어나도 동일 찜 행이 중복 집계되지 않도록 distinct
         NumberExpression<Long> likeCount = wishProduct.id.countDistinct();
         JPQLQuery<Double> avgRatingSub = JPAExpressions
             .select(Expressions.numberTemplate(Double.class, "round(avg({0}), 1)", review.rating))
             .from(review)
-            .where(
-                review.product.id.eq(product.id)
-                    .or(
-                        review.reservation.isNotNull()
-                            .and(review.reservation.product.id.eq(product.id))
-                    )
-            );
+            .where(review.product.id.eq(product.id));
 
         BooleanExpression liked = query.userId() == null
             ? Expressions.FALSE
@@ -235,13 +222,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
             )
             .join(photo).on(photo.id.eq(productPhoto.photo.id))
             .leftJoin(wishProduct).on(wishProduct.product.id.eq(product.id))
-            .leftJoin(review).on(
-                review.product.id.eq(product.id)
-                    .or(
-                        review.reservation.isNotNull()
-                            .and(review.reservation.product.id.eq(product.id))
-                    )
-            )
+            .leftJoin(review).on(review.product.id.eq(product.id))
             .where(
                 photographerEq(query.photographerId()),
                 snapCategoryEq(query.snapCategory()),
@@ -396,13 +377,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 productPhoto.product.id.eq(product.id).and(productPhoto.displayOrder.eq(1))
             )
             .join(photo).on(photo.id.eq(productPhoto.photo.id))
-            .leftJoin(review).on(
-                review.product.id.eq(product.id)
-                    .or(
-                        review.reservation.isNotNull()
-                            .and(review.reservation.product.id.eq(product.id))
-                    )
-            )
+            .leftJoin(review).on(review.product.id.eq(product.id))
             .where(product.id.in(productIds))
             .groupBy(
                 product.id,

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
@@ -194,8 +194,13 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
         JPQLQuery<Double> avgRatingSub = JPAExpressions
             .select(Expressions.numberTemplate(Double.class, "round(avg({0}), 1)", review.rating))
             .from(review)
-            .join(review.reservation, reservation)
-            .where(reservation.product.id.eq(product.id));
+            .where(
+                review.product.id.eq(product.id)
+                    .or(
+                        review.reservation.isNotNull()
+                            .and(review.reservation.product.id.eq(product.id))
+                    )
+            );
 
         BooleanExpression liked = query.userId() == null
             ? Expressions.FALSE
@@ -229,8 +234,13 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
             )
             .join(photo).on(photo.id.eq(productPhoto.photo.id))
             .leftJoin(wishProduct).on(wishProduct.product.id.eq(product.id))
-            .leftJoin(reservation).on(reservation.product.id.eq(product.id))
-            .leftJoin(review).on(review.reservation.id.eq(reservation.id))
+            .leftJoin(review).on(
+                review.product.id.eq(product.id)
+                    .or(
+                        review.reservation.isNotNull()
+                            .and(review.reservation.product.id.eq(product.id))
+                    )
+            )
             .where(
                 photographerEq(query.photographerId()),
                 snapCategoryEq(query.snapCategory()),

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
@@ -190,7 +190,8 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
         QWishProduct wishProductSub = new QWishProduct("wishProductSub");
         SortType sort = query.sort() == null ? SortType.RECOMMENDED : query.sort();
 
-        NumberExpression<Long> likeCount = wishProduct.id.count();
+        // review 조인으로 행이 늘어나도 동일 찜 행이 중복 집계되지 않도록 distinct
+        NumberExpression<Long> likeCount = wishProduct.id.countDistinct();
         JPQLQuery<Double> avgRatingSub = JPAExpressions
             .select(Expressions.numberTemplate(Double.class, "round(avg({0}), 1)", review.rating))
             .from(review)


### PR DESCRIPTION
## 👀 Summary

- close #279 

<!--관련 있는 Issue를 태그해주세요. (e.g. > - #1) -->

findProductCardsV2에서 reservation QueryDSL 별칭을 사용하는 코드가 QReservation static import 없이 컴파일되지 않아 CI에 실패했고, findProducts / 인기 무드 조회와 동일하게 review.product 또는 review.reservation.product가 현재 상품과 일치하는 리뷰를 모두 포함하도록 서브쿼리·메인 조인을 수정했습니다.


<!--해당 PR에 대한 작업 내용을 요약하여 작성해주세요-->


## 🖇️ Tasks

- [x] V2 상품 카드 QueryDSL 리뷰 조인·평균 별점 서브쿼리 수정

<!--해당 PR에 수행한 작업을 작성해주세요.-->

## 🔍 To Reviewer

### ❶ 원인

 findProductCardsV2 안에서 `.join(review.reservation, reservation)`의 두 번째 인자는 QReservation의 별칭인데, QReservation의 import문이 누락되어 reservation을 변수로 찾지 못했고, 그 결과 `reservation.product`가 패키지 `reservation.product`처럼 해석되면서 `package reservation.product does not exist`가 발생했습니다.

### ❷  변경 사항
1. 평균 별점 서브쿼리에서 reservation 조인을 제거한 후 review만 두고 `review.product = 외부 product` 또는 `review.reservation.product = 외부 product` 조건으로 where 정리
2. 메인 쿼리 리뷰 조인에서 `leftJoin(reservation)` + `leftJoin(review)` 체인을 제거한 후,  단일 `leftJoin(review`) + 위와 동일한 OR 조건으로 처리

이렇게 상품만 걸려 있는 리뷰 + 예약으로 묶인 리뷰가 모두 조인에 들어가고, reservation 별칭 자체가 필요 없어져 CI도 통과합니다.

### ❸ QReservation import로 해결하지 않은 이유

import만 추가해도 빌드는 통과합니다.

다만 기존 조인은 예약을 통해서만 상품과 연결된 리뷰만 집계해, reservation_id가 null이고 product_id만 있는 상품 단독 리뷰가 평균 별점·리뷰 수에 반영되지 않을 수 있어서 근본적인 문제를 해결했어요!


<!--리뷰어에게 요청하는 내용을 작성해주세요-->
