### PR TITLE
[FIX] #292: 리뷰 작성 시 상품과 연결되도록 쿼리문 수정

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/org/sopt/snappinserver/domain/review/repository/ReviewRepository.java
@@ -27,9 +27,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             left join fetch review.user author
             left join fetch review.reservation reservation
             left join fetch reservation.user reservationUser
+            left join reservation.product reservationProduct
             where (
                 (review.product is not null and review.product.id = :productId)
-                or (review.reservation is not null and review.reservation.product.id = :productId)
+                or (reservation is not null and reservationProduct.id = :productId)
             )
             order by review.id desc
         """)
@@ -45,9 +46,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             left join fetch review.user author
             left join fetch review.reservation reservation
             left join fetch reservation.user reservationUser
+            left join reservation.product reservationProduct
             where (
                 (review.product is not null and review.product.id = :productId)
-                or (review.reservation is not null and review.reservation.product.id = :productId)
+                or (reservation is not null and reservationProduct.id = :productId)
             )
               and review.id < :cursor
             order by review.id desc
@@ -65,9 +67,11 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             cast(round(avg(r.rating), 1) as double)
         )
         from Review r
+        left join r.reservation res
+        left join res.product resProd
         where (
             (r.product is not null and r.product.id = :productId)
-            or (r.reservation is not null and r.reservation.product.id = :productId)
+            or (res is not null and resProd.id = :productId)
         )
         """)
     ProductReviewStatsResult findReviewStatsByProductId(
@@ -77,17 +81,19 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     // 상품 리뷰 통계 수치 여러 개 배치 조회
     @Query("""
         select
-            case when r.product is not null then r.product.id else r.reservation.product.id end,
+            case when r.product is not null then r.product.id else resProd.id end,
             new org.sopt.snappinserver.domain.product.service.dto.response.ProductReviewStatsResult(
                 count(r),
                 cast(round(avg(r.rating), 1) as double)
             )
         from Review r
+        left join r.reservation res
+        left join res.product resProd
         where (
             (r.product is not null and r.product.id in :productIds)
-            or (r.reservation is not null and r.reservation.product.id in :productIds)
+            or (res is not null and resProd.id in :productIds)
         )
-        group by case when r.product is not null then r.product.id else r.reservation.product.id end
+        group by case when r.product is not null then r.product.id else resProd.id end
         """)
     List<Object[]> findReviewStatsByProductIds(@Param("productIds") List<Long> productIds);
 


### PR DESCRIPTION
## 👀 Summary

- close #292

<!--관련 있는 Issue를 태그해주세요. (e.g. > - #1) -->

<!--해당 PR에 대한 작업 내용을 요약하여 작성해주세요-->


## 🖇️ Tasks

- [x] 상품 상세 조회 시 리뷰 개수, 별점 불일치 문제 쿼리문 수정

<!--해당 PR에 수행한 작업을 작성해주세요.-->

## 🔍 To Reviewer

기존에 리뷰 조회 시에 쿼리문을 reservation 테이블과 join해서 가져오느라 값이 나오지 않는 문제가 있었습니다. 이 부분을 변경된 로직에 맞게 상품과 연관지어서 값이 제대로 나올 수 있도록 했습니다

<!--리뷰어에게 요청하는 내용을 작성해주세요-->
