### PR TITLE
[REFACTOR] #288: 무드 큐레이션 질문 조회 및 사진 저장 시 로직 변경

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/curation/domain/exception/CurationErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/domain/exception/CurationErrorCode.java
@@ -17,7 +17,7 @@ public enum CurationErrorCode implements ErrorCode {
 
     // 401 UNAUTHORIZED
     CURATION_LOGIN_REQUIRED(401, "CURATION_401_001", "무드 큐레이션은 로그인이 필요합니다."),
-    CURATIOON_ONBOARDING_REQUIRED(401, "CURATION_401_002", "무드 큐레이션은 온보딩 정보가 필요합니다."),
+    CURATION_ONBOARDING_REQUIRED(401, "CURATION_401_002", "무드 큐레이션은 온보딩 정보가 필요합니다."),
 
     // 403 FORBIDDEN
 

--- a/src/main/java/org/sopt/snappinserver/domain/curation/domain/exception/CurationErrorCode.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/domain/exception/CurationErrorCode.java
@@ -17,6 +17,7 @@ public enum CurationErrorCode implements ErrorCode {
 
     // 401 UNAUTHORIZED
     CURATION_LOGIN_REQUIRED(401, "CURATION_401_001", "무드 큐레이션은 로그인이 필요합니다."),
+    CURATIOON_ONBOARDING_REQUIRED(401, "CURATION_401_002", "무드 큐레이션은 온보딩 정보가 필요합니다."),
 
     // 403 FORBIDDEN
 

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/GetAllCurationQuestionService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/GetAllCurationQuestionService.java
@@ -80,7 +80,7 @@ public class GetAllCurationQuestionService implements GetAllCurationQuestionUseC
     private Gender getUserGender(User user) {
         Onboarding onboarding = onboardingRepository.findByUser(user)
             .orElseThrow(
-                () -> new CurationException(CurationErrorCode.CURATIOON_ONBOARDING_REQUIRED)
+                () -> new CurationException(CurationErrorCode.CURATION_ONBOARDING_REQUIRED)
             );
 
         return onboarding.getGender();

--- a/src/main/java/org/sopt/snappinserver/domain/curation/service/GetAllCurationQuestionService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/curation/service/GetAllCurationQuestionService.java
@@ -1,8 +1,8 @@
 package org.sopt.snappinserver.domain.curation.service;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.snappinserver.domain.curation.domain.exception.CurationErrorCode;
 import org.sopt.snappinserver.domain.curation.domain.exception.CurationException;
@@ -11,12 +11,15 @@ import org.sopt.snappinserver.domain.curation.service.dto.response.GetCurationQu
 import org.sopt.snappinserver.domain.curation.service.dto.response.GetPhotoResult;
 import org.sopt.snappinserver.domain.curation.service.usecase.GetAllCurationQuestionUseCase;
 import org.sopt.snappinserver.domain.photo.domain.entity.Photo;
+import org.sopt.snappinserver.domain.photo.repository.PhotoRepository;
 import org.sopt.snappinserver.domain.question.domain.entity.Question;
-import org.sopt.snappinserver.domain.question.domain.entity.QuestionPhoto;
 import org.sopt.snappinserver.domain.question.domain.enums.QuestionDomain;
-import org.sopt.snappinserver.domain.question.repository.QuestionPhotoRepository;
 import org.sopt.snappinserver.domain.question.repository.QuestionRepository;
+import org.sopt.snappinserver.domain.user.domain.entity.Onboarding;
+import org.sopt.snappinserver.domain.user.domain.entity.User;
+import org.sopt.snappinserver.domain.user.repository.OnboardingRepository;
 import org.sopt.snappinserver.domain.user.repository.UserRepository;
+import org.sopt.snappinserver.global.enums.Gender;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,44 +29,41 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class GetAllCurationQuestionService implements GetAllCurationQuestionUseCase {
 
+    private static final int PHOTOS_PER_STEP = 4;
+
     private final UserRepository userRepository;
+    private final OnboardingRepository onboardingRepository;
     private final QuestionRepository questionRepository;
-    private final QuestionPhotoRepository questionPhotoRepository;
+    private final PhotoRepository photoRepository;
 
     @Value("${cloud.aws.cloud-front.domain}")
     private String cloudFrontDomain;
 
     @Override
     public GetAllCurationQuestionResult getAllCurationQuestions(Long userId) {
-        validateLoginUser(userId);
+        User user = validateAndGetLoginUser(userId);
 
         List<Question> questions = getQuestions();
         validateQuestionsExist(questions);
-        List<QuestionPhoto> questionPhotos = questionPhotoRepository.findAllByQuestionIn(questions);
 
-        Map<Long, List<QuestionPhoto>> photosByQuestionId =
-            questionPhotos.stream()
-                .collect(Collectors.groupingBy(
-                    qp -> qp.getQuestion().getId()
-                ));
+        Gender gender = getUserGender(user);
+        List<Photo> photos = new ArrayList<>(photoRepository.findAllByGender(gender));
+        Collections.shuffle(photos);
 
-        List<GetCurationQuestionResult> results =
-            questions.stream()
-                .map(question -> GetCurationQuestionResult.of(
-                    question,
-                    mapToPhotoResults(
-                        photosByQuestionId.getOrDefault(question.getId(), List.of())
-                    )
-                ))
-                .toList();
+        List<GetCurationQuestionResult> results = new ArrayList<>();
+        for (int i = 0; i < questions.size(); i++) {
+            int startIndex = i * PHOTOS_PER_STEP;
+            List<Photo> stepPhotos = photos.subList(startIndex, startIndex + PHOTOS_PER_STEP);
+            List<GetPhotoResult> photoResults = mapPhotosToResults(stepPhotos);
+            results.add(GetCurationQuestionResult.of(questions.get(i), photoResults));
+        }
 
         return GetAllCurationQuestionResult.of(results);
     }
 
-    private void validateLoginUser(Long userId) {
-        if(!userRepository.existsById(userId)) {
-            throw new CurationException(CurationErrorCode.CURATION_LOGIN_REQUIRED);
-        }
+    private User validateAndGetLoginUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new CurationException(CurationErrorCode.CURATION_LOGIN_REQUIRED));
     }
 
     private List<Question> getQuestions() {
@@ -72,21 +72,32 @@ public class GetAllCurationQuestionService implements GetAllCurationQuestionUseC
     }
 
     private static void validateQuestionsExist(List<Question> questions) {
-        if(questions.isEmpty()) {
+        if (questions.isEmpty()) {
             throw new CurationException(CurationErrorCode.QUESTION_NOT_FOUND);
         }
     }
 
-    private List<GetPhotoResult> mapToPhotoResults(List<QuestionPhoto> questionPhotos) {
-        return questionPhotos.stream()
-            .map(questionPhoto -> {
-                Photo photo = questionPhoto.getPhoto();
-                return new GetPhotoResult(
+    private Gender getUserGender(User user) {
+        Onboarding onboarding = onboardingRepository.findByUser(user)
+            .orElseThrow(
+                () -> new CurationException(CurationErrorCode.CURATIOON_ONBOARDING_REQUIRED)
+            );
+
+        return onboarding.getGender();
+    }
+
+    private List<GetPhotoResult> mapPhotosToResults(List<Photo> photos) {
+        List<GetPhotoResult> results = new ArrayList<>();
+        for (int i = 0; i < photos.size(); i++) {
+            Photo photo = photos.get(i);
+            results.add(
+                new GetPhotoResult(
                     photo.getId(),
                     cloudFrontDomain + photo.getImageUrl(),
-                    questionPhoto.getDisplayOrder()
-                );
-            })
-            .toList();
+                    i + 1
+                )
+            );
+        }
+        return results;
     }
 }

--- a/src/main/java/org/sopt/snappinserver/domain/photo/domain/entity/Photo.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photo/domain/entity/Photo.java
@@ -2,6 +2,8 @@ package org.sopt.snappinserver.domain.photo.domain.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -17,6 +19,7 @@ import org.sopt.snappinserver.domain.mood.repository.MoodWithScore;
 import org.sopt.snappinserver.domain.photo.domain.exception.PhotoErrorCode;
 import org.sopt.snappinserver.domain.photo.domain.exception.PhotoException;
 import org.sopt.snappinserver.global.entity.BaseEntity;
+import org.sopt.snappinserver.global.enums.Gender;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -38,16 +41,29 @@ public class Photo extends BaseEntity {
     @Column(nullable = false, length = MAX_IMAGE_URL_LENGTH)
     private String imageUrl;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true)
+    private Gender gender;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Photo(String imageUrl) {
+    private Photo(String imageUrl, Gender gender) {
         this.imageUrl = imageUrl;
+        this.gender = gender;
     }
 
     public static Photo create(String imageUrl) {
         validatePhoto(imageUrl);
         return Photo.builder()
             .imageUrl(imageUrl)
+            .gender(null)
+            .build();
+    }
+
+    public static Photo create(String imageUrl, Gender gender) {
+        validatePhoto(imageUrl);
+        return Photo.builder()
+            .imageUrl(imageUrl)
+            .gender(gender)
             .build();
     }
 

--- a/src/main/java/org/sopt/snappinserver/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photo/repository/PhotoRepository.java
@@ -1,7 +1,9 @@
 package org.sopt.snappinserver.domain.photo.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.sopt.snappinserver.domain.photo.domain.entity.Photo;
+import org.sopt.snappinserver.global.enums.Gender;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
 
     Optional<Photo> findByImageUrl(String imageUrl);
+
+    List<Photo> findAllByGender(Gender gender);
 }

--- a/src/main/java/org/sopt/snappinserver/domain/photo/service/ProcessPhotoService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/photo/service/ProcessPhotoService.java
@@ -14,6 +14,7 @@ import org.sopt.snappinserver.domain.photo.repository.PhotoMoodRepository;
 import org.sopt.snappinserver.domain.photo.repository.PhotoRepository;
 import org.sopt.snappinserver.domain.photo.service.dto.request.PhotoProcessCommand;
 import org.sopt.snappinserver.domain.photo.service.usecase.ProcessPhotoUseCase;
+import org.sopt.snappinserver.global.enums.Gender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,7 +34,9 @@ public class ProcessPhotoService implements ProcessPhotoUseCase {
     @Override
     public void linkPhotoWithMoodTags(PhotoProcessCommand photoProcessCommand) {
         Photo photo = photoRepository.findByImageUrl(photoProcessCommand.imageUrl())
-            .orElseGet(() -> photoRepository.save(Photo.create(photoProcessCommand.imageUrl())));
+            .orElseGet(() -> photoRepository.save(
+                Photo.create(photoProcessCommand.imageUrl(), parseGender(photoProcessCommand.imageUrl()))
+            ));
 
         List<MoodWithScore> candidates = moodVectorRepository.findTopCandidates(
             toVectorLiteral(photoProcessCommand.embedding())
@@ -56,6 +59,16 @@ public class ProcessPhotoService implements ProcessPhotoUseCase {
         return selected.stream()
             .map(m -> moodRepository.getReferenceById(m.id()))
             .toList();
+    }
+
+    private Gender parseGender(String imageUrl) {
+        if (imageUrl.contains("/female/")) {
+            return Gender.FEMALE;
+        }
+        if (imageUrl.contains("/male/")) {
+            return Gender.MALE;
+        }
+        return null;
     }
 
 }


### PR DESCRIPTION
## 👀 Summary

- close #288

<!--관련 있는 Issue를 태그해주세요. (e.g. > - #1) -->

<!--해당 PR에 대한 작업 내용을 요약하여 작성해주세요-->


## 🖇️ Tasks

- [x] 무드 큐레이션 질문 조회 시 성별에 따라 랜덤하게 질문 나오도록 수정
- [x] s3에 사진 저장 후 DB 저장 시 성별 추가

<!--해당 PR에 수행한 작업을 작성해주세요.-->

## 🔍 To Reviewer

### ❶ Photo 테이블 변경에 따른 쿼리문

```sql
  ALTER TABLE photo ADD COLUMN gender VARCHAR(10);                                                                                                                           
````
현재 dev db에 적용해둔 상태입니다! 로컬에 반영해주세용

### ❷ 무드 큐레이션 조회 로직 변경

기존에는 Question에 따라서 순차적으로 맞는 Photo를 보내주었는데, 질문 4개에 대한 사진 16개를 성별에 따라 분리 후, 랜덤한 순서대로 섞어서 전송합니다.


<!--리뷰어에게 요청하는 내용을 작성해주세요-->
