### PR TITLE
[REFACTOR] 인기 무드 상품 조회 응답에 좋아요 여부 추가

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductApi.java
@@ -174,7 +174,10 @@ public interface ProductApi {
     )
     @GetMapping("/popular")
     ApiResponseBody<GetPopularMoodProductsResponse, Void> getPopularMoodProducts(
-        @Schema(description = "무드 태그 아이디", example = "1")
+        @Parameter(hidden = true)
+        CustomUserInfo principal,
+
+        @Parameter(description = "무드 태그 아이디", example = "1")
         @RequestParam @NotNull @Positive Long moodId
     );
 

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductController.java
@@ -45,10 +45,13 @@ import org.sopt.snappinserver.domain.product.service.usecase.GetProductPeopleRan
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.PostProductReservationUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.PostProductReviewUseCase;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/products")
@@ -213,10 +216,12 @@ public class ProductController implements ProductApi {
 
     @Override
     public ApiResponseBody<GetPopularMoodProductsResponse, Void> getPopularMoodProducts(
-        Long moodId
+        @AuthenticationPrincipal CustomUserInfo principal,
+        @RequestParam @NotNull @Positive Long moodId
     ) {
+        Long userId = principal != null ? principal.userId() : null;
         GetPopularMoodProductsResult result =
-            getPopularMoodProductsUseCase.getPopularMoodProducts(moodId);
+            getPopularMoodProductsUseCase.getPopularMoodProducts(moodId, userId);
 
         return ApiResponseBody.ok(
             ProductSuccessCode.GET_POPULAR_MOOD_PRODUCTS_OK,

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetPopularMoodProductItemResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetPopularMoodProductItemResponse.java
@@ -1,6 +1,5 @@
 package org.sopt.snappinserver.api.v1.product.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -30,7 +29,6 @@ public record GetPopularMoodProductItemResponse(
     @Schema(description = "상품 가격")
     int price,
 
-    @JsonProperty("isLiked")
     @Schema(description = "좋아요 여부 (비로그인 시 항상 false)")
     boolean isLiked
 ) {

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetPopularMoodProductItemResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetPopularMoodProductItemResponse.java
@@ -27,7 +27,10 @@ public record GetPopularMoodProductItemResponse(
     String photographer,
 
     @Schema(description = "상품 가격")
-    int price
+    int price,
+
+    @Schema(description = "좋아요 여부 (비로그인 시 항상 false)")
+    boolean isLiked
 ) {
 
     public static GetPopularMoodProductItemResponse from(PopularMoodProductItemResult result) {
@@ -43,7 +46,8 @@ public record GetPopularMoodProductItemResponse(
             rate,
             result.reviewCount(),
             result.photographer(),
-            result.price()
+            result.price(),
+            result.isLiked()
         );
     }
 }

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetPopularMoodProductItemResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/dto/response/GetPopularMoodProductItemResponse.java
@@ -1,5 +1,6 @@
 package org.sopt.snappinserver.api.v1.product.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -29,6 +30,7 @@ public record GetPopularMoodProductItemResponse(
     @Schema(description = "상품 가격")
     int price,
 
+    @JsonProperty("isLiked")
     @Schema(description = "좋아요 여부 (비로그인 시 항상 false)")
     boolean isLiked
 ) {

--- a/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/repository/ProductRepositoryImpl.java
@@ -401,7 +401,8 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 row.rate(),
                 row.reviewCount() == null ? 0L : row.reviewCount(),
                 row.photographerName(),
-                row.price()
+                row.price(),
+                false
             ))
             .toList();
     }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/GetPopularMoodProductsService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/GetPopularMoodProductsService.java
@@ -2,13 +2,16 @@ package org.sopt.snappinserver.domain.product.service;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.domain.mood.domain.entity.Mood;
 import org.sopt.snappinserver.domain.mood.domain.exception.MoodErrorCode;
 import org.sopt.snappinserver.domain.mood.domain.exception.MoodException;
 import org.sopt.snappinserver.domain.mood.repository.MoodRepository;
 import org.sopt.snappinserver.domain.product.repository.ProductRepositoryCustom;
+import org.sopt.snappinserver.domain.wish.repository.WishProductRepository;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetPopularMoodProductsResult;
 import org.sopt.snappinserver.domain.product.service.dto.response.PopularMoodProductItemResult;
 import org.sopt.snappinserver.domain.product.service.usecase.GetPopularMoodProductsUseCase;
@@ -26,12 +29,13 @@ public class GetPopularMoodProductsService implements GetPopularMoodProductsUseC
 
     private final MoodRepository moodRepository;
     private final ProductRepositoryCustom productRepository;
+    private final WishProductRepository wishProductRepository;
 
     @Value("${cloud.aws.cloud-front.domain}")
     private String cloudFrontDomain;
 
     @Override
-    public GetPopularMoodProductsResult getPopularMoodProducts(Long moodId) {
+    public GetPopularMoodProductsResult getPopularMoodProducts(Long moodId, Long userId) {
         Mood mood = moodRepository.findById(moodId)
             .orElseThrow(() -> new MoodException(MoodErrorCode.MOOD_NOT_FOUND));
 
@@ -44,6 +48,8 @@ public class GetPopularMoodProductsService implements GetPopularMoodProductsUseC
         List<PopularMoodProductItemResult> items =
             productRepository.findPopularMoodProductItemsByIds(pickedIds);
 
+        Set<Long> likedProductIds = resolveLikedProductIds(userId, pickedIds);
+
         List<PopularMoodProductItemResult> withUrls = items.stream()
             .map(item -> new PopularMoodProductItemResult(
                 item.id(),
@@ -52,11 +58,22 @@ public class GetPopularMoodProductsService implements GetPopularMoodProductsUseC
                 item.rate(),
                 item.reviewCount(),
                 item.photographer(),
-                item.price()
+                item.price(),
+                likedProductIds.contains(item.id())
             ))
             .toList();
 
         return new GetPopularMoodProductsResult(mood.getName(), withUrls);
+    }
+
+    private Set<Long> resolveLikedProductIds(Long userId, List<Long> productIds) {
+        if (userId == null || productIds.isEmpty()) {
+            return Set.of();
+        }
+        return new HashSet<>(wishProductRepository.findProductIdsByUserIdAndProductIdIn(
+            userId,
+            productIds
+        ));
     }
 
     private String toFullImageUrl(String imageUrl) {

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/PopularMoodProductItemResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/PopularMoodProductItemResult.java
@@ -7,7 +7,8 @@ public record PopularMoodProductItemResult(
     Double rate,
     long reviewCount,
     String photographer,
-    int price
+    int price,
+    boolean isLiked
 ) {
 
 }

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetPopularMoodProductsUseCase.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/usecase/GetPopularMoodProductsUseCase.java
@@ -4,5 +4,5 @@ import org.sopt.snappinserver.domain.product.service.dto.response.GetPopularMood
 
 public interface GetPopularMoodProductsUseCase {
 
-    GetPopularMoodProductsResult getPopularMoodProducts(Long moodId);
+    GetPopularMoodProductsResult getPopularMoodProducts(Long moodId, Long userId);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishProductRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/wish/repository/WishProductRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.snappinserver.domain.wish.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.sopt.snappinserver.domain.product.domain.entity.Product;
@@ -13,6 +14,17 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WishProductRepository extends JpaRepository<WishProduct, Long> {
+
+    @Query("""
+            select wp.product.id
+            from WishProduct wp
+            where wp.user.id = :userId
+              and wp.product.id in :productIds
+        """)
+    List<Long> findProductIdsByUserIdAndProductIdIn(
+        @Param("userId") Long userId,
+        @Param("productIds") Collection<Long> productIds
+    );
 
     Optional<WishProduct> findByUserAndProduct(User user, Product product);
 


### PR DESCRIPTION
## 👀 Summary

- close #282

인기 무드 상품 조회 API의 응답 스펙에 좋아요 여부 필드를 추가했습니다.


## 🖇️ Tasks

- [x] 로그인 사용자·상품 ID 목록에 대한 좋아요 상품 ID 배치 조회 (N+1 방지)
- [x] DTO에 좋아요 여부 필드 추가 

<!--해당 PR에 수행한 작업을 작성해주세요.-->

## 🔍 To Reviewer

### ❶ 서비스 로직
- **로그인 시** principal이 있으면 userId를 꺼내, 이번에 내려줄 상품 ID들에 대해 WishProduct로 찜한 상품 ID만 한 번에 조회한 뒤, 상품별로 isLiked를 맞춥니다.

- **비로그인 시** principal이 없으면(비로그인) 좋아요 조회를 자체를 수행하지 않으며, isLiked는 항상 false입니다.

### ❷ 레포지토리 관련
findPopularMoodProductItemsByIds에서는 상품 카드용 조회·매핑만 담당하며, PopularMoodProductItemResult의 isLiked 자리에는 매핑 편의상 false를 넣은 임시값만 두었습니다. 실제 좋아요 여부는 서비스 레이어에서 WishProduct 배치 조회 결과로 PopularMoodProductItemResult를 다시 생성하면서 isLiked를 덮어쓰도록 했습니다.

따라서 userId를 Repository까지 넘기지 않는 것은 의도이며, 찜 여부는 위시 전용 쿼리와 상품 카드 쿼리를 서비스에서 조합하는 구조라고 봐주시면 됩니다!

