### PR TITLE
[REFACTOR] #296: 인기 무드 상품 조회 시 중복 어노테이션 제거

### DIFF
--- a/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductController.java
@@ -45,13 +45,10 @@ import org.sopt.snappinserver.domain.product.service.usecase.GetProductPeopleRan
 import org.sopt.snappinserver.domain.product.service.usecase.GetProductReviewsUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.PostProductReservationUseCase;
 import org.sopt.snappinserver.domain.product.service.usecase.PostProductReviewUseCase;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import org.sopt.snappinserver.global.response.dto.ApiResponseBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/products")

--- a/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/snappinserver/api/v1/product/controller/ProductController.java
@@ -217,7 +217,7 @@ public class ProductController implements ProductApi {
     @Override
     public ApiResponseBody<GetPopularMoodProductsResponse, Void> getPopularMoodProducts(
         @AuthenticationPrincipal CustomUserInfo principal,
-        @RequestParam @NotNull @Positive Long moodId
+        Long moodId
     ) {
         Long userId = principal != null ? principal.userId() : null;
         GetPopularMoodProductsResult result =


### PR DESCRIPTION
## 👀 Summary

- close #296

인기 무드 상품 조회 API의 컨트롤러 단에서 인터페이스와 중복되는 어노테이션을 컨벤션에 맞추어 제거했습니다.


## 🖇️ Tasks

- [x] 중복 어노테이션 제거

<!--해당 PR에 수행한 작업을 작성해주세요.-->

## 🔍 To Reviewer

. 
<!--리뷰어에게 요청하는 내용을 작성해주세요-->
