### PR TITLE
[REFACTOR] #285: 상품 상세, 작가 상세 조회 시 연락 링크 추가

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/photographer/controller/PhotographerApi.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/photographer/controller/PhotographerApi.java
@@ -15,9 +15,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 @Validated
 public interface PhotographerApi {
 
+    @Deprecated
     @Operation(
         summary = "작가 상세 조회 API",
-        description = "입력받은 photographerId로 해당 작가의 프로필을 조회합니다."
+        description = "입력받은 photographerId로 해당 작가의 프로필을 조회합니다.",
+        deprecated = true
     )
     @GetMapping("/{photographerId}")
     ApiResponseBody<GetPhotographerProfileResponse, Void> getPhotographerProfile(

--- a/src/main/java/org/sopt/snappinserver/api/v2/photographer/controller/PhotographerApiV2.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/photographer/controller/PhotographerApiV2.java
@@ -1,0 +1,30 @@
+package org.sopt.snappinserver.api.v2.photographer.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.sopt.snappinserver.api.v2.photographer.dto.response.GetPhotographerProfileResponseV2;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "02 - Photographer", description = "스냅 작가 관련 API")
+@Validated
+public interface PhotographerApiV2 {
+
+    @Operation(
+        summary = "작가 상세 조회 API V2",
+        description = "입력받은 photographerId로 해당 작가의 프로필을 조회합니다. (contactLink 포함)"
+    )
+    @GetMapping("/{photographerId}")
+    ApiResponseBody<GetPhotographerProfileResponseV2, Void> getPhotographerProfile(
+        @Parameter(description = "조회할 작가 ID")
+        @NotNull(message = "작가 ID는 필수입니다.")
+        @Positive(message = "작가 ID는 양수여야 합니다.")
+        @PathVariable
+        Long photographerId
+    );
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/photographer/controller/PhotographerControllerV2.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/photographer/controller/PhotographerControllerV2.java
@@ -1,0 +1,29 @@
+package org.sopt.snappinserver.api.v2.photographer.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.snappinserver.api.v2.photographer.dto.response.GetPhotographerProfileResponseV2;
+import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerProfileResult;
+import org.sopt.snappinserver.domain.photographer.service.usecase.GetPhotographerProfileUseCase;
+import org.sopt.snappinserver.global.response.code.photographer.PhotographerSuccessCode;
+import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v2/photographers")
+@RequiredArgsConstructor
+@RestController
+public class PhotographerControllerV2 implements PhotographerApiV2 {
+
+    private final GetPhotographerProfileUseCase getPhotographerProfileUseCase;
+
+    @Override
+    public ApiResponseBody<GetPhotographerProfileResponseV2, Void> getPhotographerProfile(
+        Long photographerId
+    ) {
+        GetPhotographerProfileResult result = getPhotographerProfileUseCase
+            .getPhotographerProfile(photographerId);
+        GetPhotographerProfileResponseV2 response = GetPhotographerProfileResponseV2.from(result);
+
+        return ApiResponseBody.ok(PhotographerSuccessCode.GET_PHOTOGRAPHER_PROFILE_OK, response);
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/photographer/dto/response/GetPhotographerProfileResponseV2.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/photographer/dto/response/GetPhotographerProfileResponseV2.java
@@ -1,0 +1,43 @@
+package org.sopt.snappinserver.api.v2.photographer.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.photographer.service.dto.response.GetPhotographerProfileResult;
+
+@Schema(description = "작가 상세 조회 응답 DTO V2")
+public record GetPhotographerProfileResponseV2(
+
+    @Schema(description = "작가 ID", example = "1")
+    Long id,
+
+    @Schema(description = "작가가 설정한 작가명", example = "스윙스냅")
+    String name,
+
+    @Schema(description = "작가 프로필 이미지 URL")
+    String profileImageUrl,
+
+    @Schema(description = "작가 한 줄 소개", example = "일상의 아름다움을 포착합니다")
+    String bio,
+
+    @Schema(description = "연락 링크 URL", example = "https://open.kakao.com/o/example")
+    String contactLink,
+
+    @Schema(description = "촬영 상품", example = "[ \"졸업스냅\", \"웨딩스냅\" ]")
+    List<String> specialties,
+
+    @Schema(description = "활동 지역", example = "[ \"서울\", \"인천\" ]")
+    List<String> locations
+) {
+
+    public static GetPhotographerProfileResponseV2 from(GetPhotographerProfileResult result) {
+        return new GetPhotographerProfileResponseV2(
+            result.id(),
+            result.name(),
+            result.profileImageUrl(),
+            result.bio(),
+            result.contactLink(),
+            result.specialties(),
+            result.locations()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/api/v2/product/controller/ProductControllerV2.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/product/controller/ProductControllerV2.java
@@ -2,11 +2,14 @@ package org.sopt.snappinserver.api.v2.product.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.api.v2.product.dto.request.GetProductListRequestV2;
+import org.sopt.snappinserver.api.v2.product.dto.response.GetProductDetailResponse;
 import org.sopt.snappinserver.api.v2.product.dto.response.GetProductListResponseV2;
 import org.sopt.snappinserver.api.v2.product.dto.response.GetProductMetaResponseV2;
 import org.sopt.snappinserver.domain.auth.infra.jwt.CustomUserInfo;
 import org.sopt.snappinserver.domain.product.service.dto.request.GetProductListQueryV2;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductListResultV2;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetProductResult;
+import org.sopt.snappinserver.domain.product.service.usecase.GetProductDetailUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductListUseCaseV2;
 import org.sopt.snappinserver.global.enums.SortType;
 import org.sopt.snappinserver.global.response.code.product.ProductSuccessCode;
@@ -21,9 +24,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @Validated
-public class ProductControllerV2 implements ProductApiV2 {
+public class ProductControllerV2 implements ProductApiV2, ProductApi {
 
     private final GetProductListUseCaseV2 getProductListUseCaseV2;
+    private final GetProductDetailUseCase getProductDetailUseCase;
 
     @Override
     public ApiResponseBody<GetProductListResponseV2, GetProductMetaResponseV2> getProductList(
@@ -39,6 +43,18 @@ public class ProductControllerV2 implements ProductApiV2 {
             GetProductListResponseV2.from(result),
             GetProductMetaResponseV2.from(result.meta())
         );
+    }
+
+    @Override
+    public ApiResponseBody<GetProductDetailResponse, Void> getProductDetail(
+        @AuthenticationPrincipal CustomUserInfo userInfo,
+        Long productId
+    ) {
+        Long userId = (userInfo != null) ? userInfo.userId() : null;
+        GetProductResult result = getProductDetailUseCase.getProductDetail(userId, productId);
+        GetProductDetailResponse response = GetProductDetailResponse.from(result);
+
+        return ApiResponseBody.ok(ProductSuccessCode.GET_PRODUCT_DETAIL_OK, response);
     }
 
     private GetProductListQueryV2 toQuery(GetProductListRequestV2 request, Long userId) {

--- a/src/main/java/org/sopt/snappinserver/api/v2/product/dto/response/GetProductDetailResponse.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/product/dto/response/GetProductDetailResponse.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
-import org.sopt.snappinserver.api.v1.product.dto.response.GetProductPhotographerInfoResponse;
 import org.sopt.snappinserver.domain.product.service.dto.response.GetProductResult;
 
 @Schema(description = "상품 상세 조회 응답 DTO")
@@ -35,7 +34,7 @@ public record GetProductDetailResponse(
     int price,
 
     @Schema(description = "스냅 작가 응답 DTO")
-    GetProductPhotographerInfoResponse photographerInfo,
+    GetProductPhotographerInfoResponseV2 photographerInfo,
 
     @Schema(description = "상품 안내 정보 응답 DTO")
     GetProductInfoResponse productInfo
@@ -56,7 +55,7 @@ public record GetProductDetailResponse(
             rate,
             result.reviewCount(),
             result.price(),
-            GetProductPhotographerInfoResponse.from(result.photographerInfo()),
+            GetProductPhotographerInfoResponseV2.from(result.photographerInfo()),
             GetProductInfoResponse.from(result.productInfo())
         );
     }

--- a/src/main/java/org/sopt/snappinserver/api/v2/product/dto/response/GetProductPhotographerInfoResponseV2.java
+++ b/src/main/java/org/sopt/snappinserver/api/v2/product/dto/response/GetProductPhotographerInfoResponseV2.java
@@ -1,0 +1,43 @@
+package org.sopt.snappinserver.api.v2.product.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.sopt.snappinserver.domain.product.service.dto.response.GetPhotographerInfoResult;
+
+@Schema(description = "상품 조회 시 작가 응답 DTO V2")
+public record GetProductPhotographerInfoResponseV2(
+
+    @Schema(description = "작가 ID")
+    Long id,
+
+    @Schema(description = "작가 이름")
+    String name,
+
+    @Schema(description = "프로필 이미지 URL")
+    String profileImageUrl,
+
+    @Schema(description = "한줄 소개")
+    String bio,
+
+    @Schema(description = "연락 링크 URL", example = "https://open.kakao.com/o/example")
+    String contactLink,
+
+    @Schema(description = "촬영 상품 (전문 스냅 유형)")
+    List<String> specialties,
+
+    @Schema(description = "활동 지역")
+    List<String> locations
+) {
+
+    public static GetProductPhotographerInfoResponseV2 from(GetPhotographerInfoResult result) {
+        return new GetProductPhotographerInfoResponseV2(
+            result.id(),
+            result.name(),
+            result.profileImageUrl(),
+            result.bio(),
+            result.contactLink(),
+            result.specialties(),
+            result.locations()
+        );
+    }
+}

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/Photographer.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/domain/entity/Photographer.java
@@ -14,6 +14,7 @@ import jakarta.persistence.SequenceGenerator;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,6 +34,7 @@ public class Photographer extends BaseEntity {
     private static final int MAX_NICKNAME_LENGTH = 20;
     private static final int MAX_BIO_LENGTH = 200;
     private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+    private static final Pattern URL_PATTERN = Pattern.compile("^https?://.+");
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "photographer_seq_gen")
@@ -60,19 +62,24 @@ public class Photographer extends BaseEntity {
     @Column(length = MAX_BIO_LENGTH)
     private String bio;
 
+    @Column
+    private String contactLink;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Photographer(
         User user,
         String name,
         String nickname,
         Gender gender,
-        String bio
+        String bio,
+        String contactLink
     ) {
         this.user = user;
         this.name = name;
         this.nickname = nickname;
         this.gender = gender;
         this.bio = bio;
+        this.contactLink = contactLink;
     }
 
     public static Photographer create(
@@ -80,15 +87,17 @@ public class Photographer extends BaseEntity {
         String name,
         String nickname,
         Gender gender,
-        String bio
+        String bio,
+        String contactLink
     ) {
-        validatePhotographer(user, name, nickname, gender, bio);
+        validatePhotographer(user, name, nickname, gender, bio, contactLink);
         return Photographer.builder()
             .user(user)
             .name(name)
             .nickname(nickname)
             .gender(gender)
             .bio(bio)
+            .contactLink(contactLink)
             .build();
     }
 
@@ -97,13 +106,15 @@ public class Photographer extends BaseEntity {
         String name,
         String nickname,
         Gender gender,
-        String bio
+        String bio,
+        String contactLink
     ) {
         validateUserExists(user);
         validateName(name);
         validateNickname(nickname);
         validateGenderExists(gender);
         validateBioLength(bio);
+        validateContactLink(contactLink);
     }
 
     private static void validateUserExists(User user) {
@@ -155,6 +166,12 @@ public class Photographer extends BaseEntity {
     private static void validateBioLength(String bio) {
         if (bio != null && bio.length() > MAX_BIO_LENGTH) {
             throw new PhotographerException(PhotographerErrorCode.BIO_TOO_LONG);
+        }
+    }
+
+    private static void validateContactLink(String contactLink) {
+        if (contactLink != null && !URL_PATTERN.matcher(contactLink).matches()) {
+            throw new PhotographerException(PhotographerErrorCode.CONTACT_LINK_INVALID);
         }
     }
 

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/domain/exception/PhotographerErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/domain/exception/PhotographerErrorCode.java
@@ -23,6 +23,7 @@ public enum PhotographerErrorCode implements ErrorCode {
     START_TIME_AFTER_THAN_END_TIME(400, "PHOTOGRAPHER_400_012", "스케줄 시작 시간이 종료 시간보다 늦을 수 없습니다."),
     BIO_TOO_LONG(400, "PHOTOGRAPHER_400_013", "한 줄 소개 길이는 200자 이하입니다."),
     AVAILABLE_LOCATION_REQUIRED(400, "PHOTOGRAPHER_400_014", "활동 지역은 필수입니다."),
+    CONTACT_LINK_INVALID(400, "PHOTOGRAPHER_400_015", "연락 링크는 유효한 URL 형식이어야 합니다."),
 
     // 401 UNAUTHORIZED
 

--- a/src/main/java/org/sopt/snappinserver/domain/photographer/service/dto/response/GetPhotographerProfileResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photographer/service/dto/response/GetPhotographerProfileResult.java
@@ -12,6 +12,7 @@ public record GetPhotographerProfileResult(
     String name,
     String profileImageUrl,
     String bio,
+    String contactLink,
     List<String> specialties,
     List<String> locations
 ) {
@@ -27,6 +28,7 @@ public record GetPhotographerProfileResult(
             photographer.getNickname(),
             profileImageUrl,
             photographer.getBio(),
+            photographer.getContactLink(),
 
             specialties.stream()
                 .map(PhotographerSpecialty::getSpecialty)

--- a/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetPhotographerInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/product/service/dto/response/GetPhotographerInfoResult.java
@@ -8,6 +8,7 @@ public record GetPhotographerInfoResult(
     String name,
     String profileImageUrl,
     String bio,
+    String contactLink,
     List<String> specialties,
     List<String> locations
 ) {
@@ -23,6 +24,7 @@ public record GetPhotographerInfoResult(
             photographer.getNickname(),
             profileImageUrl,
             photographer.getBio(),
+            photographer.getContactLink(),
             specialties,
             locations
         );

--- a/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/snappinserver/global/config/security/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
         "/api/v2/moods",
 
         "/api/v1/photographers/**",
+        "/api/v2/photographers/**",
         "/api/v1/places/**",
         "/api/v1/portfolios",
         "/api/v1/portfolios/*",


### PR DESCRIPTION
## 👀 Summary

- close #285

<!--관련 있는 Issue를 태그해주세요. (e.g. > - #1) -->

<!--해당 PR에 대한 작업 내용을 요약하여 작성해주세요-->


## 🖇️ Tasks

- [x] v2 상품 상세 조회 시 작가 연락 링크 추가
- [x] 작가 상세 조회 시 작가 연락 링크 추가 및 v2 버전 업

<!--해당 PR에 수행한 작업을 작성해주세요.-->

## 🔍 To Reviewer

### ❶ 작가 도메인 연락 링크 추가 및 v2 버전 업

상품 상세 조회 및 작가 상세 조회를 위해 작가 도메인에 연락 링크를 추가했습니다. 작가에게 귀속되는 정보라고 생각해서 ProductOption의 answer로 저장하는 형태가 아니라, 작가 도메인에 연락 링크를 추가하는 게 맞다고 판단했습니다. v1과 응답형태가 달라지기 때문에 작가 상세 조회도 v2로 버전업하고, public endpoint에 추가했습니다. 참고로 연락 링크는 http://나, https://로 시작하는 것만 받을 수 있게 검증합니다.

### ❷ v2 상품 상세 조회 시 작가 연락 링크 추가

이전에 작업했던 거 머지할 때 컨플릭트 충돌하면서 컨트롤러에 v2 상세 조회가 빠졌던 것 같습니다... 이 부분 해결했습니다!

### ❸ 쿼리 반영 필요

작가 도메인에 연락 링크가 추가됨에 따라, 아래의 쿼리문을 실행시켜서 성하님 로컬에 반영해주세요! dev db에는 제가 반영했습니다.

```sql
ALTER TABLE photographer
                  ADD COLUMN contact_link VARCHAR(255)
```



<!--리뷰어에게 요청하는 내용을 작성해주세요-->
