### PR TITLE
[REFACTOR] #294: 유저 조회 시 온보딩하지 않은 유저 정보 null 반환

### DIFF
--- a/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/GetUserInfoService.java
@@ -81,7 +81,7 @@ public class GetUserInfoService implements GetUserInfoUseCase {
 
     private Onboarding getExistingOnboarding(User user) {
         return onboardingRepository.findByUser(user)
-            .orElseThrow(() -> new UserException(UserErrorCode.ONBOARDING_NOT_FOUND));
+            .orElse(null);
     }
 
     private List<String> getMoodNames(List<Long> moodIds) {

--- a/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetClientInfoResult.java
+++ b/src/main/java/org/sopt/snappinserver/domain/user/service/dto/response/GetClientInfoResult.java
@@ -11,8 +11,8 @@ public record GetClientInfoResult(
 
     public static GetClientInfoResult create(Onboarding onboarding, List<String> curatedMoods) {
         return new GetClientInfoResult(
-            onboarding.getName(),
-            onboarding.getNickname(),
+            onboarding != null ? onboarding.getName() : null,
+            onboarding != null ? onboarding.getNickname() : null,
             curatedMoods
         );
     }


### PR DESCRIPTION
## 👀 Summary

- close #294

<!--관련 있는 Issue를 태그해주세요. (e.g. > - #1) -->

<!--해당 PR에 대한 작업 내용을 요약하여 작성해주세요-->


## 🖇️ Tasks

- [x] 유저 조회 시 온보딩하지 않은 유저 정보 null로 반환할 수 있도록 변경

<!--해당 PR에 수행한 작업을 작성해주세요.-->

## 🔍 To Reviewer

기존 404로 반환해주던 부분에서 유저 조회 시 온보딩하지 않은 유저 정보를 null로 반환해줍니다!


<!--리뷰어에게 요청하는 내용을 작성해주세요-->
